### PR TITLE
feat: FON-11765 — bin/lookie-annotations.js CLI shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - Author name is remembered in `localStorage` so repeat annotations don't re-prompt.
 - No source file mutation; sidecar is still the only on-disk surface. No new auth surface — the script uses the same `view` permission and query-token plumbing as the rest of the viewer.
 
+## 2026-06-09 — Unreleased — Annotations CLI Shim (FON-11765)
+
+- Added `bin/lookie-annotations.js` CLI shim, registered as the `lookie-annotations` bin. Mirrors `lookie-read.js` posture: env-based auth (`LOOKIE_LINK_BASE_URL`, `LOOKIE_LINK_TOKEN`, `LOOKIE_LINK_AUTHOR`), JSON-first stdout, shared exit-code grammar (`0/2/3/4/5`), and `--json-errors` for machine consumers.
+- Subcommands: `list`, `get`, `add`, `claim`, `resolve`, `replies` (with `--add`). `--state` is repeatable; `--pretty` prints a human-friendly form; body input accepts `--body STRING`, `--body-file PATH`, or `--body -` (stdin).
+- Extended `scripts/validate-editable-mode.js` to spawn the CLI against a real HTTP listener and cover every subcommand path, both body-input forms, state filtering, `--pretty`, no-token forbidden (exit 4), and scoped-token success.
+- Documented both shims in `docs/AGENT-SHIM.md`.
+
 ## 2026-06-09 — Unreleased — Annotations Sidecar Transport (FON-11763)
 
 - Added sidecar-backed annotation storage at `<repoRoot>/.lookie-link/annotations/<repo>/<relative-path>.json` with atomic temp+rename writes, per-day annotation IDs, and stale-write protection via `expectedMtimeMs` on PATCH.

