### PR TITLE
feat: FON-11764 — annotations viewer UX (Annotate + inline render)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-06-10 — Unreleased — Annotations Viewer UX (FON-11764)
+
+- When `server.enableAnnotations: true`, the document viewer now renders a 💬 button next to every anchored heading and YAML key path. Clicking it opens an inline form whose submission writes through `POST /api/annotations/<repo>/<path>`.
+- Stored annotations render inline next to their anchor as a card with author, body, state badge, claim metadata, replies, and per-state actions (Claim, Resolve, Reopen, Reply). Each action calls the API and refreshes inline; stale-mtime conflicts surface in an alert.
+- Added `public/annotations.js` (vanilla JS, ~330 lines) and a styled annotation card / inline-form section in `public/style.css`. Theme variables drive the colors so all built-in palettes look right.
+- The bootstrap (`__lookieLinkAnnotations` with `repo`, `relativePath`, `queryToken`) and the `<script src="/public/annotations.js" defer>` tag are only emitted when `annotationsEnabled` is true for the request. Validator covers both presence (enabled) and absence (disabled).
+- Author name is remembered in `localStorage` so repeat annotations don't re-prompt.
+- No source file mutation; sidecar is still the only on-disk surface. No new auth surface — the script uses the same `view` permission and query-token plumbing as the rest of the viewer.
+
 ## 2026-06-09 — Unreleased — Annotations Sidecar Transport (FON-11763)
 
 - Added sidecar-backed annotation storage at `<repoRoot>/.lookie-link/annotations/<repo>/<relative-path>.json` with atomic temp+rename writes, per-day annotation IDs, and stale-write protection via `expectedMtimeMs` on PATCH.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -125,6 +125,18 @@ Behavior:
 - Local `<img src="./file.png">` references are rewritten through `/asset/<repo>/<path>` so images still load from the repo
 - Heading anchors and TOC generation apply to rendered HTML headings the same way they do for markdown
 
+## Annotations
+
+When `server.enableAnnotations: true`, the document viewer adds an inline annotation layer to every rendered file.
+
+- A small 💬 button appears next to every anchored heading (markdown) and YAML key path. Clicking it opens an inline form to attach an annotation to that anchor.
+- Stored annotations render inline next to their anchor as a styled card, showing author, body, state (`open` / `claimed` / `resolved`), claim metadata, and replies.
+- State controls: **Claim**, **Resolve**, **Reopen**, **Reply**. Each action calls the `/api/annotations/<repo>/<path>` API and refreshes inline.
+- Annotation data lives at `<repoRoot>/.lookie-link/annotations/<repo>/<relative-path>.json` (sidecar). Source files are never mutated.
+- The flag is independent of `enableEditing` — annotations are available on the default safe configuration.
+
+See `docs/ANNOTATIONS-SPEC.md` for the full sidecar schema, phase split, and the agent-feedback loop the API enables. The HTTP transport landed in FON-11763; the viewer UX in FON-11764.
+
 ## Themes
 
 10 built-in color themes, each with dark and light variants:

