### PR TITLE
feat: FON-11756 — YAML Raw toggle (Phase C)

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -915,8 +915,9 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
   const extension = path.extname(relativePath).toLowerCase();
   const isMarkdown = MARKDOWN_EXTENSIONS.has(extension);
   const isHtmlDocument = HTML_EXTENSIONS.has(extension);
-  const hasToc = isMarkdown || isHtmlDocument || ['.yaml', '.yml'].includes(extension);
-  const supportsRawToggle = isMarkdown || isHtmlDocument;
+  const isYaml = ['.yaml', '.yml'].includes(extension);
+  const hasToc = isMarkdown || isHtmlDocument || isYaml;
+  const supportsRawToggle = isMarkdown || isHtmlDocument || isYaml;
   const rendered = renderContent(relativePath, source, {
     repo,
     repoRoot: repoRoot || null,
@@ -925,7 +926,7 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
   });
   const heading = `${repo}/${relativePath}`;
   const rawSourceJson = supportsRawToggle ? jsonForInlineScript(source) : null;
-  const rawLanguage = isMarkdown ? 'markdown' : isHtmlDocument ? 'xml' : null;
+  const rawLanguage = isMarkdown ? 'markdown' : isHtmlDocument ? 'xml' : isYaml ? 'yaml' : null;
 
   const renderedClass = isMarkdown ? 'markdown' : rendered.kind;
   const contentHtml = `${hasToc ? `<article class="content toc-view" id="toc-view" data-toc-view hidden aria-hidden="true">


### PR DESCRIPTION
## Summary

Phase C of the FON-11756 structured-viewer toggle. YAML already had highlight.js + the FON-11762 nested-anchor pass + Edit as its structured view; it just lacked the Raw toggle button. This adds it so the toolbar matches CSV (Phase A) and JSON (Phase B).

- `lib/renderer.js`: extends `renderDocumentPage`'s `supportsRawToggle` to include `.yaml` / `.yml`, with `rawLanguage='yaml'` for the raw block so highlight.js picks the right grammar.

Real indent folding (collapse-by-key / expand-on-click) on top of the anchor pass is a follow-on enhancement; it's not blocking the toolbar parity the user asked for.

## Test plan

- [x] Smoke: `renderDocumentPage` for a `.yaml` file produces `data-rendered-view` + `data-raw-view` + `data-raw-toggle` button + Edit href + `language-yaml` raw block, with TOC button preserved.
- [ ] After deploy: open `/view/lookie-link/lookie-link.yaml.example` (or any `.yaml`), confirm Raw button toggles to a syntax-highlighted YAML source view and back, confirm Edit + TOC still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)