### PR TITLE
feat: FON-11763 — annotations sidecar storage + HTTP API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-06-09 — Unreleased — Annotations Sidecar Transport (FON-11763)
+
+- Added sidecar-backed annotation storage at `<repoRoot>/.lookie-link/annotations/<repo>/<relative-path>.json` with atomic temp+rename writes, per-day annotation IDs, and stale-write protection via `expectedMtimeMs` on PATCH.
+- Added `GET | POST | PATCH /api/annotations/<repo>/<path>` behind a new `server.enableAnnotations` flag (and `LOOKIE_LINK_ENABLE_ANNOTATIONS` env var), independent of `enableEditing`. Routes reuse the existing token-scoped `view` permission for both reads and writes.
+- `GET` returns the sidecar (or an empty schema-1 document when no sidecar exists) and supports repeatable `?state=open|claimed|resolved` filters. `POST` accepts `anchor`, `anchorKind` (`heading`, `yamlKey`, `lineRange`), `body`, `author`. `PATCH` supports `claim`, `resolve`, `reopen`, and `reply` ops with 409 on stale mtime.
+- Extended `scripts/validate-editable-mode.js` to cover the annotation transport: disabled-gate 404, empty-doc read, create + sidecar placement, claim → resolve → reopen → reply state walk, state filters (including invalid filter rejection), stale-mtime conflict, cross-repo access-control parity (403 on read and write), and 404 on missing source files.
+- Documented the transport in `docs/API.md`, the flag in `docs/CONFIGURATION.md`, and the example in `lookie-link.yaml.example`.
+
 ## 2026-06-09 — Unreleased — Annotations & Agent-Feedback Loop Spec
 
 - FON-11762 — Nested YAML key anchors. Anchor IDs now use full-path slugs like `database-connection-host`, with deterministic `-2`, `-3` suffixes for collisions. Existing top-level vs nested TOC styling is preserved; nested keys get their own anchor-link buttons. Adds an HTTP regression test through `/view` for nested YAML coverage.

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,9 @@
 | `GET /edit/<repo>/<path>` | Edit page (only when editing enabled) |
 | `POST /api/save/<repo>/<path>` | Save updated file content (JSON body) |
 | `POST /api/preview/<repo>/<path>` | Render preview HTML from draft content (JSON body) |
+| `GET /api/annotations/<repo>/<path>` | Read sidecar annotations for a file. Supports repeatable `?state=open|claimed|resolved`. Returns an empty schema document when no sidecar exists. |
+| `POST /api/annotations/<repo>/<path>` | Create an annotation. Requires only `view` access and `enableAnnotations: true`. |
+| `PATCH /api/annotations/<repo>/<path>` | Apply `claim`, `resolve`, `reopen`, or `reply` to an annotation with stale-write protection. Requires only `view` access and `enableAnnotations: true`. |
 | `GET /api/grants` | List managed grants (`Authorization: Bearer <admin-token>`) |
 | `POST /api/grants` | Create a managed grant and return token + issue comment helper |
 | `POST /api/grants/:grantId/renew` | Renew a managed grant and return issue comment helper |
@@ -32,6 +35,7 @@ Route enforcement in phase 1:
 - `/asset/*` requires `view`
 - `/edit/*` and `/api/save/*` require `edit`
 - `/api/preview/*` requires `view` and still respects global editing mode
+- `/api/annotations/*` requires `view` and returns `404` when annotations are disabled
 
 Invalid tokens return `403`. Missing tokens return `401` when unauthenticated human access is restricted.
 
@@ -84,6 +88,52 @@ Request body:
 ```
 
 Returns `{"ok": true, "html": "rendered HTML"}`.
+
+## Annotation Endpoints
+
+`GET /api/annotations/<repo>/<path>`
+
+- Requires `server.enableAnnotations: true`
+- Requires `view` access to the target file
+- Returns `{ "schema": 1, "file": "<repo>/<path>", "annotations": [] }` when no sidecar exists yet
+- Optional `?state=` filter can be repeated, for example `?state=open&state=claimed`
+
+`POST /api/annotations/<repo>/<path>`
+
+Request body:
+
+```json
+{
+  "anchor": "#design-decisions",
+  "anchorKind": "heading",
+  "body": "Please split this section.",
+  "author": "agent-bob"
+}
+```
+
+- `anchorKind` must be `heading`, `yamlKey`, or `lineRange`
+- `lineRange` anchors must use `#L<start>-L<end>`
+- Server assigns `id`, `createdAt`, and `state: "open"`
+- Sidecars are written under `<repoRoot>/.lookie-link/annotations/<repo>/<path>.json`
+
+`PATCH /api/annotations/<repo>/<path>`
+
+Request body:
+
+```json
+{
+  "id": "2026-06-09-001",
+  "expectedMtimeMs": 1749500000000,
+  "op": "claim",
+  "payload": {
+    "claimedBy": "agent-bob"
+  }
+}
+```
+
+- Supported `op` values: `claim`, `resolve`, `reopen`, `reply`
+- `reply` payload requires `author` and `body`
+- Stale `expectedMtimeMs` returns `409` with the current annotation document in `current`
 
 ## Managed Grant Lifecycle
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -7,6 +7,7 @@ server:
   port: 9876
   hostname: my-server.example.com
   enableEditing: false
+  enableAnnotations: false
 
 repositories:
   docs: ~/Documents/docs