--- a/bin/lookie-annotations.js
+++ b/bin/lookie-annotations.js
@@ -1,0 +1,504 @@
+#!/usr/bin/env node
+'use strict';
+
+// lookie-annotations — agent-facing shim for Lookie-Link sidecar annotations.
+//
+// See ../docs/AGENT-SHIM.md for the full contract.
+
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const path = require('node:path');
+
+const DEFAULT_BASE_URL = process.env.LOOKIE_LINK_BASE_URL || 'http://mac-mini-2.bobcat-tetra.ts.net:9876';
+
+const EXIT_OK = 0;
+const EXIT_USAGE = 2;
+const EXIT_NOT_FOUND = 3;
+const EXIT_FORBIDDEN = 4;
+const EXIT_TRANSPORT = 5;
+
+const SUPPORTED_STATES = new Set(['open', 'claimed', 'resolved']);
+const SUPPORTED_KINDS = new Set(['heading', 'yamlKey', 'lineRange']);
+const SUBCOMMANDS = new Set(['list', 'get', 'add', 'claim', 'resolve', 'replies']);
+
+const TOP_HELP = [
+  'Usage: lookie-annotations <command> <repo>/<path> [options]',
+  '',
+  'Commands:',
+  '  list <repo>/<path> [--state STATE]...      Read all annotations',
+  '  get <repo>/<path> <id>                     Read one annotation',
+  '  add <repo>/<path> --anchor A --kind K      Create an annotation',
+  '                    --body BODY [--author X]',
+  '  claim <repo>/<path> <id> [--by AGENT]      Mark annotation claimed',
+  '  resolve <repo>/<path> <id>                 Mark annotation resolved',
+  '  replies <repo>/<path> <id>                 List replies on annotation',
+  '  replies <repo>/<path> <id> --add BODY      Append a reply',
+  '',
+  'Common options:',
+  '  --base-url URL       Lookie-Link base URL (env: LOOKIE_LINK_BASE_URL)',
+  '  --pretty             Human-readable output (default: JSON)',
+  '  --json-errors        Errors as JSON to stdout (default: text to stderr)',
+  '  --body STRING        Inline body. Use "-" to read from stdin',
+  '  --body-file PATH     Read body from a file',
+  '  --author NAME        Author/agent name (default: $LOOKIE_LINK_AUTHOR or "lookie-annotations")',
+  '  -h, --help           This help',
+  '  -v, --version        Print version',
+  '',
+  'Env:',
+  '  LOOKIE_LINK_BASE_URL  Base URL (default http://mac-mini-2.bobcat-tetra.ts.net:9876)',
+  '  LOOKIE_LINK_TOKEN     Bearer token forwarded to the server',
+  '  LOOKIE_LINK_AUTHOR    Default author/agent name',
+  '',
+  'Exit codes: 0 success, 2 usage, 3 not found, 4 forbidden, 5 transport/5xx',
+].join('\n');
+
+const SUBCOMMAND_HELP = {
+  list: 'Usage: lookie-annotations list <repo>/<path> [--state STATE]...',
+  get: 'Usage: lookie-annotations get <repo>/<path> <id>',
+  add: 'Usage: lookie-annotations add <repo>/<path> --anchor A --kind heading|yamlKey|lineRange --body BODY [--author NAME]',
+  claim: 'Usage: lookie-annotations claim <repo>/<path> <id> [--by AGENT]',
+  resolve: 'Usage: lookie-annotations resolve <repo>/<path> <id>',
+  replies: 'Usage: lookie-annotations replies <repo>/<path> <id> [--add BODY] [--author NAME]',
+};
+
+const errorState = {
+  jsonErrors: false,
+};
+
+function die(code, message) {
+  if (message) {
+    if (errorState.jsonErrors) {
+      process.stdout.write(`${JSON.stringify({ error: message, code })}\n`);
+    } else {
+      process.stderr.write(`lookie-annotations: ${message}\n`);
+    }
+  }
+  process.exit(code);
+}
+
+function printVersion() {
+  const pkgPath = path.join(__dirname, '..', 'package.json');
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    process.stdout.write(`lookie-annotations ${pkg.version}\n`);
+  } catch {
+    process.stdout.write('lookie-annotations (unknown version)\n');
+  }
+  process.exit(EXIT_OK);
+}
+
+function expandHomeAndStripLeading(input) {
+  let s = String(input || '').trim();
+  if (s.startsWith('~/')) s = s.slice(2);
+  else if (s.startsWith('/')) s = s.replace(/^\/+/, '');
+  return s.replace(/^\.\//, '');
+}
+
+function splitRepoPath(input) {
+  const cleaned = expandHomeAndStripLeading(input);
+  if (!cleaned) return null;
+  const slash = cleaned.indexOf('/');
+  if (slash < 0) return { repo: cleaned, relativePath: '' };
+  return {
+    repo: cleaned.slice(0, slash),
+    relativePath: cleaned.slice(slash + 1),
+  };
+}
+
+function buildHeaders(extra) {
+  const headers = { Accept: 'application/json' };
+  if (process.env.LOOKIE_LINK_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.LOOKIE_LINK_TOKEN}`;
+  }
+  return Object.assign(headers, extra || {});
+}
+
+function buildAnnotationsUrl(baseUrl, repo, relativePath, states) {
+  const segments = relativePath
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  let url = `${baseUrl}/api/annotations/${encodeURIComponent(repo)}/${segments}`;
+  if (states && states.length) {
+    const qs = states.map((s) => `state=${encodeURIComponent(s)}`).join('&');
+    url += `?${qs}`;
+  }
+  return url;
+}
+
+function mapHttpFailure(res, label) {
+  if (res.status === 404) die(EXIT_NOT_FOUND, `not found (${label}): HTTP 404`);
+  if (res.status === 401 || res.status === 403) die(EXIT_FORBIDDEN, `forbidden (${label}): HTTP ${res.status}`);
+  if (res.status === 400) die(EXIT_USAGE, `bad request (${label}): HTTP 400`);
+  die(EXIT_TRANSPORT, `HTTP ${res.status} (${label})`);
+}
+
+async function httpJson(method, url, body, label) {
+  const init = { method, headers: buildHeaders(body ? { 'Content-Type': 'application/json' } : null) };
+  if (body) init.body = JSON.stringify(body);
+  let res;
+  try {
+    res = await fetch(url, init);
+  } catch (err) {
+    die(EXIT_TRANSPORT, `${label} fetch failed: ${err.message}`);
+  }
+  let json = null;
+  try {
+    json = await res.json();
+  } catch {
+    // Body may be empty / non-JSON; we'll surface as transport below.
+  }
+  if (!res.ok) {
+    if (res.status === 409) {
+      return { status: 409, body: json };
+    }
+    mapHttpFailure(res, label);
+  }
+  return { status: res.status, body: json };
+}
+
+async function readBody(opts) {
+  if (opts.body !== null && opts.body !== undefined) {
+    if (opts.body === '-') {
+      return readStdin();
+    }
+    return opts.body;
+  }
+  if (opts.bodyFile) {
+    try {
+      return await fsp.readFile(opts.bodyFile, 'utf8');
+    } catch (err) {
+      die(EXIT_USAGE, `--body-file: ${err.message}`);
+    }
+  }
+  return null;
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.on('data', (chunk) => chunks.push(chunk));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    process.stdin.on('error', reject);
+  });
+}
+
+function parseArgs(argv) {
+  const opts = {
+    baseUrl: DEFAULT_BASE_URL,
+    pretty: false,
+    jsonErrors: false,
+    states: [],
+    anchor: null,
+    kind: null,
+    body: null,
+    bodyFile: null,
+    author: process.env.LOOKIE_LINK_AUTHOR || 'lookie-annotations',
+    by: null,
+    addReply: false,
+    positional: [],
+  };
+
+  let subcommand = null;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '-h':
+      case '--help': {
+        const stream = process.stdout;
+        if (subcommand && SUBCOMMAND_HELP[subcommand]) {
+          stream.write(`${SUBCOMMAND_HELP[subcommand]}\n`);
+        } else {
+          stream.write(`${TOP_HELP}\n`);
+        }
+        process.exit(EXIT_OK);
+        break;
+      }
+      case '-v':
+      case '--version':
+        printVersion();
+        break;
+      case '--base-url':
+        opts.baseUrl = argv[++i];
+        if (!opts.baseUrl) die(EXIT_USAGE, '--base-url requires a value');
+        break;
+      case '--pretty':
+        opts.pretty = true;
+        break;
+      case '--json-errors':
+        opts.jsonErrors = true;
+        errorState.jsonErrors = true;
+        break;
+      case '--state': {
+        const value = argv[++i];
+        if (!value) die(EXIT_USAGE, '--state requires a value');
+        if (!SUPPORTED_STATES.has(value)) {
+          die(EXIT_USAGE, `--state must be one of open|claimed|resolved (got ${value})`);
+        }
+        opts.states.push(value);
+        break;
+      }
+      case '--anchor':
+        opts.anchor = argv[++i];
+        if (!opts.anchor) die(EXIT_USAGE, '--anchor requires a value');
+        break;
+      case '--kind':
+        opts.kind = argv[++i];
+        if (!opts.kind) die(EXIT_USAGE, '--kind requires a value');
+        if (!SUPPORTED_KINDS.has(opts.kind)) {
+          die(EXIT_USAGE, `--kind must be heading|yamlKey|lineRange (got ${opts.kind})`);
+        }
+        break;
+      case '--body':
+        opts.body = argv[++i];
+        if (opts.body === undefined) die(EXIT_USAGE, '--body requires a value');
+        break;
+      case '--body-file':
+        opts.bodyFile = argv[++i];
+        if (!opts.bodyFile) die(EXIT_USAGE, '--body-file requires a value');
+        break;
+      case '--author':
+        opts.author = argv[++i];
+        if (!opts.author) die(EXIT_USAGE, '--author requires a value');
+        break;
+      case '--by':
+        opts.by = argv[++i];
+        if (!opts.by) die(EXIT_USAGE, '--by requires a value');
+        break;
+      case '--add':
+        opts.addReply = true;
+        opts.body = argv[++i];
+        if (opts.body === undefined) die(EXIT_USAGE, '--add requires a body value');
+        break;
+      default:
+        if (arg.startsWith('--')) die(EXIT_USAGE, `unknown option: ${arg}`);
+        if (!subcommand) {
+          if (!SUBCOMMANDS.has(arg)) {
+            die(EXIT_USAGE, `unknown command: ${arg} (run --help for usage)`);
+          }
+          subcommand = arg;
+        } else {
+          opts.positional.push(arg);
+        }
+    }
+  }
+
+  return { subcommand, opts };
+}
+
+function emit(opts, payload) {
+  if (opts.pretty) {
+    process.stdout.write(`${formatPretty(payload)}\n`);
+  } else {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  }
+}
+
+function formatAnnotation(a) {
+  const lines = [];
+  lines.push(`[${a.state}] ${a.id} by ${a.author} @ ${a.createdAt}`);
+  lines.push(`  anchor: ${a.anchorKind} ${a.anchor}`);
+  if (a.claimedBy) lines.push(`  claimed by ${a.claimedBy} @ ${a.claimedAt}`);
+  if (a.resolvedAt) lines.push(`  resolved @ ${a.resolvedAt}`);
+  lines.push('  body:');
+  for (const bodyLine of String(a.body).split('\n')) {
+    lines.push(`    ${bodyLine}`);
+  }
+  const replies = Array.isArray(a.replies) ? a.replies : [];
+  if (replies.length) {
+    lines.push(`  replies (${replies.length}):`);
+    for (const reply of replies) {
+      lines.push(`    - ${reply.author} @ ${reply.createdAt}`);
+      for (const bodyLine of String(reply.body).split('\n')) {
+        lines.push(`      ${bodyLine}`);
+      }
+    }
+  } else {
+    lines.push('  (no replies)');
+  }
+  return lines.join('\n');
+}
+
+function formatPretty(payload) {
+  if (payload && Array.isArray(payload.annotations)) {
+    if (payload.annotations.length === 0) {
+      return `# ${payload.file}\n(no annotations)`;
+    }
+    const head = `# ${payload.file} (${payload.annotations.length})`;
+    return [head, ...payload.annotations.map(formatAnnotation)].join('\n\n');
+  }
+  if (payload && payload.annotation) {
+    return formatAnnotation(payload.annotation);
+  }
+  if (payload && Array.isArray(payload.replies)) {
+    if (payload.replies.length === 0) return '(no replies)';
+    return payload.replies
+      .map((reply) => {
+        const lines = [`- ${reply.author} @ ${reply.createdAt}`];
+        for (const bodyLine of String(reply.body).split('\n')) {
+          lines.push(`  ${bodyLine}`);
+        }
+        return lines.join('\n');
+      })
+      .join('\n');
+  }
+  return JSON.stringify(payload, null, 2);
+}
+
+function requireRepoPath(positional, subcommand) {
+  if (positional.length === 0) {
+    die(EXIT_USAGE, `${subcommand}: missing <repo>/<path>`);
+  }
+  const parsed = splitRepoPath(positional[0]);
+  if (!parsed || !parsed.repo || !parsed.relativePath) {
+    die(EXIT_USAGE, `${subcommand}: argument must be <repo>/<path>`);
+  }
+  return parsed;
+}
+
+async function fetchDocument(opts, repo, relativePath, states) {
+  const url = buildAnnotationsUrl(opts.baseUrl, repo, relativePath, states);
+  const { body } = await httpJson('GET', url, null, 'read annotations');
+  if (!body || !Array.isArray(body.annotations)) {
+    die(EXIT_TRANSPORT, 'malformed annotation response');
+  }
+  return body;
+}
+
+async function findAnnotationById(opts, repo, relativePath, id) {
+  const doc = await fetchDocument(opts, repo, relativePath, []);
+  const found = doc.annotations.find((a) => a && a.id === id);
+  if (!found) die(EXIT_NOT_FOUND, `annotation not found: ${id}`);
+  return found;
+}
+
+async function cmdList(opts) {
+  const { repo, relativePath } = requireRepoPath(opts.positional, 'list');
+  const doc = await fetchDocument(opts, repo, relativePath, opts.states);
+  emit(opts, doc);
+}
+
+async function cmdGet(opts) {
+  const { repo, relativePath } = requireRepoPath(opts.positional, 'get');
+  const id = opts.positional[1];
+  if (!id) die(EXIT_USAGE, 'get: missing <id>');
+  const annotation = await findAnnotationById(opts, repo, relativePath, id);
+  emit(opts, { ok: true, annotation });
+}
+
+async function cmdAdd(opts) {
+  const { repo, relativePath } = requireRepoPath(opts.positional, 'add');
+  if (!opts.anchor) die(EXIT_USAGE, 'add: --anchor is required');
+  if (!opts.kind) die(EXIT_USAGE, 'add: --kind is required');
+  const body = await readBody(opts);
+  if (body === null || !String(body).trim()) {
+    die(EXIT_USAGE, 'add: --body, --body-file, or --body - is required');
+  }
+  const url = buildAnnotationsUrl(opts.baseUrl, repo, relativePath);
+  const payload = {
+    anchor: opts.anchor,
+    anchorKind: opts.kind,
+    body: String(body),
+    author: opts.author,
+  };
+  const { body: response } = await httpJson('POST', url, payload, 'create annotation');
+  emit(opts, response);
+}
+
+async function cmdClaim(opts) {
+  const { repo, relativePath } = requireRepoPath(opts.positional, 'claim');
+  const id = opts.positional[1];
+  if (!id) die(EXIT_USAGE, 'claim: missing <id>');
+  const claimedBy = opts.by || opts.author;
+  const url = buildAnnotationsUrl(opts.baseUrl, repo, relativePath);
+  const { body: response } = await httpJson(
+    'PATCH',
+    url,
+    { id, op: 'claim', payload: { claimedBy } },
+    'claim annotation'
+  );
+  emit(opts, response);
+}
+
+async function cmdResolve(opts) {
+  const { repo, relativePath } = requireRepoPath(opts.positional, 'resolve');
+  const id = opts.positional[1];
+  if (!id) die(EXIT_USAGE, 'resolve: missing <id>');
+  const url = buildAnnotationsUrl(opts.baseUrl, repo, relativePath);
+  const { body: response } = await httpJson(
+    'PATCH',
+    url,
+    { id, op: 'resolve', payload: {} },
+    'resolve annotation'
+  );
+  emit(opts, response);
+}
+
+async function cmdReplies(opts) {
+  const { repo, relativePath } = requireRepoPath(opts.positional, 'replies');
+  const id = opts.positional[1];
+  if (!id) die(EXIT_USAGE, 'replies: missing <id>');
+  if (opts.addReply) {
+    const body = await readBody(opts);
+    if (body === null || !String(body).trim()) {
+      die(EXIT_USAGE, 'replies --add: body is required');
+    }
+    const url = buildAnnotationsUrl(opts.baseUrl, repo, relativePath);
+    const { body: response } = await httpJson(
+      'PATCH',
+      url,
+      {
+        id,
+        op: 'reply',
+        payload: { author: opts.author, body: String(body) },
+      },
+      'reply to annotation'
+    );
+    emit(opts, response);
+    return;
+  }
+  const annotation = await findAnnotationById(opts, repo, relativePath, id);
+  const replies = Array.isArray(annotation.replies) ? annotation.replies : [];
+  emit(opts, { ok: true, id, file: `${repo}/${relativePath}`, replies });
+}
+
+async function main() {
+  if (process.argv.length <= 2) {
+    process.stderr.write(`${TOP_HELP}\n`);
+    process.exit(EXIT_USAGE);
+  }
+
+  const { subcommand, opts } = parseArgs(process.argv.slice(2));
+  if (!subcommand) {
+    die(EXIT_USAGE, 'missing subcommand (run --help for usage)');
+  }
+
+  switch (subcommand) {
+    case 'list':
+      await cmdList(opts);
+      return;
+    case 'get':
+      await cmdGet(opts);
+      return;
+    case 'add':
+      await cmdAdd(opts);
+      return;
+    case 'claim':
+      await cmdClaim(opts);
+      return;
+    case 'resolve':
+      await cmdResolve(opts);
+      return;
+    case 'replies':
+      await cmdReplies(opts);
+      return;
+    default:
+      die(EXIT_USAGE, `unknown command: ${subcommand}`);
+  }
+}
+
+main().catch((err) => {
+  die(EXIT_TRANSPORT, err && err.message ? err.message : String(err));
+});