--- a/public/annotations.js
+++ b/public/annotations.js
@@ -1,0 +1,330 @@
+'use strict';
+
+(function () {
+  const bootstrap = window.__lookieLinkAnnotations;
+  if (!bootstrap || !bootstrap.repo || !bootstrap.relativePath) return;
+
+  const repo = bootstrap.repo;
+  const relativePath = bootstrap.relativePath;
+  const queryToken = bootstrap.queryToken || null;
+  const apiBase = `/api/annotations/${encodeURIComponent(repo)}/${relativePath
+    .split('/').map(encodeURIComponent).join('/')}`;
+
+  function withToken(url) {
+    if (!queryToken) return url;
+    const sep = url.includes('?') ? '&' : '?';
+    return `${url}${sep}token=${encodeURIComponent(queryToken)}`;
+  }
+
+  function getDefaultAuthor() {
+    try {
+      const stored = window.localStorage.getItem('lookieLinkAnnotationAuthor');
+      if (stored && stored.trim()) return stored.trim();
+    } catch (_) {}
+    return '';
+  }
+
+  function setDefaultAuthor(value) {
+    if (!value) return;
+    try { window.localStorage.setItem('lookieLinkAnnotationAuthor', value); } catch (_) {}
+  }
+
+  function el(tag, attrs, ...children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const [k, v] of Object.entries(attrs)) {
+        if (k === 'class') node.className = v;
+        else if (k === 'dataset') {
+          for (const [dk, dv] of Object.entries(v)) node.dataset[dk] = dv;
+        } else if (k.startsWith('on') && typeof v === 'function') {
+          node.addEventListener(k.slice(2), v);
+        } else if (v !== null && v !== undefined) {
+          node.setAttribute(k, v);
+        }
+      }
+    }
+    for (const child of children) {
+      if (child === null || child === undefined) continue;
+      if (typeof child === 'string') node.appendChild(document.createTextNode(child));
+      else node.appendChild(child);
+    }
+    return node;
+  }
+
+  function formatTimestamp(iso) {
+    if (!iso) return '';
+    try { return new Date(iso).toLocaleString(); } catch (_) { return iso; }
+  }
+
+  function classifyAnchor(element) {
+    if (!element) return 'lineRange';
+    if (/^H[1-6]$/.test(element.tagName)) return 'heading';
+    if (element.classList.contains('yaml-anchor-wrap')) return 'yamlKey';
+    return 'heading';
+  }
+
+  let cachedMtimeMs = null;
+  const annotationsByAnchor = new Map();
+
+  async function api(method, path, body) {
+    const init = { method, headers: { 'Content-Type': 'application/json' } };
+    if (body !== undefined) init.body = JSON.stringify(body);
+    const res = await fetch(withToken(path), init);
+    let data = null;
+    try { data = await res.json(); } catch (_) {}
+    if (!res.ok) {
+      const message = (data && data.error) || `HTTP ${res.status}`;
+      const err = new Error(message);
+      err.status = res.status;
+      err.data = data;
+      throw err;
+    }
+    return data;
+  }
+
+  function buildAnnotateButton(anchorId, anchorKind) {
+    const btn = el('button', {
+      type: 'button',
+      class: 'lookie-annotate-btn',
+      'aria-label': `Annotate ${anchorId}`,
+      title: 'Add annotation',
+      dataset: { anchorId, anchorKind },
+    }, '💬');
+    btn.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openAnnotateForm(anchorId, anchorKind);
+    });
+    return btn;
+  }
+
+  function getOrCreateAnchorCard(anchorId) {
+    let card = document.querySelector(
+      `.lookie-annotation-card[data-anchor-id="${CSS.escape(anchorId)}"]`);
+    if (card) return card;
+
+    const target = document.getElementById(anchorId);
+    if (!target) return null;
+
+    card = el('aside', { class: 'lookie-annotation-card', dataset: { anchorId } });
+    let insertAfter = target;
+    if (target.classList.contains('yaml-anchor-wrap')) {
+      const preParent = target.closest('pre');
+      if (preParent) insertAfter = preParent;
+    }
+    if (insertAfter.parentNode) {
+      insertAfter.parentNode.insertBefore(card, insertAfter.nextSibling);
+    }
+    return card;
+  }
+
+  function renderAnnotationList(anchorId) {
+    const card = getOrCreateAnchorCard(anchorId);
+    if (!card) return;
+    card.innerHTML = '';
+    const items = annotationsByAnchor.get(anchorId) || [];
+    if (items.length === 0) { card.remove(); return; }
+    card.appendChild(el('div', { class: 'lookie-annotation-card-header' },
+      `Annotations on ${anchorId} (${items.length})`));
+    for (const annotation of items) {
+      card.appendChild(renderAnnotationItem(annotation));
+    }
+  }
+
+  function renderAnnotationItem(annotation) {
+    const stateClass = `lookie-annotation-state lookie-annotation-state-${annotation.state}`;
+    const item = el('article', {
+      class: 'lookie-annotation-item',
+      dataset: { annotationId: annotation.id, state: annotation.state },
+    });
+    item.appendChild(el('header', { class: 'lookie-annotation-item-header' },
+      el('span', { class: stateClass }, annotation.state),
+      el('span', { class: 'lookie-annotation-author' }, annotation.author || 'anonymous'),
+      el('time', { class: 'lookie-annotation-time', datetime: annotation.createdAt },
+        formatTimestamp(annotation.createdAt)),
+    ));
+    item.appendChild(el('p', { class: 'lookie-annotation-body' }, annotation.body));
+
+    if (Array.isArray(annotation.replies) && annotation.replies.length > 0) {
+      const replies = el('ul', { class: 'lookie-annotation-replies' });
+      for (const reply of annotation.replies) {
+        replies.appendChild(el('li', { class: 'lookie-annotation-reply' },
+          el('span', { class: 'lookie-annotation-author' }, reply.author || 'anonymous'),
+          el('time', { datetime: reply.createdAt }, formatTimestamp(reply.createdAt)),
+          el('p', { class: 'lookie-annotation-body' }, reply.body),
+        ));
+      }
+      item.appendChild(replies);
+    }
+
+    const actions = el('div', { class: 'lookie-annotation-actions' });
+    if (annotation.state === 'open') {
+      actions.appendChild(makeOpBtn('Claim', annotation, 'claim'));
+      actions.appendChild(makeOpBtn('Resolve', annotation, 'resolve'));
+    } else if (annotation.state === 'claimed') {
+      actions.appendChild(el('span', { class: 'lookie-annotation-claimed-by' },
+        `claimed by ${annotation.claimedBy || 'unknown'}`));
+      actions.appendChild(makeOpBtn('Resolve', annotation, 'resolve'));
+      actions.appendChild(makeOpBtn('Reopen', annotation, 'reopen'));
+    } else if (annotation.state === 'resolved') {
+      actions.appendChild(makeOpBtn('Reopen', annotation, 'reopen'));
+    }
+    actions.appendChild(makeReplyBtn(annotation));
+    item.appendChild(actions);
+    return item;
+  }
+
+  function makeOpBtn(label, annotation, op) {
+    return el('button', {
+      type: 'button',
+      class: `lookie-annotation-op lookie-annotation-op-${op}`,
+      onclick: async () => {
+        try {
+          const payload = {};
+          if (op === 'claim') {
+            const claimedBy = window.prompt('Claim as (your name)?', getDefaultAuthor() || '');
+            if (!claimedBy) return;
+            setDefaultAuthor(claimedBy);
+            payload.claimedBy = claimedBy;
+          }
+          await patchAnnotation(annotation.id, op, payload);
+          await refreshAnnotations();
+        } catch (error) {
+          window.alert(`Annotation ${op} failed: ${error.message}`);
+        }
+      },
+    }, label);
+  }
+
+  function makeReplyBtn(annotation) {
+    return el('button', {
+      type: 'button',
+      class: 'lookie-annotation-op lookie-annotation-op-reply',
+      onclick: async () => {
+        const author = window.prompt('Your name?', getDefaultAuthor() || '');
+        if (!author) return;
+        const body = window.prompt('Reply body?');
+        if (!body || !body.trim()) return;
+        setDefaultAuthor(author);
+        try {
+          await patchAnnotation(annotation.id, 'reply', { author, body: body.trim() });
+          await refreshAnnotations();
+        } catch (error) {
+          window.alert(`Annotation reply failed: ${error.message}`);
+        }
+      },
+    }, 'Reply');
+  }
+
+  async function patchAnnotation(id, op, payload) {
+    return api('PATCH', apiBase, { id, op, payload, expectedMtimeMs: cachedMtimeMs });
+  }
+
+  function openAnnotateForm(anchorId, anchorKind) {
+    document.querySelectorAll('.lookie-annotate-form').forEach((node) => node.remove());
+    const card = getOrCreateAnchorCard(anchorId);
+    if (!card) return;
+
+    const form = el('form', { class: 'lookie-annotate-form', dataset: { anchorId } });
+    const authorInput = el('input', {
+      type: 'text', name: 'author', placeholder: 'Your name',
+      required: 'required', value: getDefaultAuthor(),
+    });
+    const bodyInput = el('textarea', {
+      name: 'body', placeholder: 'What needs attention?',
+      required: 'required', rows: '3',
+    });
+    const submit = el('button', { type: 'submit', class: 'lookie-annotation-submit' }, 'Save annotation');
+    const cancel = el('button', {
+      type: 'button', class: 'lookie-annotation-cancel',
+      onclick: () => form.remove(),
+    }, 'Cancel');
+
+    form.appendChild(authorInput);
+    form.appendChild(bodyInput);
+    form.appendChild(el('div', { class: 'lookie-annotate-form-actions' }, submit, cancel));
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const author = authorInput.value.trim();
+      const body = bodyInput.value.trim();
+      if (!author || !body) return;
+      setDefaultAuthor(author);
+      submit.disabled = true;
+      try {
+        await api('POST', apiBase, {
+          anchor: `#${anchorId}`, anchorKind, author, body,
+        });
+        form.remove();
+        await refreshAnnotations();
+      } catch (error) {
+        window.alert(`Save annotation failed: ${error.message}`);
+        submit.disabled = false;
+      }
+    });
+
+    card.appendChild(form);
+    bodyInput.focus();
+  }
+
+  async function refreshAnnotations() {
+    try {
+      const doc = await api('GET', apiBase);
+      cachedMtimeMs = doc.mtimeMs || null;
+      annotationsByAnchor.clear();
+      for (const annotation of doc.annotations || []) {
+        const anchorId = String(annotation.anchor || '').replace(/^#/, '');
+        if (!anchorId) continue;
+        const list = annotationsByAnchor.get(anchorId) || [];
+        list.push(annotation);
+        annotationsByAnchor.set(anchorId, list);
+      }
+      const seen = new Set();
+      for (const [anchorId] of annotationsByAnchor) {
+        renderAnnotationList(anchorId);
+        seen.add(anchorId);
+      }
+      document.querySelectorAll('.lookie-annotation-card').forEach((node) => {
+        if (!seen.has(node.dataset.anchorId)) node.remove();
+      });
+    } catch (error) {
+      console.warn('Lookie-Link: failed to load annotations', error);
+    }
+  }
+
+  function injectAnnotateButtons() {
+    const root = document.querySelector('article.content[data-rendered-view]')
+      || document.querySelector('article.content');
+    if (!root) return;
+    const targets = root.querySelectorAll(
+      'h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], span.yaml-anchor-wrap[id]'
+    );
+    for (const target of targets) {
+      if (target.dataset.lookieAnnotateInjected) continue;
+      target.dataset.lookieAnnotateInjected = '1';
+      const anchorId = target.id;
+      if (!anchorId) continue;
+      const kind = classifyAnchor(target);
+      const btn = buildAnnotateButton(anchorId, kind);
+      if (/^H[1-6]$/.test(target.tagName)) {
+        target.appendChild(document.createTextNode(' '));
+        target.appendChild(btn);
+      } else {
+        target.appendChild(btn);
+      }
+    }
+  }
+
+  function ready(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  ready(() => {
+    injectAnnotateButtons();
+    refreshAnnotations();
+  });
+})();