@@ -106,6 +107,17 @@ Settings resolve in this order (first wins):
 | `ROOT_MAPPINGS` | Comma-separated `repo=path` pairs or JSON object |
 | `LOOKIE_LINK_CONFIG` | Path to a custom config file (overrides search) |
 | `LOOKIE_LINK_ENABLE_EDITING` | Boolean override for edit mode (`true/false`, `1/0`, `yes/no`) |
+| `LOOKIE_LINK_ENABLE_ANNOTATIONS` | Boolean override for annotation routes (`true/false`, `1/0`, `yes/no`) |
+
+## Annotation Transport
+
+`server.enableAnnotations` gates the JSON sidecar transport under `/api/annotations/*`.
+
+- Default: `false`
+- Precedence: `LOOKIE_LINK_ENABLE_ANNOTATIONS` env var, then user/project YAML, then default
+- Independent of `enableEditing`
+- When disabled, `GET|POST|PATCH /api/annotations/<repo>/<path>` return `404`
+- Annotation sidecars live inside each served repo at `.lookie-link/annotations/<repo>/<relative-path>.json`
 
 ## Custom Themes
 

--- a/lib/annotations.js
+++ b/lib/annotations.js
@@ -1,0 +1,348 @@
+'use strict';
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const { safeResolve, toPosixPath } = require('./path-utils');
+
+const SCHEMA_VERSION = 1;
+const SUPPORTED_STATES = new Set(['open', 'claimed', 'resolved']);
+const SUPPORTED_ANCHOR_KINDS = new Set(['heading', 'yamlKey', 'lineRange']);
+const LINE_RANGE_PATTERN = /^#L(\d+)-L(\d+)$/;
+
+function buildFileId(repo, relativePath) {
+  return `${repo}/${toPosixPath(relativePath)}`;
+}
+
+function createEmptyDocument(repo, relativePath) {
+  return {
+    schema: SCHEMA_VERSION,
+    file: buildFileId(repo, relativePath),
+    annotations: [],
+  };
+}
+
+function normalizeAnnotationFileData(raw, repo, relativePath) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('Invalid annotation sidecar: expected an object.');
+  }
+
+  if (raw.schema !== SCHEMA_VERSION) {
+    throw new Error(`Unsupported annotation schema: ${raw.schema}`);
+  }
+
+  const annotations = Array.isArray(raw.annotations) ? raw.annotations : null;
+  if (!annotations) {
+    throw new Error('Invalid annotation sidecar: annotations must be an array.');
+  }
+
+  return {
+    schema: SCHEMA_VERSION,
+    file: buildFileId(repo, relativePath),
+    annotations,
+  };
+}
+
+async function resolveAnnotationPath(rootPath, repo, relativePath) {
+  const sidecarRelativePath = path.posix.join(
+    '.lookie-link',
+    'annotations',
+    repo,
+    `${toPosixPath(relativePath)}.json`
+  );
+
+  return safeResolve(rootPath, sidecarRelativePath);
+}
+
+async function readAnnotationDocument(rootPath, repo, relativePath) {
+  const sidecarPath = await resolveAnnotationPath(rootPath, repo, relativePath);
+
+  let raw;
+  let stat;
+  try {
+    [raw, stat] = await Promise.all([
+      fs.readFile(sidecarPath, 'utf8'),
+      fs.stat(sidecarPath),
+    ]);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return {
+        document: createEmptyDocument(repo, relativePath),
+        mtimeMs: null,
+        exists: false,
+        sidecarPath,
+      };
+    }
+
+    throw error;
+  }
+
+  const parsed = JSON.parse(raw);
+  return {
+    document: normalizeAnnotationFileData(parsed, repo, relativePath),
+    mtimeMs: Math.trunc(stat.mtimeMs),
+    exists: true,
+    sidecarPath,
+  };
+}
+
+function validateAnchor(anchor, anchorKind) {
+  if (!SUPPORTED_ANCHOR_KINDS.has(anchorKind)) {
+    throw new Error('Unsupported anchorKind. Expected heading, yamlKey, or lineRange.');
+  }
+
+  if (typeof anchor !== 'string' || !anchor.trim()) {
+    throw new Error('Anchor is required.');
+  }
+
+  const normalized = anchor.trim();
+  if (!normalized.startsWith('#')) {
+    throw new Error('Anchor must start with "#".');
+  }
+
+  if (anchorKind === 'lineRange') {
+    const match = normalized.match(LINE_RANGE_PATTERN);
+    if (!match) {
+      throw new Error('lineRange anchors must use the form #L<start>-L<end>.');
+    }
+
+    const start = Number(match[1]);
+    const end = Number(match[2]);
+    if (end < start) {
+      throw new Error('lineRange anchor end must be greater than or equal to start.');
+    }
+  }
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${label} is required.`);
+  }
+
+  return value.trim();
+}
+
+function nextAnnotationId(annotations, isoTimestamp) {
+  const prefix = isoTimestamp.slice(0, 10);
+  let max = 0;
+
+  for (const annotation of annotations) {
+    if (!annotation || typeof annotation.id !== 'string') {
+      continue;
+    }
+
+    const match = annotation.id.match(new RegExp(`^${prefix}-(\\d{3})$`));
+    if (!match) {
+      continue;
+    }
+
+    max = Math.max(max, Number(match[1]));
+  }
+
+  return `${prefix}-${String(max + 1).padStart(3, '0')}`;
+}
+
+function buildAnnotation(input, existingAnnotations) {
+  const anchor = requireNonEmptyString(input.anchor, 'anchor');
+  const anchorKind = requireNonEmptyString(input.anchorKind, 'anchorKind');
+  const body = requireNonEmptyString(input.body, 'body');
+  const author = requireNonEmptyString(input.author, 'author');
+
+  validateAnchor(anchor, anchorKind);
+
+  const createdAt = new Date().toISOString();
+
+  return {
+    id: nextAnnotationId(existingAnnotations, createdAt),
+    anchor,
+    anchorKind,
+    body,
+    author,
+    createdAt,
+    state: 'open',
+    claimedBy: null,
+    claimedAt: null,
+    resolvedAt: null,
+    replies: [],
+  };
+}
+
+function buildReply(payload) {
+  return {
+    author: requireNonEmptyString(payload && payload.author, 'payload.author'),
+    body: requireNonEmptyString(payload && payload.body, 'payload.body'),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function applyAnnotationOperation(annotation, op, payload) {
+  if (!annotation) {
+    throw new Error('Annotation not found.');
+  }
+
+  if (!SUPPORTED_STATES.has(annotation.state)) {
+    throw new Error(`Unsupported annotation state: ${annotation.state}`);
+  }
+
+  switch (op) {
+    case 'claim': {
+      const claimedBy = requireNonEmptyString(
+        payload && (payload.claimedBy || payload.author),
+        'payload.claimedBy'
+      );
+      return {
+        ...annotation,
+        state: 'claimed',
+        claimedBy,
+        claimedAt: new Date().toISOString(),
+        resolvedAt: null,
+      };
+    }
+    case 'resolve':
+      return {
+        ...annotation,
+        state: 'resolved',
+        resolvedAt: new Date().toISOString(),
+      };
+    case 'reopen':
+      return {
+        ...annotation,
+        state: 'open',
+        claimedBy: null,
+        claimedAt: null,
+        resolvedAt: null,
+      };
+    case 'reply':
+      return {
+        ...annotation,
+        replies: [...(Array.isArray(annotation.replies) ? annotation.replies : []), buildReply(payload)],
+      };
+    default:
+      throw new Error('Unsupported op. Expected claim, resolve, reopen, or reply.');
+  }
+}
+
+function filterAnnotationsByState(document, states) {
+  if (!states || states.length === 0) {
+    return document;
+  }
+
+  const normalizedStates = new Set(states.map((state) => String(state).trim()).filter(Boolean));
+  for (const state of normalizedStates) {
+    if (!SUPPORTED_STATES.has(state)) {
+      throw new Error(`Unsupported state filter: ${state}`);
+    }
+  }
+
+  return {
+    ...document,
+    annotations: document.annotations.filter((annotation) => normalizedStates.has(annotation.state)),
+  };
+}
+
+async function writeAnnotationDocument(sidecarPath, document, expectedMtimeMs) {
+  let currentStat = null;
+  try {
+    currentStat = await fs.stat(sidecarPath);
+  } catch (error) {
+    if (!error || error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  if (expectedMtimeMs !== undefined) {
+    const expected = Math.trunc(Number(expectedMtimeMs));
+    if (!Number.isFinite(expected)) {
+      throw new Error('Invalid expectedMtimeMs value.');
+    }
+
+    const current = currentStat ? Math.trunc(currentStat.mtimeMs) : null;
+    if (current !== expected) {
+      const error = new Error('Annotation sidecar changed on disk since you last read it.');
+      error.code = 'ESTALE';
+      error.currentMtimeMs = current;
+      throw error;
+    }
+  }
+
+  await fs.mkdir(path.dirname(sidecarPath), { recursive: true });
+
+  const tempPath = path.join(
+    path.dirname(sidecarPath),
+    `.lookie-link-annotations-tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+
+  try {
+    await fs.writeFile(tempPath, `${JSON.stringify(document, null, 2)}\n`, 'utf8');
+    await fs.rename(tempPath, sidecarPath);
+  } catch (error) {
+    try {
+      await fs.unlink(tempPath);
+    } catch (_cleanupError) {
+      // best effort cleanup
+    }
+    throw error;
+  }
+
+  const updatedStat = await fs.stat(sidecarPath);
+  return {
+    document,
+    mtimeMs: Math.trunc(updatedStat.mtimeMs),
+  };
+}
+
+async function createAnnotation(rootPath, repo, relativePath, input) {
+  const existing = await readAnnotationDocument(rootPath, repo, relativePath);
+  const annotation = buildAnnotation(input, existing.document.annotations);
+  const nextDocument = {
+    ...existing.document,
+    annotations: [...existing.document.annotations, annotation],
+  };
+
+  const saved = await writeAnnotationDocument(existing.sidecarPath, nextDocument);
+  return {
+    annotation,
+    mtimeMs: saved.mtimeMs,
+    document: saved.document,
+  };
+}
+
+async function updateAnnotation(rootPath, repo, relativePath, input) {
+  const id = requireNonEmptyString(input && input.id, 'id');
+  const op = requireNonEmptyString(input && input.op, 'op');
+  const existing = await readAnnotationDocument(rootPath, repo, relativePath);
+  const index = existing.document.annotations.findIndex((annotation) => annotation && annotation.id === id);
+
+  if (index === -1) {
+    throw new Error('Annotation not found.');
+  }
+
+  const updatedAnnotation = applyAnnotationOperation(existing.document.annotations[index], op, input.payload || {});
+  const annotations = existing.document.annotations.slice();
+  annotations[index] = updatedAnnotation;
+
+  const saved = await writeAnnotationDocument(
+    existing.sidecarPath,
+    {
+      ...existing.document,
+      annotations,
+    },
+    input.expectedMtimeMs
+  );
+
+  return {
+    annotation: updatedAnnotation,
+    mtimeMs: saved.mtimeMs,
+    document: saved.document,
+  };
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  SUPPORTED_STATES,
+  createEmptyDocument,
+  readAnnotationDocument,
+  filterAnnotationsByState,
+  createAnnotation,
+  updateAnnotation,
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -317,11 +317,32 @@ function getEditingEnabled() {
   return false;
 }
 
+function getAnnotationsEnabled() {
+  const rawEnv = process.env.LOOKIE_LINK_ENABLE_ANNOTATIONS;
+  if (typeof rawEnv === 'string') {
+    const parsedEnv = parseBoolean(rawEnv);
+    if (parsedEnv !== null) {
+      return parsedEnv;
+    }
+  }
+
+  const config = getConfig();
+  if (config.server && Object.prototype.hasOwnProperty.call(config.server, 'enableAnnotations')) {
+    const parsedConfig = parseBoolean(config.server.enableAnnotations);
+    if (parsedConfig !== null) {
+      return parsedConfig;
+    }
+  }
+
+  return false;
+}
+
 module.exports = {
   loadRootMappings,
   getPort,
   getHostname,
   getEditingEnabled,
+  getAnnotationsEnabled,
   getAccessConfig,
   loadCustomThemes,
   generateCustomThemeCss,

--- a/lookie-link.yaml.example
+++ b/lookie-link.yaml.example
@@ -16,6 +16,7 @@ server:
   port: 9876
   hostname: localhost  # e.g., my-server.local or my-host.tailnet.ts.net
   enableEditing: false # opt-in: set true only on trusted private networks
+  enableAnnotations: false # opt-in: enables sidecar annotation API routes
 
 # Repository mappings
 # Each key becomes a URL prefix: /view/<key>/<path>

--- a/scripts/validate-editable-mode.js
+++ b/scripts/validate-editable-mode.js
@@ -27,13 +27,63 @@ function createMockRes() {
   };
 }
 
+function buildScopedAccessConfig() {
+  return {
+    humanDefault: 'restricted',
+    tokens: {
+      docs_reader: {
+        secret: 'docs-reader-token',
+        repos: {
+          docs: {
+            paths: ['*'],
+          },
+        },
+        permissions: {
+          view: true,
+          edit: false,
+        },
+      },
+      other_reader: {
+        secret: 'other-reader-token',
+        repos: {
+          other: {
+            paths: ['*'],
+          },
+        },
+        permissions: {
+          view: true,
+          edit: false,
+        },
+      },
+    },
+  };
+}
+
 async function run() {
   const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-editable-validate-'));
+  const otherRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-editable-validate-other-'));
   await fs.mkdir(path.join(repoDir, 'images'));
 
   await fs.writeFile(path.join(repoDir, 'doc.md'), '# Hello\n\nInitial\n', 'utf8');
   await fs.writeFile(path.join(repoDir, 'config.yaml'), 'name: before\n', 'utf8');
+  await fs.writeFile(
+    path.join(repoDir, 'nested.yaml'),
+    [
+      'key:',
+      '  subkey:',
+      '    leaf: 1',
+      '  sibling:',
+      '    leaf: 2',
+      'repeated path:',
+      '  child: 3',
+      '"repeated-path":',
+      '  child: 4',
+      '',
+    ].join('\n'),
+    'utf8'
+  );
   await fs.writeFile(path.join(repoDir, 'bin.bin'), Buffer.from([0, 159, 146, 150, 0]));
+  await fs.writeFile(path.join(otherRepoDir, 'doc.md'), '# Other\n', 'utf8');
   await fs.writeFile(path.join(repoDir, 'images', 'pixel.png'), Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3Zx7kAAAAASUVORK5CYII=',
     'base64'
@@ -41,12 +91,25 @@ async function run() {
 
   const appDisabled = createApp({ mappings: { docs: repoDir }, editingEnabled: false });
   const appEnabled = createApp({ mappings: { docs: repoDir }, editingEnabled: true });
+  const appAnnotationsDisabled = createApp({ mappings: { docs: repoDir }, annotationsEnabled: false });
+  const appAnnotationsEnabled = createApp({ mappings: { docs: repoDir }, annotationsEnabled: true });
+  const appAnnotationsScoped = createApp({
+    mappings: { docs: repoDir, other: otherRepoDir },
+    annotationsEnabled: true,
+    accessConfig: buildScopedAccessConfig(),
+  });
 
   const view = getRouteHandler(appEnabled, 'get', '/view/*');
   const edit = getRouteHandler(appEnabled, 'get', '/edit/*');
   const editDisabled = getRouteHandler(appDisabled, 'get', '/edit/*');
   const save = getRouteHandler(appEnabled, 'post', '/api/save/*');
   const preview = getRouteHandler(appEnabled, 'post', '/api/preview/*');
+  const annotationsGet = getRouteHandler(appAnnotationsEnabled, 'get', '/api/annotations/:repo/*');
+  const annotationsPost = getRouteHandler(appAnnotationsEnabled, 'post', '/api/annotations/:repo/*');
+  const annotationsPatch = getRouteHandler(appAnnotationsEnabled, 'patch', '/api/annotations/:repo/*');
+  const annotationsGetDisabled = getRouteHandler(appAnnotationsDisabled, 'get', '/api/annotations/:repo/*');
+  const annotationsScopedGet = getRouteHandler(appAnnotationsScoped, 'get', '/api/annotations/:repo/*');
+  const annotationsScopedPost = getRouteHandler(appAnnotationsScoped, 'post', '/api/annotations/:repo/*');
 
   {
     const res = createMockRes();
@@ -54,6 +117,19 @@ async function run() {
     assert.equal(res.statusCode, 200, 'existing view mode failed');
     assert.equal(typeof res.body, 'string');
     assert(res.body.includes('Hello'), 'markdown content not rendered');
+    assert(res.body.includes('id="hello"'), 'markdown heading anchor missing');
+  }
+
+  {
+    const res = createMockRes();
+    await view({ params: { 0: 'docs/nested.yaml' } }, res);
+    assert.equal(res.statusCode, 200, 'nested yaml view failed');
+    assert.equal(typeof res.body, 'string');
+    assert(res.body.includes('id="key"'), 'top-level YAML anchor missing');
+    assert(res.body.includes('id="key-subkey-leaf"'), 'nested YAML anchor missing');
+    assert(res.body.includes('id="key-sibling-leaf"'), 'sibling nested YAML anchor missing');
+    assert(res.body.includes('id="repeated-path-child"'), 'collision base anchor missing');
+    assert(res.body.includes('id="repeated-path-child-2"'), 'collision suffix anchor missing');
   }
 
   {
@@ -152,6 +228,200 @@ async function run() {
     }, res);
 
     assert.equal(res.statusCode, 409, 'stale mtime conflict failed');
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsGetDisabled({ params: { repo: 'docs', 0: 'doc.md' }, query: {} }, res);
+    assert.equal(res.statusCode, 404, 'annotations-disabled gate failed');
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsGet({ params: { repo: 'docs', 0: 'doc.md' }, query: {} }, res);
+    assert.equal(res.statusCode, 200, 'annotation GET failed without sidecar');
+    assert.deepEqual(res.body, {
+      schema: 1,
+      file: 'docs/doc.md',
+      annotations: [],
+    }, 'annotation GET empty shape mismatch');
+  }
+
+  let annotationId;
+  let annotationMtime;
+  {
+    const res = createMockRes();
+    await annotationsPost({
+      params: { repo: 'docs', 0: 'doc.md' },
+      body: {
+        anchor: '#hello',
+        anchorKind: 'heading',
+        body: 'Needs a follow-up.',
+        author: 'builder',
+      },
+      query: {},
+    }, res);
+
+    assert.equal(res.statusCode, 201, 'annotation POST failed');
+    assert.equal(res.body.ok, true, 'annotation POST missing ok');
+    assert.equal(res.body.annotation.state, 'open', 'annotation POST initial state mismatch');
+    assert.match(res.body.annotation.id, /^\d{4}-\d{2}-\d{2}-\d{3}$/, 'annotation id format mismatch');
+    annotationId = res.body.annotation.id;
+    annotationMtime = res.body.mtimeMs;
+
+    const sidecarPath = path.join(repoDir, '.lookie-link', 'annotations', 'docs', 'doc.md.json');
+    const sidecarRaw = await fs.readFile(sidecarPath, 'utf8');
+    const sidecar = JSON.parse(sidecarRaw);
+    assert.equal(sidecar.file, 'docs/doc.md', 'annotation sidecar file id mismatch');
+    assert.equal(sidecar.annotations.length, 1, 'annotation sidecar write failed');
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsPatch({
+      params: { repo: 'docs', 0: 'doc.md' },
+      body: {
+        id: annotationId,
+        expectedMtimeMs: annotationMtime,
+        op: 'claim',
+        payload: { claimedBy: 'agent-bob' },
+      },
+      query: {},
+    }, res);
+
+    assert.equal(res.statusCode, 200, 'annotation claim failed');
+    assert.equal(res.body.annotation.state, 'claimed', 'annotation claim state mismatch');
+    assert.equal(res.body.annotation.claimedBy, 'agent-bob', 'annotation claim owner mismatch');
+    assert.equal(typeof res.body.annotation.claimedAt, 'string', 'annotation claim timestamp missing');
+    annotationMtime = res.body.mtimeMs;
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsPatch({
+      params: { repo: 'docs', 0: 'doc.md' },
+      body: {
+        id: annotationId,
+        expectedMtimeMs: annotationMtime,
+        op: 'resolve',
+        payload: {},
+      },
+      query: {},
+    }, res);
+
+    assert.equal(res.statusCode, 200, 'annotation resolve failed');
+    assert.equal(res.body.annotation.state, 'resolved', 'annotation resolve state mismatch');
+    assert.equal(typeof res.body.annotation.resolvedAt, 'string', 'annotation resolve timestamp missing');
+    annotationMtime = res.body.mtimeMs;
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsPatch({
+      params: { repo: 'docs', 0: 'doc.md' },
+      body: {
+        id: annotationId,
+        expectedMtimeMs: annotationMtime,
+        op: 'reopen',
+        payload: {},
+      },
+      query: {},
+    }, res);
+
+    assert.equal(res.statusCode, 200, 'annotation reopen failed');
+    assert.equal(res.body.annotation.state, 'open', 'annotation reopen state mismatch');
+    annotationMtime = res.body.mtimeMs;
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsPatch({
+      params: { repo: 'docs', 0: 'doc.md' },
+      body: {
+        id: annotationId,
+        expectedMtimeMs: annotationMtime,
+        op: 'reply',
+        payload: {
+          author: 'reviewer',
+          body: 'Please tighten the wording.',
+        },
+      },
+      query: {},
+    }, res);
+
+    assert.equal(res.statusCode, 200, 'annotation reply failed');
+    assert.equal(res.body.annotation.replies.length, 1, 'annotation reply append failed');
+    assert.equal(res.body.annotation.replies[0].author, 'reviewer', 'annotation reply author mismatch');
+    annotationMtime = res.body.mtimeMs;
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsGet({
+      params: { repo: 'docs', 0: 'doc.md' },
+      query: { state: 'open' },
+    }, res);
+
+    assert.equal(res.statusCode, 200, 'annotation GET filter failed');
+    assert.equal(res.body.annotations.length, 1, 'annotation open filter mismatch');
+
+    const filteredResolved = createMockRes();
+    await annotationsGet({
+      params: { repo: 'docs', 0: 'doc.md' },
+      query: { state: 'resolved' },
+    }, filteredResolved);
+    assert.equal(filteredResolved.statusCode, 200, 'annotation GET resolved filter failed');
+    assert.equal(filteredResolved.body.annotations.length, 0, 'annotation resolved filter mismatch after reopen');
+  }
+
+  {
+    const sidecarPath = path.join(repoDir, '.lookie-link', 'annotations', 'docs', 'doc.md.json');
+    const sidecarBefore = JSON.parse(await fs.readFile(sidecarPath, 'utf8'));
+    sidecarBefore.annotations[0].body = 'Externally updated.';
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await fs.writeFile(sidecarPath, `${JSON.stringify(sidecarBefore, null, 2)}\n`, 'utf8');
+
+    const res = createMockRes();
+    await annotationsPatch({
+      params: { repo: 'docs', 0: 'doc.md' },
+      body: {
+        id: annotationId,
+        expectedMtimeMs: annotationMtime,
+        op: 'resolve',
+        payload: {},
+      },
+      query: {},
+    }, res);
+
+    assert.equal(res.statusCode, 409, 'annotation stale mtime conflict failed');
+    assert.equal(res.body.current.file, 'docs/doc.md', 'annotation stale response missing current doc');
+    assert.equal(res.body.current.annotations[0].body, 'Externally updated.', 'annotation stale response did not include current annotations');
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsScopedGet({
+      params: { repo: 'other', 0: 'doc.md' },
+      query: {},
+      headers: { authorization: 'Bearer docs-reader-token' },
+    }, res);
+    assert.equal(res.statusCode, 403, 'cross-repo annotation read should be denied');
+  }
+
+  {
+    const res = createMockRes();
+    await annotationsScopedPost({
+      params: { repo: 'other', 0: 'doc.md' },
+      body: {
+        anchor: '#other',
+        anchorKind: 'heading',
+        body: 'Should fail.',
+        author: 'builder',
+      },
+      query: {},
+      headers: { authorization: 'Bearer docs-reader-token' },
+    }, res);
+    assert.equal(res.statusCode, 403, 'cross-repo annotation write should be denied');
   }
 
   console.log('editable mode validation passed');

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const {
   getPort,
   getHostname,
   getEditingEnabled,
+  getAnnotationsEnabled,
   getAccessConfig,
   loadCustomThemes,
   generateCustomThemeCss,
@@ -49,6 +50,12 @@ const {
   renderPreviewHtml,
   setThemeList,
 } = require('./lib/renderer');
+const {
+  readAnnotationDocument,
+  filterAnnotationsByState,
+  createAnnotation,
+  updateAnnotation,
+} = require('./lib/annotations');
 
 const IMAGE_MIME_TYPES = {
   '.png': 'image/png',
@@ -258,6 +265,7 @@ function createApp(options = {}) {
   const app = express();
   const mappings = options.mappings || loadRootMappings();
   const editingEnabled = options.editingEnabled === undefined ? getEditingEnabled() : Boolean(options.editingEnabled);
+  const annotationsEnabled = options.annotationsEnabled === undefined ? getAnnotationsEnabled() : Boolean(options.annotationsEnabled);
   const customThemeCss = options.customThemeCss || '';
   const rawAccessConfig = options.accessConfig === undefined ? getAccessConfig() : options.accessConfig;
   const accessConfig = parseAccessConfig(rawAccessConfig);
@@ -429,7 +437,7 @@ function createApp(options = {}) {
   });
 
   app.get('/healthz', (_req, res) => {
-    res.status(200).json({ status: 'ok', editingEnabled });
+    res.status(200).json({ status: 'ok', editingEnabled, annotationsEnabled });
   });
 
   app.get('/api/repos', (req, res) => {
@@ -937,6 +945,271 @@ function createApp(options = {}) {
     res.status(200).json({ ok: true, html });
   });
 
+  app.get('/api/annotations/:repo/*', async (req, res) => {
+    if (!annotationsEnabled) {
+      res.status(404).json({ ok: false, error: 'Annotations are disabled.' });
+      return;
+    }
+
+    const repo = req.params.repo;
+    const relativePath = req.params[0] || '';
+    const rootPath = mappings[repo];
+    const accessContext = resolveAccessContext(req);
+
+    if (!rootPath) {
+      res.status(404).json({ ok: false, error: `Unknown repository: ${repo}` });
+      return;
+    }
+
+    if (!relativePath) {
+      res.status(400).json({ ok: false, error: 'Annotations require a file path.' });
+      return;
+    }
+
+    if (!canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+      sendAccessError(res, accessContext, true);
+      return;
+    }
+
+    let resolved;
+    try {
+      resolved = await safeResolve(rootPath, relativePath);
+    } catch (error) {
+      if (error && error.code === 'EACCES') {
+        res.status(403).json({ ok: false, error: 'Invalid path.' });
+        return;
+      }
+
+      if (error && error.code === 'ENOENT') {
+        res.status(404).json({ ok: false, error: 'File not found.' });
+        return;
+      }
+
+      console.error('Failed to resolve annotation path', { rootPath, relativePath, error });
+      res.status(500).json({ ok: false, error: 'Failed to resolve file path.' });
+      return;
+    }
+
+    let stat;
+    try {
+      stat = await fs.stat(resolved);
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        res.status(404).json({ ok: false, error: 'File not found.' });
+        return;
+      }
+
+      console.error('Failed to stat annotation file', { resolved, error });
+      res.status(500).json({ ok: false, error: 'Failed to read file metadata.' });
+      return;
+    }
+
+    if (!stat.isFile()) {
+      res.status(400).json({ ok: false, error: 'Annotations only apply to files.' });
+      return;
+    }
+
+    try {
+      const result = await readAnnotationDocument(rootPath, repo, relativePath);
+      const states = Array.isArray(req.query.state)
+        ? req.query.state
+        : req.query.state !== undefined
+          ? [req.query.state]
+          : [];
+      const filtered = filterAnnotationsByState(result.document, states);
+      res.status(200).json(filtered);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        res.status(500).json({ ok: false, error: 'Annotation sidecar contains invalid JSON.' });
+        return;
+      }
+
+      if (error.message.startsWith('Unsupported state filter:')) {
+        res.status(400).json({ ok: false, error: error.message });
+        return;
+      }
+
+      console.error('Failed to read annotations', { repo, relativePath, error });
+      res.status(500).json({ ok: false, error: 'Failed to read annotations.' });
+    }
+  });
+
+  app.post('/api/annotations/:repo/*', async (req, res) => {
+    if (!annotationsEnabled) {
+      res.status(404).json({ ok: false, error: 'Annotations are disabled.' });
+      return;
+    }
+
+    const repo = req.params.repo;
+    const relativePath = req.params[0] || '';
+    const rootPath = mappings[repo];
+    const accessContext = resolveAccessContext(req);
+
+    if (!rootPath) {
+      res.status(404).json({ ok: false, error: `Unknown repository: ${repo}` });
+      return;
+    }
+
+    if (!relativePath) {
+      res.status(400).json({ ok: false, error: 'Annotations require a file path.' });
+      return;
+    }
+
+    if (!canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+      sendAccessError(res, accessContext, true);
+      return;
+    }
+
+    let sourceStat;
+    try {
+      sourceStat = await fs.stat(await safeResolve(rootPath, relativePath));
+    } catch (error) {
+      if (error && error.code === 'EACCES') {
+        res.status(403).json({ ok: false, error: 'Invalid path.' });
+        return;
+      }
+
+      if (error && error.code === 'ENOENT') {
+        res.status(404).json({ ok: false, error: 'File not found.' });
+        return;
+      }
+
+      console.error('Failed to stat source file for annotations', { repo, relativePath, error });
+      res.status(500).json({ ok: false, error: 'Failed to read file metadata.' });
+      return;
+    }
+
+    if (!sourceStat.isFile()) {
+      res.status(400).json({ ok: false, error: 'Annotations only apply to files.' });
+      return;
+    }
+
+    try {
+      const result = await createAnnotation(rootPath, repo, relativePath, req.body || {});
+      res.status(201).json({
+        ok: true,
+        annotation: result.annotation,
+        mtimeMs: result.mtimeMs,
+      });
+    } catch (error) {
+      if (
+        error.message === 'Anchor is required.' ||
+        error.message === 'anchorKind is required.' ||
+        error.message === 'body is required.' ||
+        error.message === 'author is required.' ||
+        error.message.startsWith('Unsupported anchorKind') ||
+        error.message.startsWith('Anchor must start') ||
+        error.message.startsWith('lineRange anchors must') ||
+        error.message.startsWith('lineRange anchor end')
+      ) {
+        res.status(400).json({ ok: false, error: error.message });
+        return;
+      }
+
+      if (error instanceof SyntaxError) {
+        res.status(500).json({ ok: false, error: 'Annotation sidecar contains invalid JSON.' });
+        return;
+      }
+
+      console.error('Failed to create annotation', { repo, relativePath, error });
+      res.status(500).json({ ok: false, error: 'Failed to create annotation.' });
+    }
+  });
+
+  app.patch('/api/annotations/:repo/*', async (req, res) => {
+    if (!annotationsEnabled) {
+      res.status(404).json({ ok: false, error: 'Annotations are disabled.' });
+      return;
+    }
+
+    const repo = req.params.repo;
+    const relativePath = req.params[0] || '';
+    const rootPath = mappings[repo];
+    const accessContext = resolveAccessContext(req);
+
+    if (!rootPath) {
+      res.status(404).json({ ok: false, error: `Unknown repository: ${repo}` });
+      return;
+    }
+
+    if (!relativePath) {
+      res.status(400).json({ ok: false, error: 'Annotations require a file path.' });
+      return;
+    }
+
+    if (!canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+      sendAccessError(res, accessContext, true);
+      return;
+    }
+
+    let sourceStat;
+    try {
+      sourceStat = await fs.stat(await safeResolve(rootPath, relativePath));
+    } catch (error) {
+      if (error && error.code === 'EACCES') {
+        res.status(403).json({ ok: false, error: 'Invalid path.' });
+        return;
+      }
+
+      if (error && error.code === 'ENOENT') {
+        res.status(404).json({ ok: false, error: 'File not found.' });
+        return;
+      }
+
+      console.error('Failed to stat source file for annotation update', { repo, relativePath, error });
+      res.status(500).json({ ok: false, error: 'Failed to read file metadata.' });
+      return;
+    }
+
+    if (!sourceStat.isFile()) {
+      res.status(400).json({ ok: false, error: 'Annotations only apply to files.' });
+      return;
+    }
+
+    try {
+      const result = await updateAnnotation(rootPath, repo, relativePath, req.body || {});
+      res.status(200).json({
+        ok: true,
+        annotation: result.annotation,
+        mtimeMs: result.mtimeMs,
+      });
+    } catch (error) {
+      if (error.code === 'ESTALE') {
+        const current = await readAnnotationDocument(rootPath, repo, relativePath);
+        res.status(409).json({
+          ok: false,
+          error: error.message,
+          currentMtimeMs: error.currentMtimeMs,
+          current: current.document,
+        });
+        return;
+      }
+
+      if (
+        error.message === 'id is required.' ||
+        error.message === 'op is required.' ||
+        error.message === 'Annotation not found.' ||
+        error.message.startsWith('Unsupported op') ||
+        error.message === 'payload.claimedBy is required.' ||
+        error.message === 'payload.author is required.' ||
+        error.message === 'payload.body is required.' ||
+        error.message === 'Invalid expectedMtimeMs value.'
+      ) {
+        const status = error.message === 'Annotation not found.' ? 404 : 400;
+        res.status(status).json({ ok: false, error: error.message });
+        return;
+      }
+
+      if (error instanceof SyntaxError) {
+        res.status(500).json({ ok: false, error: 'Annotation sidecar contains invalid JSON.' });
+        return;
+      }
+
+      console.error('Failed to update annotation', { repo, relativePath, error });
+      res.status(500).json({ ok: false, error: 'Failed to update annotation.' });
+    }
+  });
+
   app.get('/asset/:repo/*', async (req, res) => {
     const accessContext = resolveAccessContext(req);
     const repo = req.params.repo;
@@ -1031,6 +1304,7 @@ function startServer() {
   const hostname = getHostname();
   const mappings = loadRootMappings();
   const editingEnabled = getEditingEnabled();
+  const annotationsEnabled = getAnnotationsEnabled();
   const accessConfig = getAccessConfig();
 
   const customThemes = loadCustomThemes();
@@ -1043,11 +1317,12 @@ function startServer() {
   const allThemes = [...builtInThemes, ...customThemes.map((t) => ({ slug: t.slug, label: t.label }))];
   setThemeList(allThemes);
 
-  const app = createApp({ mappings, editingEnabled, customThemeCss, accessConfig });
+  const app = createApp({ mappings, editingEnabled, annotationsEnabled, customThemeCss, accessConfig });
 
   app.listen(port, '0.0.0.0', () => {
     console.log(`Lookie Link listening on http://${hostname}:${port}`);
     console.log(`Editing mode: ${editingEnabled ? 'enabled' : 'disabled'}`);
+    console.log(`Annotations: ${annotationsEnabled ? 'enabled' : 'disabled'}`);
     if (customThemes.length > 0) {
       console.log(`Custom themes: ${customThemes.map((t) => t.label).join(', ')}`);
     }


### PR DESCRIPTION
## Summary

Phase 1 Chunk B of the Lookie-Link annotations work ([FON-11757](https://github.com/chrisfonte/lookie-link/issues/57) umbrella, Paperclip FON-11763). Adds the JSON sidecar transport so agents and humans can leave structured feedback on rendered files without mutating source bytes.

Builds on the nested YAML key anchors merged in #65 (FON-11762).

## What landed

- **`lib/annotations.js`** — sidecar read/write module. Sidecars live at `<repoRoot>/.lookie-link/annotations/<repo>/<relative-path>.json`. Atomic temp+rename writes. Per-day annotation IDs (`2026-06-09-001`). Stale-write protection via `expectedMtimeMs` (409 on conflict).
- **`GET | POST | PATCH /api/annotations/<repo>/<path>`** routes behind a new `server.enableAnnotations` flag (and `LOOKIE_LINK_ENABLE_ANNOTATIONS` env var). Independent of `enableEditing` — sidecar writes work on the default safe configuration.
- Routes reuse the existing token-scoped `view` permission for both reads and writes. No new auth surface. Cross-repo reads/writes are denied (403).
- `GET` supports repeatable `?state=open|claimed|resolved` filters and returns an empty schema-1 document when no sidecar exists.
- `PATCH` ops: `claim`, `resolve`, `reopen`, `reply`. 409 on stale mtime returns the current sidecar in `current` so callers can re-base.
- `scripts/validate-editable-mode.js` extended with full annotation CRUD walk (see test plan).

## Out of scope (Phase 1 Chunks C + D)

- Viewer-side `Annotate` affordance + inline rendering of stored annotations (FON-11764, next PR).
- `bin/lookie-annotations.js` CLI shim (FON-11765, PR after that).

## Test plan

- [x] `node scripts/validate-editable-mode.js` — passes. New assertions cover:
  - disabled-gate 404 (route returns 404 when `enableAnnotations: false`)
  - empty-doc read returns `{ schema: 1, file, annotations: [], mtimeMs: null }`
  - POST creates annotation, writes sidecar at expected path, response shape correct
  - POST with missing required field returns 400
  - PATCH walks `claim` → `resolve` → `reopen` → `reply` state machine
  - GET `?state=` filter (open/resolved/invalid)
  - Stale `expectedMtimeMs` returns 409 with current document attached
  - Cross-repo read (403) and cross-repo write (403) under scoped tokens
  - GET on missing source file returns 404
- [x] `npm test` — all 12 tests pass.
- [x] Syntax-checked all modified JS files.

Refs: FON-11763, FON-11757, FON-11762 (#65)