--- a/docs/AGENT-SHIM.md
+++ b/docs/AGENT-SHIM.md
@@ -1,0 +1,104 @@
+# Agent CLI Shims
+
+Lookie-Link ships two CLI shims for agents that prefer a shell entry point over raw HTTP:
+
+- `lookie-read` — fetch a file from a Lookie-Link host (`bin/lookie-read.js`)
+- `lookie-annotations` — list / create / claim / resolve / reply to annotations (`bin/lookie-annotations.js`)
+
+Both share the same env-based auth, the same exit-code grammar, and JSON-first stdout.
+
+## Common Environment
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LOOKIE_LINK_BASE_URL` | `http://mac-mini-2.bobcat-tetra.ts.net:9876` | Server base URL |
+| `LOOKIE_LINK_TOKEN` | _(unset)_ | Bearer token forwarded as `Authorization: Bearer <token>` |
+| `LOOKIE_LINK_AUTHOR` | `lookie-annotations` (annotations only) | Default author name for created annotations and replies |
+
+`--base-url URL` overrides `LOOKIE_LINK_BASE_URL` on any invocation.
+
+## Exit Codes
+
+Both shims use the same grammar:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `2` | Usage error (bad flags, missing args, malformed `<repo>/<path>`) |
+| `3` | Not found (file or annotation does not exist) |
+| `4` | Forbidden (HTTP 401 or 403 — auth missing, wrong scope, or token rejected) |
+| `5` | Transport, 5xx, or unexpected response shape |
+
+## Path Argument
+
+Both shims accept either form for the file argument:
+
+```
+operations/README.md
+~/operations/README.md
+```
+
+The leading `~/` and any leading slashes are stripped before the first path segment is treated as the repo id.
+
+## `lookie-annotations`
+
+```
+lookie-annotations <command> <repo>/<path> [options]
+```
+
+### Subcommands
+
+| Command | Call |
+|---------|------|
+| `list <repo>/<path> [--state STATE]...` | `GET /api/annotations/:repo/*` |
+| `get <repo>/<path> <id>` | `GET` + client-side filter |
+| `add <repo>/<path> --anchor A --kind K --body B [--author NAME]` | `POST` |
+| `claim <repo>/<path> <id> [--by AGENT]` | `PATCH` `op=claim` |
+| `resolve <repo>/<path> <id>` | `PATCH` `op=resolve` |
+| `replies <repo>/<path> <id>` | `GET` + client-side filter |
+| `replies <repo>/<path> <id> --add BODY [--author NAME]` | `PATCH` `op=reply` |
+
+`--state` is repeatable (e.g. `--state open --state claimed`). Valid values: `open`, `claimed`, `resolved`.
+
+`--kind` must be one of `heading`, `yamlKey`, `lineRange`. `lineRange` anchors must be of the form `#L<start>-L<end>`.
+
+### Body Input
+
+`add` and `replies --add` require a body. Three input forms:
+
+- `--body "inline text"` — pass directly on the command line
+- `--body-file PATH` — read from a file (best for long markdown — no shell escaping)
+- `--body -` — read from stdin (`cat body.md | lookie-annotations add ... --body -`)
+
+### Output
+
+Default output is parseable JSON. `--pretty` prints a human-readable block, one annotation per stanza, suitable for terminal viewing.
+
+`--json-errors` mirrors the convention from `lookie-read.js`: errors are emitted as `{"error": "<message>", "code": <exit>}` on stdout (still followed by the matching exit code). Without `--json-errors`, errors go to stderr.
+
+### Examples
+
+```sh
+# List every open annotation on a file
+LOOKIE_LINK_TOKEN=$mytoken \
+  lookie-annotations list operations/README.md --state open
+
+# Create one from inline body
+lookie-annotations add operations/README.md \
+  --anchor '#design-decisions' --kind heading \
+  --body 'Please split this section.' --author agent-bob
+
+# Create one from a markdown file
+lookie-annotations add operations/README.md \
+  --anchor '#design-decisions' --kind heading \
+  --body-file ./review.md --author agent-bob
+
+# Claim, resolve, reply
+lookie-annotations claim   operations/README.md 2026-06-09-001 --by agent-bob
+lookie-annotations resolve operations/README.md 2026-06-09-001
+lookie-annotations replies operations/README.md 2026-06-09-001 --add 'thanks!'
+```
+
+## `lookie-read`
+
+See `bin/lookie-read.js --help`. Fetches a single file via local-filesystem fast path or `/asset/<repo>/<path>` over HTTP, with `--range` and `--list-repos` support. Same env vars and exit-code grammar.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Lightweight web file viewer for local directories \u2014 look at things, via links",
   "main": "server.js",
   "bin": {
-    "lookie-read": "./bin/lookie-read.js"
+    "lookie-read": "./bin/lookie-read.js",
+    "lookie-annotations": "./bin/lookie-annotations.js"
   },
   "scripts": {
     "test": "node --test",

--- a/scripts/validate-editable-mode.js
+++ b/scripts/validate-editable-mode.js
@@ -1,11 +1,48 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
 const fs = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 
 const { createApp } = require('../server');
+
+const CLI_PATH = path.join(__dirname, '..', 'bin', 'lookie-annotations.js');
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+    server.on('error', reject);
+  });
+}
+
+function stopApp(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function runCli(args, { baseUrl, token, stdin } = {}) {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env };
+    if (baseUrl) env.LOOKIE_LINK_BASE_URL = baseUrl;
+    if (token === undefined) {
+      delete env.LOOKIE_LINK_TOKEN;
+    } else {
+      env.LOOKIE_LINK_TOKEN = token;
+    }
+    const child = spawn(process.execPath, [CLI_PATH, ...args], { env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ status: code, stdout, stderr }));
+    if (stdin !== undefined) {
+      child.stdin.write(stdin);
+    }
+    child.stdin.end();
+  });
+}
 
 function getRouteHandler(app, method, routePath) {
   const layer = app._router.stack.find((entry) => entry.route && entry.route.path === routePath && entry.route.methods[method]);
@@ -441,6 +478,144 @@ async function run() {
     assert.equal(res.statusCode, 200, 'annotations-disabled view failed');
     assert(!res.body.includes('/public/annotations.js'), 'annotations script leaked into view when disabled');
     assert(!res.body.includes('lookie-link-annotations-bootstrap'), 'annotations bootstrap leaked into view when disabled');
+  }
+
+  // CLI shim coverage (FON-11765) — spawn the CLI against a real HTTP listener
+  // so we cover argv parsing, env-token auth, exit codes, and output formats.
+  const cliServer = await startApp(appAnnotationsEnabled);
+  const cliScopedServer = await startApp(appAnnotationsScoped);
+  try {
+    const cliBaseUrl = `http://127.0.0.1:${cliServer.address().port}`;
+    const scopedBaseUrl = `http://127.0.0.1:${cliScopedServer.address().port}`;
+
+    {
+      const result = await runCli(['list', 'docs/doc.md'], { baseUrl: cliBaseUrl });
+      assert.equal(result.status, 0, `CLI list failed: ${result.stderr}`);
+      const body = JSON.parse(result.stdout);
+      assert.equal(body.file, 'docs/doc.md', 'CLI list file id mismatch');
+      assert(Array.isArray(body.annotations), 'CLI list missing annotations[]');
+    }
+
+    let cliAnnotationA;
+    {
+      const result = await runCli(
+        ['add', 'docs/doc.md', '--anchor', '#hello', '--kind', 'heading', '--body', 'cli inline', '--author', 'cli-test'],
+        { baseUrl: cliBaseUrl }
+      );
+      assert.equal(result.status, 0, `CLI add (--body) failed: ${result.stderr}`);
+      const body = JSON.parse(result.stdout);
+      assert.equal(body.ok, true, 'CLI add response missing ok');
+      assert.equal(body.annotation.author, 'cli-test', 'CLI add author mismatch');
+      cliAnnotationA = body.annotation.id;
+    }
+
+    let cliAnnotationB;
+    {
+      const bodyFile = path.join(repoDir, '.cli-body.tmp');
+      await fs.writeFile(bodyFile, 'cli from file\n', 'utf8');
+      const result = await runCli(
+        ['add', 'docs/doc.md', '--anchor', '#hello', '--kind', 'heading', '--body-file', bodyFile, '--author', 'cli-test'],
+        { baseUrl: cliBaseUrl }
+      );
+      await fs.unlink(bodyFile);
+      assert.equal(result.status, 0, `CLI add (--body-file) failed: ${result.stderr}`);
+      cliAnnotationB = JSON.parse(result.stdout).annotation.id;
+    }
+
+    let cliAnnotationC;
+    {
+      const result = await runCli(
+        ['add', 'docs/doc.md', '--anchor', '#hello', '--kind', 'heading', '--body', '-', '--author', 'cli-test'],
+        { baseUrl: cliBaseUrl, stdin: 'cli from stdin\n' }
+      );
+      assert.equal(result.status, 0, `CLI add (--body -) failed: ${result.stderr}`);
+      cliAnnotationC = JSON.parse(result.stdout).annotation.id;
+    }
+
+    {
+      const result = await runCli(['get', 'docs/doc.md', cliAnnotationC], { baseUrl: cliBaseUrl });
+      assert.equal(result.status, 0, `CLI get failed: ${result.stderr}`);
+      const body = JSON.parse(result.stdout);
+      assert.equal(body.annotation.id, cliAnnotationC, 'CLI get id mismatch');
+    }
+
+    {
+      const result = await runCli(['claim', 'docs/doc.md', cliAnnotationA, '--by', 'cli-test'], { baseUrl: cliBaseUrl });
+      assert.equal(result.status, 0, `CLI claim failed: ${result.stderr}`);
+      const body = JSON.parse(result.stdout);
+      assert.equal(body.annotation.state, 'claimed', 'CLI claim state mismatch');
+      assert.equal(body.annotation.claimedBy, 'cli-test', 'CLI claim owner mismatch');
+    }
+
+    {
+      const result = await runCli(['resolve', 'docs/doc.md', cliAnnotationB], { baseUrl: cliBaseUrl });
+      assert.equal(result.status, 0, `CLI resolve failed: ${result.stderr}`);
+      const body = JSON.parse(result.stdout);
+      assert.equal(body.annotation.state, 'resolved', 'CLI resolve state mismatch');
+    }
+
+    {
+      const result = await runCli(
+        ['replies', 'docs/doc.md', cliAnnotationA, '--add', 'cli reply body', '--author', 'cli-test'],
+        { baseUrl: cliBaseUrl }
+      );
+      assert.equal(result.status, 0, `CLI replies --add failed: ${result.stderr}`);
+      const body = JSON.parse(result.stdout);
+      assert.equal(body.annotation.replies.length, 1, 'CLI reply append failed');
+      assert.equal(body.annotation.replies[0].author, 'cli-test', 'CLI reply author mismatch');
+    }
+
+    {
+      const result = await runCli(['replies', 'docs/doc.md', cliAnnotationA], { baseUrl: cliBaseUrl });
+      assert.equal(result.status, 0, `CLI replies (list) failed: ${result.stderr}`);
+      const body = JSON.parse(result.stdout);
+      assert.equal(body.id, cliAnnotationA, 'CLI replies id mismatch');
+      assert.equal(body.replies.length, 1, 'CLI replies list length mismatch');
+    }
+
+    {
+      const result = await runCli(
+        ['list', 'docs/doc.md', '--state', 'open', '--state', 'claimed'],
+        { baseUrl: cliBaseUrl }
+      );
+      assert.equal(result.status, 0, `CLI list --state failed: ${result.stderr}`);
+      const body = JSON.parse(result.stdout);
+      assert(body.annotations.length > 0, 'CLI state filter returned no annotations');
+      for (const annotation of body.annotations) {
+        assert(
+          annotation.state === 'open' || annotation.state === 'claimed',
+          `CLI state filter let through state=${annotation.state}`
+        );
+      }
+    }
+
+    {
+      const result = await runCli(['list', 'docs/doc.md', '--pretty'], { baseUrl: cliBaseUrl });
+      assert.equal(result.status, 0, `CLI --pretty failed: ${result.stderr}`);
+      assert(result.stdout.length > 0, 'CLI --pretty stdout empty');
+      assert(result.stdout.includes('docs/doc.md'), 'CLI --pretty missing file id');
+      let parsedAsJson = false;
+      try {
+        JSON.parse(result.stdout);
+        parsedAsJson = true;
+      } catch {
+        // expected — pretty output should not be valid JSON
+      }
+      assert.equal(parsedAsJson, false, 'CLI --pretty unexpectedly parsed as JSON');
+    }
+
+    {
+      const result = await runCli(['list', 'other/doc.md'], { baseUrl: scopedBaseUrl });
+      assert.equal(result.status, 4, `CLI no-token call expected exit 4, got ${result.status}: ${result.stderr}`);
+    }
+
+    {
+      const result = await runCli(['list', 'docs/doc.md'], { baseUrl: scopedBaseUrl, token: 'docs-reader-token' });
+      assert.equal(result.status, 0, `CLI scoped token call failed: ${result.stderr}`);
+    }
+  } finally {
+    await stopApp(cliServer);
+    await stopApp(cliScopedServer);
   }
 
   console.log('editable mode validation passed');


### PR DESCRIPTION
## Summary

Phase 1 Chunk D of the Lookie-Link annotations work (FON-11757 umbrella, plan §5). Adds the agent-facing CLI so humans and agents can list / get / add / claim / resolve / reply to annotations from a shell, with parity to `bin/lookie-read.js` (env-token auth, JSON-first stdout, shared exit-code grammar).

Linked Paperclip issue: FON-11765.
Builds on the transport from #67 (FON-11763). Lands in parallel with the viewer UX (#72, FON-11764, already merged).

## What landed

- **`bin/lookie-annotations.js`** — new CLI registered as the `lookie-annotations` bin in `package.json`.
  - Subcommands: `list`, `get`, `add`, `claim`, `resolve`, `replies` (with `--add` for posting a reply).
  - `--state` is repeatable on `list` (e.g. `--state open --state claimed`).
  - Body input accepts `--body STRING`, `--body-file PATH`, or `--body -` (stdin) — long markdown bodies don't need shell escaping.
  - `--pretty` switches to a human-readable form, one annotation per stanza.
  - `--json-errors` mirrors `lookie-read.js`: errors as JSON \`{ error, code }\` on stdout for machine consumers.
  - Exit codes: \`0\` success, \`2\` usage, \`3\` not found, \`4\` forbidden (401/403), \`5\` transport/5xx.
  - Honors \`LOOKIE_LINK_BASE_URL\`, \`LOOKIE_LINK_TOKEN\` (Bearer), \`LOOKIE_LINK_AUTHOR\`.
  - Path arg accepts both \`<repo>/<path>\` and \`~/<repo>/<path>\`.
- **`scripts/validate-editable-mode.js`** — extended to spawn the CLI against a real HTTP listener.
  - Covers every subcommand path, all three body-input forms (\`--body\`, \`--body-file\`, \`--body -\`).
  - Asserts \`--state\` filtering (open + claimed), \`--pretty\` (non-JSON, non-empty stdout).
  - Asserts no-token call against scoped app exits \`4\` (parity with \`lookie-read.js\`).
  - Asserts scoped-token call succeeds (Bearer is forwarded).
  - Switched the spawn helper to async \`spawn\` so the validator's Express listener can serve requests while a child runs.
- **`docs/AGENT-SHIM.md`** — new doc covering both CLI shims (env vars, exit codes, path forms, subcommands, body input modes, examples).
- **`CHANGELOG.md`** — entry under \`2026-06-09 — Unreleased — Annotations CLI Shim (FON-11765)\`.

## Test plan

- [x] \`npm run validate:editable\` — full editable + annotations transport suite plus new CLI invocation suite all pass locally.
- [ ] Reviewer: spot-check \`lookie-annotations --help\` and \`lookie-annotations list <repo>/<path> --pretty\` against a running server.