--- a/public/style.css
+++ b/public/style.css
@@ -1056,3 +1056,72 @@ tbody tr:last-child td {
     right: 0.55rem;
   }
 }
+
+/* Annotations (Phase 1) */
+.lookie-annotate-btn {
+  display: inline-block; margin-left: 0.4rem; padding: 0 0.3rem;
+  font-size: 0.8em; line-height: 1.4; background: transparent;
+  border: 1px solid var(--border); border-radius: 4px;
+  color: var(--text-soft); cursor: pointer; opacity: 0.55;
+  vertical-align: baseline;
+  transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.lookie-annotate-btn:hover, .lookie-annotate-btn:focus {
+  opacity: 1; color: var(--accent); border-color: var(--accent);
+}
+.lookie-annotation-card {
+  margin: 0.4rem 0 1.1rem; padding: 0.7rem 0.85rem 0.85rem;
+  background: var(--bg-elev); border: 1px solid var(--border);
+  border-left: 3px solid var(--accent); border-radius: 6px;
+  font-size: 0.93em;
+}
+.lookie-annotation-card-header { font-weight: 600; color: var(--text-soft); margin-bottom: 0.55rem; }
+.lookie-annotation-item { padding: 0.45rem 0; border-top: 1px dashed var(--border); }
+.lookie-annotation-item:first-of-type { border-top: none; }
+.lookie-annotation-item-header {
+  display: flex; align-items: center; gap: 0.55rem;
+  margin-bottom: 0.3rem; font-size: 0.85em; color: var(--text-soft);
+}
+.lookie-annotation-state {
+  text-transform: uppercase; font-size: 0.72em; letter-spacing: 0.07em;
+  padding: 0.05rem 0.45rem; border-radius: 4px;
+  background: var(--bg-code); color: var(--text);
+}
+.lookie-annotation-state-open { background: rgba(255, 184, 0, 0.16); color: #d68b00; }
+.lookie-annotation-state-claimed { background: rgba(0, 132, 255, 0.16); color: #196edc; }
+.lookie-annotation-state-resolved { background: rgba(0, 168, 92, 0.16); color: #008a4d; }
+.lookie-annotation-author { font-weight: 600; color: var(--text); }
+.lookie-annotation-time { margin-left: auto; font-variant-numeric: tabular-nums; }
+.lookie-annotation-body { white-space: pre-wrap; margin: 0.15rem 0 0.45rem; color: var(--text); }
+.lookie-annotation-replies {
+  margin: 0.3rem 0 0.4rem 0.4rem; padding-left: 0.6rem;
+  list-style: none; border-left: 2px solid var(--border);
+}
+.lookie-annotation-reply { padding: 0.25rem 0; font-size: 0.95em; }
+.lookie-annotation-reply time { margin-left: 0.4rem; font-size: 0.78em; color: var(--text-soft); }
+.lookie-annotation-actions { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
+.lookie-annotation-op {
+  padding: 0.18rem 0.55rem; font-size: 0.82em;
+  background: var(--bg-code); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px; cursor: pointer;
+}
+.lookie-annotation-op:hover { border-color: var(--accent); color: var(--accent); }
+.lookie-annotation-claimed-by { font-size: 0.82em; color: var(--text-soft); font-style: italic; }
+.lookie-annotate-form {
+  display: flex; flex-direction: column; gap: 0.4rem;
+  margin-top: 0.55rem; padding: 0.55rem;
+  background: var(--bg); border: 1px dashed var(--border); border-radius: 5px;
+}
+.lookie-annotate-form input, .lookie-annotate-form textarea {
+  font: inherit; padding: 0.35rem 0.5rem;
+  background: var(--bg-code); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px;
+}
+.lookie-annotate-form textarea { resize: vertical; min-height: 4.5rem; }
+.lookie-annotate-form-actions { display: flex; gap: 0.4rem; }
+.lookie-annotation-submit, .lookie-annotation-cancel {
+  padding: 0.3rem 0.75rem; font: inherit; border-radius: 4px; cursor: pointer;
+  border: 1px solid var(--border);
+}
+.lookie-annotation-submit { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+.lookie-annotation-cancel { background: transparent; color: var(--text-soft); }

--- a/scripts/validate-editable-mode.js
+++ b/scripts/validate-editable-mode.js
@@ -100,6 +100,8 @@ async function run() {
   });
 
   const view = getRouteHandler(appEnabled, 'get', '/view/*');
+  const viewWithAnnotations = getRouteHandler(appAnnotationsEnabled, 'get', '/view/*');
+  const viewWithoutAnnotations = getRouteHandler(appAnnotationsDisabled, 'get', '/view/*');
   const edit = getRouteHandler(appEnabled, 'get', '/edit/*');
   const editDisabled = getRouteHandler(appDisabled, 'get', '/edit/*');
   const save = getRouteHandler(appEnabled, 'post', '/api/save/*');
@@ -422,6 +424,23 @@ async function run() {
       headers: { authorization: 'Bearer docs-reader-token' },
     }, res);
     assert.equal(res.statusCode, 403, 'cross-repo annotation write should be denied');
+  }
+
+  {
+    const res = createMockRes();
+    await viewWithAnnotations({ params: { 0: 'docs/doc.md' } }, res);
+    assert.equal(res.statusCode, 200, 'annotations-enabled view failed');
+    assert(typeof res.body === 'string', 'annotations-enabled view body missing');
+    assert(res.body.includes('/public/annotations.js'), 'annotations script not injected when enabled');
+    assert(res.body.includes('lookie-link-annotations-bootstrap'), 'annotations bootstrap script tag missing when enabled');
+  }
+
+  {
+    const res = createMockRes();
+    await viewWithoutAnnotations({ params: { 0: 'docs/doc.md' } }, res);
+    assert.equal(res.statusCode, 200, 'annotations-disabled view failed');
+    assert(!res.body.includes('/public/annotations.js'), 'annotations script leaked into view when disabled');
+    assert(!res.body.includes('lookie-link-annotations-bootstrap'), 'annotations bootstrap leaked into view when disabled');
   }
 
   console.log('editable mode validation passed');


### PR DESCRIPTION
## Summary

Phase 1 Chunk C of the Lookie-Link annotations work ([FON-11757](https://github.com/chrisfonte/lookie-link/issues/57) umbrella, Paperclip FON-11764). The browser-side viewer surface on top of the sidecar transport landed in #67 (FON-11763) and the nested YAML anchors from #65 (FON-11762).

> **Note on diff size.** The `lib/renderer.js` (`annotationsEnabled` param + bootstrap injection) and `server.js` (passing the flag through the view handler) edits I wrote for Chunk C were already merged to `main` as part of the CSV viewer PR #70 (which touched the same renderer code path and pulled the annotation hooks along for the ride). What remains here is the client-side surface that those hooks point at: `public/annotations.js`, the new CSS, the validator smoke test that asserts script presence/absence, and docs.

## What this PR lands

- **`public/annotations.js`** — vanilla JS client that runs on the document view when `server.enableAnnotations: true`. Reads `window.__lookieLinkAnnotations` bootstrap (`repo` / `relativePath` / `queryToken`), then:
  - Injects a 💬 Annotate button next to every anchored markdown heading (h1–h6) and every YAML key path span (`span.yaml-anchor-wrap[id]`).
  - On click, opens an inline form (author + body) anchored to the matching id. Submit posts to `POST /api/annotations/<repo>/<path>` with `anchorKind` of `heading` or `yamlKey`.
  - Fetches existing annotations on load and renders them inline as cards next to their anchor. Cards show state badge, author, body, claim metadata, replies, and per-state action buttons (Claim / Resolve / Reopen / Reply) that call `PATCH /api/annotations/<repo>/<path>`.
  - Stale-mtime conflicts surface in a window alert; the script refetches after each successful change.
  - Author name is remembered in `localStorage` so repeat annotations don't re-prompt.
- **`public/style.css`** — styled annotation card and inline-form section. All colors come from existing CSS custom properties so every built-in theme (Slate, Teal, Nord, Rosé Pine, Monokai, Solarized, GitHub, Ember, Noir, Indigo) renders the layer correctly.
- **`scripts/validate-editable-mode.js`** — two new smoke assertions confirm the annotation script and bootstrap tag are present when `annotationsEnabled: true` and absent when it's false.
- Docs: new **Annotations** section in `docs/FEATURES.md`; CHANGELOG entry.

## Security / auth

- No source-file mutation; sidecar remains the only on-disk surface.
- No new auth path. The script uses the existing token-scoped `view` permission and the query-token plumbing that the rest of the viewer already uses (see `withToken(url)` in `public/annotations.js`).
- The bootstrap and script tag are only emitted when `annotationsEnabled && canAccessPath(view)` is true for the request (gate is in `server.js`).

## Out of scope

- Phase 1 Chunk D ([FON-11765](paperclip)): `bin/lookie-annotations.js` CLI shim — separate PR.
- Phase 2+: line-range picker for un-anchored files, element + text-range HTML annotations, inline-in-source mode.

## Test plan

- [x] `node scripts/validate-editable-mode.js` — passes. New assertions cover script presence (enabled) and absence (disabled).
- [x] `npm test` — all tests pass.
- [x] Syntax-checked all modified JS files.

Refs: FON-11764, FON-11757, FON-11763 (#67), FON-11762 (#65)