### PR TITLE
feat: FON-11756 — CSV table viewer + /asset/ MIME

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1412,6 +1412,155 @@ function renderPdfPage({ repo, relativePath, parentHref, pdfHref, mtime, size, c
   });
 }
 
+function parseCsv(source) {
+  let text = source;
+  if (text.charCodeAt(0) === 0xFEFF) {
+    text = text.slice(1);
+  }
+
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+  const len = text.length;
+  let i = 0;
+
+  while (i < len) {
+    const ch = text[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < len && text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      field += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"' && field === '') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+
+    if (ch === ',') {
+      row.push(field);
+      field = '';
+      i += 1;
+      continue;
+    }
+
+    if (ch === '\r') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      if (i + 1 < len && text[i + 1] === '\n') {
+        i += 2;
+      } else {
+        i += 1;
+      }
+      continue;
+    }
+
+    if (ch === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      i += 1;
+      continue;
+    }
+
+    field += ch;
+    i += 1;
+  }
+
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  while (
+    rows.length > 0 &&
+    rows[rows.length - 1].length === 1 &&
+    rows[rows.length - 1][0] === ''
+  ) {
+    rows.pop();
+  }
+
+  return rows;
+}
+
+function renderCsvPage({ repo, relativePath, source, parentHref, rawHref, mtime, size, customThemeCss, queryToken = null }) {
+  const heading = `${repo}/${relativePath}`;
+  const rows = parseCsv(source);
+  const headerRow = rows[0] || [];
+  const dataRows = rows.slice(1);
+  const colCount = Math.max(headerRow.length, ...dataRows.map((r) => r.length), 0);
+
+  let tableHtml;
+  if (rows.length === 0) {
+    tableHtml = '<p class="csv-empty">CSV file is empty.</p>';
+  } else {
+    const headerCells = [];
+    for (let c = 0; c < colCount; c += 1) {
+      headerCells.push(`<th>${escapeHtml(headerRow[c] ?? '')}</th>`);
+    }
+    const bodyRows = dataRows.map((r) => {
+      const cells = [];
+      for (let c = 0; c < colCount; c += 1) {
+        cells.push(`<td>${escapeHtml(r[c] ?? '')}</td>`);
+      }
+      return `<tr>${cells.join('')}</tr>`;
+    });
+    tableHtml = `<div class="csv-table-wrap">
+        <table class="csv-table">
+          <thead><tr>${headerCells.join('')}</tr></thead>
+          <tbody>
+            ${bodyRows.join('\n            ')}
+          </tbody>
+        </table>
+      </div>`;
+  }
+
+  const rowLabel = dataRows.length === 1 ? 'row' : 'rows';
+  const colLabel = colCount === 1 ? 'column' : 'columns';
+  const summary = rows.length === 0
+    ? 'csv · empty'
+    : `csv · ${dataRows.length} ${rowLabel} × ${colCount} ${colLabel}`;
+
+  const body = `${toolbarHtml()}
+  <main class="layout">
+    <header class="topbar">
+      <h1>${escapeHtml(path.basename(relativePath))}</h1>
+      <p class="subtitle">${escapeHtml(heading)}</p>
+      ${breadcrumbs(repo, relativePath, queryToken)}
+      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · ${escapeHtml(summary)}</p>
+      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
+      <p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>
+    </header>
+
+    <article class="content csv-view">
+      ${tableHtml}
+    </article>
+  </main>
+  ${themeScript()}`;
+
+  return baseHtml({
+    title: heading,
+    body,
+    customThemeCss,
+  });
+}
+
 function renderEditPage({
   repo,
   relativePath,
@@ -1486,6 +1635,8 @@ module.exports = {
   renderImagePage,
   renderAudioPage,
   renderPdfPage,
+  renderCsvPage,
+  parseCsv,
   renderEditPage,
   renderPreviewHtml,
   setThemeList,

--- a/server.js
+++ b/server.js
@@ -45,6 +45,7 @@ const {
   renderImagePage,
   renderAudioPage,
   renderPdfPage,
+  renderCsvPage,
   renderEditPage,
   renderPreviewHtml,
   setThemeList,
@@ -74,6 +75,8 @@ const PDF_MIME_TYPES = {
   '.pdf': 'application/pdf',
 };
 
+const CSV_EXTENSIONS = new Set(['.csv']);
+
 // Text/source asset mime allowlist. Served as raw bytes via /asset/ so agents
 // (and curl) can fetch markdown, code, and config sources without scraping HTML.
 // HTML-ish extensions are intentionally returned as text/plain to prevent the
@@ -87,6 +90,7 @@ const TEXT_MIME_TYPES = {
   '.yml': 'text/yaml; charset=utf-8',
   '.json': 'application/json; charset=utf-8',
   '.xml': 'application/xml; charset=utf-8',
+  '.csv': 'text/csv; charset=utf-8',
   '.txt': TEXT_PLAIN,
   '.toml': TEXT_PLAIN,
   '.ini': TEXT_PLAIN,
@@ -593,6 +597,33 @@ function createApp(options = {}) {
         relativePath,
         parentHref: appendAccessToken(parentRel === null ? '/view' : buildHref(repo, parentRel), accessContext),
         pdfHref: appendAccessToken(buildAssetHref(repo, relativePath), accessContext),
+        mtime: formatMTime(stat.mtime),
+        size: formatFileSize(stat.size),
+        customThemeCss,
+        queryToken: accessContext.queryToken,
+      });
+
+      res.status(200).type('html').send(html);
+      return;
+    }
+
+    if (CSV_EXTENSIONS.has(extension)) {
+      let csvSource;
+      try {
+        csvSource = await fs.readFile(resolved, 'utf8');
+      } catch (error) {
+        console.error('Failed to read CSV file', { resolved, error });
+        res.status(500).type('text/plain').send('Failed to read file.');
+        return;
+      }
+
+      const parentRel = parentPath(relativePath);
+      const html = renderCsvPage({
+        repo,
+        relativePath,
+        source: csvSource,
+        parentHref: appendAccessToken(parentRel === null ? '/view' : buildHref(repo, parentRel), accessContext),
+        rawHref: appendAccessToken(buildAssetHref(repo, relativePath), accessContext),
         mtime: formatMTime(stat.mtime),
         size: formatFileSize(stat.size),
         customThemeCss,


### PR DESCRIPTION
## Summary

- Closes Gap 1 (CSV `/asset/` returns 415) and Gap 2 (no CSV table viewer) from `docs/NOTEBOOKLM-ARTIFACT-COVERAGE.md`.
- `/view/<path>.csv` now renders a proper HTML `<table>` with `<thead>` and `<tbody>`, plus row × column count, View raw link, and Download.
- `/asset/<path>.csv` now serves `text/csv; charset=utf-8` (previously 415 Unsupported Media Type).

## Implementation

- `lib/renderer.js`
  - `parseCsv(source)` — small RFC4180-ish parser: quoted fields with embedded commas, escaped doubled-quote (`""` → `"`), CRLF/LF/CR newlines, BOM strip, trailing-newline normalization.
  - `renderCsvPage(...)` — first row → `<thead>`, rest → `<tbody>`, with toolbar + breadcrumbs + theme support consistent with the audio/PDF viewers. Empty CSV shows a friendly message.
- `server.js`
  - Adds `CSV_EXTENSIONS = new Set(['.csv'])`.
  - Routes `.csv` through `renderCsvPage` in the `/view/` handler, ahead of the generic document path.
  - Adds `.csv` → `text/csv; charset=utf-8` to `TEXT_MIME_TYPES` so `/asset/` and the `lookie-read` agent CLI both work cleanly.

Note: this PR supersedes the held `fix/csv-asset-mime-allowlist` branch (commit `b460e5e`) for the asset-MIME piece. That branch can drop the CSV-MIME line once this lands; the table-viewer piece is new.

## Test plan

- [ ] `node -e "require('./lib/renderer').parseCsv(...)"` — verified locally with quoted comma, doubled-quote, header + 2 data rows. Parser output is correct.
- [ ] `node -e "require('./lib/renderer').renderCsvPage(...)"` — verified locally that the rendered HTML contains a `<table class="csv-table">` with `<thead>` and `<tbody>`.
- [ ] After deploy, browse `/view/operations-research/ai-tools/notebooklm/notebooklm-data-table.csv` and confirm the table renders instead of raw text.
- [ ] After deploy, `curl /asset/operations-research/ai-tools/notebooklm/notebooklm-data-table.csv` and confirm `200 text/csv; charset=utf-8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)