### PR TITLE
feat: FON-11792 — /raw HTML endpoint for trusted self-contained apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,16 @@ Lookie-Link is a self-hosted Express.js server for browsing and editing local di
 
 - `npm start` — run the server (`node server.js`), default http://localhost:9876
 - `npm run validate:editable` — run the validation test suite (editable mode integration tests)
+- `npm run validate:raw-html` — validate `/raw/<path>.html` serving + `/view` sanitisation invariants (FON-11792)
 - `npm install` — install dependencies (no build step needed)
 
-There is no linter, formatter, or unit test framework. The only test suite is `scripts/validate-editable-mode.js`.
+There is no linter, formatter, or unit test framework. The test suites are `scripts/validate-editable-mode.js` and `scripts/validate-raw-html.js`.
 
 ## Architecture
 
 Three core modules plus a client-side script:
 
-- **`server.js`** — Express app setup, all route handlers (`/`, `/healthz`, `/view/*`, `/edit/*`, `/api/save/*`, `/api/preview/*`, `/asset/*`), binary detection, path safety via `safeResolve()`. Loads custom themes at startup and passes `customThemeCss` to all render functions.
+- **`server.js`** — Express app setup, all route handlers (`/`, `/healthz`, `/view/*`, `/edit/*`, `/api/save/*`, `/api/preview/*`, `/asset/*`, `/raw/*`), binary detection, path safety via `safeResolve()`. Loads custom themes at startup and passes `customThemeCss` to all render functions.
 - **`lib/config.js`** — Config loading with priority: env vars > user YAML (`~/.config/lookie-link/lookie-link.yaml`) > project YAML > defaults. Key settings: PORT, HOSTNAME, ROOT_MAPPINGS, LOOKIE_LINK_ENABLE_EDITING. Also handles custom theme loading from YAML config (`loadCustomThemes()`, `generateCustomThemeCss()`).
 - **`lib/renderer.js`** — Rendering pipeline: markdown-it for markdown, sanitized inline HTML documents for `.html`/`.htm`, highlight.js for code/YAML. Post-processing chain in `postProcessHtml()`: cross-link rewriting → tilde link rewriting → image source rewriting → heading anchors → YAML anchors → DOMPurify sanitization (always last). Shared `toolbarHtml()` and `themeScript()` provide the toolbar and theme switching JS on every page type. Image lightbox is injected via `baseHtml()`.
 - **`lib/path-utils.js`** — Path resolution, URL-safe escaping, breadcrumb building.
@@ -36,3 +37,4 @@ Three core modules plus a client-side script:
 - **Theme system:** Dark mode uses absence of `data-theme` attribute; light mode sets `data-theme="light"`. Color schemes use `data-color-scheme` attribute. Theme cycling button (not a `<select>`) avoids browser dropdown interaction issues. Custom themes from YAML config are injected as inline CSS and added to the cycle list via `setThemeList()`.
 - **Toolbar is shared:** `toolbarHtml()` and `themeScript()` in renderer.js are used by all page types (directory, document, image, edit). Page-specific buttons (TOC, Raw, Edit) are passed as `extraButtons`.
 - **Image lightbox:** Clicking any `.content img` opens a full-screen overlay box with close button. Handled in `baseHtml()` so it works on all pages.
+- **Raw HTML mode (opt-in, off by default):** `/raw/<repo>/<path>.html` serves the file body verbatim with `text/html` — no DOMPurify, no viewer chrome — so self-contained interactive HTML artifacts (e.g. NotebookLM flashcards/quiz) actually run. Enabled via `LOOKIE_LINK_ENABLE_RAW_HTML=true` or `server.enableRawHtml: true` in YAML. **Trust assumption:** every file under the configured roots must be authored or vetted by you — a raw file runs on the same origin as `/api/save` and `/api/grants`, so do not flip this on for instances exposed to untrusted content. The existing `/view/<path>.html` route continues to sanitize + wrap regardless of this flag. When enabled, `/view` pages for `.html`/`.htm` files get an "Open raw" toolbar button linking to `/raw/`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -337,12 +337,57 @@ function getAnnotationsEnabled() {
   return false;
 }
 
+// Raw HTML serving (FON-11792).
+//
+// TRUST ASSUMPTION
+// ----------------
+// When enabled, the /raw/<repo>/<path>.html endpoint returns the file body
+// verbatim with `text/html` content type — no DOMPurify sanitization, no
+// viewer chrome. Inline <script> tags execute. This is required for
+// self-contained interactive HTML artifacts (e.g. NotebookLM flashcards/quiz)
+// to function in the browser.
+//
+// Enable this ONLY for instances on trusted private networks (Tailscale,
+// home LAN, etc.) where:
+//   1. Every file under the configured roots is authored by you or by tools
+//      you trust (NotebookLM exports, your own notes, etc.).
+//   2. There is no untrusted upload path that can land arbitrary HTML in a
+//      mapped repo.
+//
+// Same-origin caveat: a raw HTML file at /raw/<repo>/foo.html runs on the
+// same origin as the rest of Lookie-Link. A malicious file could call the
+// /api/save or /api/grants endpoints with the current viewer's token. Keep
+// the default off, and only flip it on when the above conditions hold.
+//
+// Existing /view/<repo>/foo.html continues to sanitize + wrap regardless of
+// this flag — the safer-by-default path is unchanged.
+function getRawHtmlEnabled() {
+  const rawEnv = process.env.LOOKIE_LINK_ENABLE_RAW_HTML;
+  if (typeof rawEnv === 'string') {
+    const parsedEnv = parseBoolean(rawEnv);
+    if (parsedEnv !== null) {
+      return parsedEnv;
+    }
+  }
+
+  const config = getConfig();
+  if (config.server && Object.prototype.hasOwnProperty.call(config.server, 'enableRawHtml')) {
+    const parsedConfig = parseBoolean(config.server.enableRawHtml);
+    if (parsedConfig !== null) {
+      return parsedConfig;
+    }
+  }
+
+  return false;
+}
+
 module.exports = {
   loadRootMappings,
   getPort,
   getHostname,
   getEditingEnabled,
   getAnnotationsEnabled,
+  getRawHtmlEnabled,
   getAccessConfig,
   loadCustomThemes,
   generateCustomThemeCss,

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -104,6 +104,16 @@ function buildPreviewHref(repo, relativePath) {
   return `/api/preview/${repoPart}/${rel.split('/').map(encodePathSegment).join('/')}`;
 }
 
+function buildRawHref(repo, relativePath) {
+  const repoPart = encodePathSegment(repo);
+  const rel = toPosixPath(relativePath);
+  if (!rel) {
+    return `/raw/${repoPart}`;
+  }
+
+  return `/raw/${repoPart}/${rel.split('/').map(encodePathSegment).join('/')}`;
+}
+
 function escapeHtml(value) {
   return String(value)
     .replace(/&/g, '&amp;')
@@ -184,6 +194,7 @@ module.exports = {
   buildEditHref,
   buildSaveHref,
   buildPreviewHref,
+  buildRawHref,
   escapeHtml,
   formatFileSize,
   formatMTime,

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -911,7 +911,7 @@ function renderDirectoryPage({ title, repo, currentPath, parentHref, entries, no
   return baseHtml({ title, body, customThemeCss });
 }
 
-function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, mtime, size, editHref = null, customThemeCss, queryToken = null, annotationsEnabled = false }) {
+function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, mtime, size, editHref = null, rawHtmlHref = null, customThemeCss, queryToken = null, annotationsEnabled = false }) {
   const extension = path.extname(relativePath).toLowerCase();
   const isMarkdown = MARKDOWN_EXTENSIONS.has(extension);
   const isHtmlDocument = HTML_EXTENSIONS.has(extension);
@@ -943,6 +943,7 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
   const extraButtons = [
     hasToc ? '<button type="button" class="toolbar-btn" data-toc-toggle aria-label="Toggle table of contents" aria-expanded="false" aria-controls="toc-view">☰</button>' : '',
     supportsRawToggle ? '<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle raw and rendered views">Raw</button>' : '',
+    rawHtmlHref ? `<a class="toolbar-btn" href="${escapeHtml(rawHtmlHref)}" target="_blank" rel="noopener" aria-label="Open raw HTML in new tab">Open raw</a>` : '',
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
   ].filter(Boolean).join('\n    ');
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "node --test",
     "start": "node server.js",
-    "validate:editable": "node scripts/validate-editable-mode.js"
+    "validate:editable": "node scripts/validate-editable-mode.js",
+    "validate:raw-html": "node scripts/validate-raw-html.js"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/validate-raw-html.js
+++ b/scripts/validate-raw-html.js
@@ -1,0 +1,145 @@
+'use strict';
+
+// Validates FON-11792 — raw HTML serving.
+//
+// Verifies:
+//   * /raw/<path>.html is 404 when disabled
+//   * /raw/<path>.html serves the file verbatim with text/html when enabled
+//   * /raw/<path>.txt returns 415 (only .html/.htm allowed)
+//   * /view/<path>.html still wraps + sanitises (no inline <script> survives)
+//   * /view exposes an "Open raw" toolbar link only when raw HTML is enabled
+//
+// Runs the real `createApp` against a tmp repo so the route/middleware wiring
+// is exercised end to end.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createApp } = require('../server');
+
+function fetchText(server, urlPath) {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address();
+    const req = http.request(
+      { host: '127.0.0.1', port, path: urlPath, method: 'GET' },
+      (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode,
+            contentType: res.headers['content-type'] || '',
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function listen(app) {
+  return new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+const FLASHCARDS_HTML = [
+  '<!doctype html>',
+  '<html><head><title>Flashcards</title></head>',
+  '<body>',
+  '  <div id="root"></div>',
+  '  <script>document.getElementById("root").textContent = "flipped";</script>',
+  '</body></html>',
+].join('\n');
+
+async function run() {
+  const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-raw-html-validate-'));
+
+  try {
+    await fs.writeFile(path.join(repoDir, 'flashcards.html'), FLASHCARDS_HTML, 'utf8');
+    await fs.writeFile(path.join(repoDir, 'notes.md'), '# Notes\n', 'utf8');
+
+    const appDisabled = createApp({ mappings: { docs: repoDir }, rawHtmlEnabled: false });
+    const appEnabled = createApp({ mappings: { docs: repoDir }, rawHtmlEnabled: true });
+
+    const disabledServer = await listen(appDisabled);
+    const enabledServer = await listen(appEnabled);
+
+    try {
+      // 1. Disabled instance: /raw/* returns 404.
+      const disabledResp = await fetchText(disabledServer, '/raw/docs/flashcards.html');
+      assert.equal(disabledResp.status, 404, '/raw/* should 404 when disabled');
+      assert.match(disabledResp.body, /disabled/i, 'disabled body should say disabled');
+
+      // 2. Enabled instance: /raw/<.html> serves verbatim text/html.
+      const enabledResp = await fetchText(enabledServer, '/raw/docs/flashcards.html');
+      assert.equal(enabledResp.status, 200, '/raw/<.html> should 200 when enabled');
+      assert.match(enabledResp.contentType, /^text\/html/, 'content-type should be text/html');
+      assert.equal(enabledResp.body, FLASHCARDS_HTML, 'raw body should equal file bytes verbatim');
+      assert.match(enabledResp.body, /<script>document.getElementById/, 'inline <script> must survive raw mode');
+
+      // 3. Enabled instance: /raw rejects non-html extensions.
+      const notMdResp = await fetchText(enabledServer, '/raw/docs/notes.md');
+      assert.equal(notMdResp.status, 415, '/raw rejects non-html extensions with 415');
+
+      // 4. Enabled instance: unknown repo returns 404.
+      const unknownResp = await fetchText(enabledServer, '/raw/missing/flashcards.html');
+      assert.equal(unknownResp.status, 404, 'unknown repo returns 404');
+
+      // 5. Enabled instance: directory traversal blocked.
+      const traversalResp = await fetchText(enabledServer, '/raw/docs/../../../etc/passwd');
+      assert.notEqual(traversalResp.status, 200, 'directory traversal must not return 200');
+
+      // 6. /view/<.html> still wraps + sanitises on both disabled and enabled.
+      const viewDisabled = await fetchText(disabledServer, '/view/docs/flashcards.html');
+      assert.equal(viewDisabled.status, 200);
+      assert.match(viewDisabled.contentType, /^text\/html/);
+      assert.match(viewDisabled.body, /<title>docs\/flashcards\.html<\/title>/, '/view wraps with viewer title');
+      assert.doesNotMatch(
+        viewDisabled.body,
+        /<script>document\.getElementById\("root"\)\.textContent = "flipped";<\/script>/,
+        '/view must strip inline <script> from rendered output'
+      );
+
+      const viewEnabled = await fetchText(enabledServer, '/view/docs/flashcards.html');
+      assert.equal(viewEnabled.status, 200);
+      assert.doesNotMatch(
+        viewEnabled.body,
+        /<script>document\.getElementById\("root"\)\.textContent = "flipped";<\/script>/,
+        '/view must strip inline <script> even when raw mode is enabled'
+      );
+
+      // 7. "Open raw" toolbar appears only when raw HTML is enabled.
+      assert.doesNotMatch(viewDisabled.body, /Open raw/, 'disabled /view should not advertise raw mode');
+      assert.match(viewEnabled.body, /Open raw/, 'enabled /view should advertise raw mode');
+      assert.match(viewEnabled.body, /href="\/raw\/docs\/flashcards\.html"/, 'Open raw button should link to /raw/');
+
+      // 8. healthz reflects rawHtmlEnabled.
+      const healthDisabled = JSON.parse((await fetchText(disabledServer, '/healthz')).body);
+      const healthEnabled = JSON.parse((await fetchText(enabledServer, '/healthz')).body);
+      assert.equal(healthDisabled.rawHtmlEnabled, false);
+      assert.equal(healthEnabled.rawHtmlEnabled, true);
+
+      console.log('OK — /raw HTML serving validates against FON-11792 acceptance criteria.');
+    } finally {
+      await close(disabledServer);
+      await close(enabledServer);
+    }
+  } finally {
+    await fs.rm(repoDir, { recursive: true, force: true });
+  }
+}
+
+run().catch((error) => {
+  console.error('FAIL', error);
+  process.exit(1);
+});

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const {
   getHostname,
   getEditingEnabled,
   getAnnotationsEnabled,
+  getRawHtmlEnabled,
   getAccessConfig,
   loadCustomThemes,
   generateCustomThemeCss,
@@ -35,6 +36,7 @@ const {
   buildEditHref,
   buildSaveHref,
   buildPreviewHref,
+  buildRawHref,
   formatFileSize,
   formatMTime,
   compareEntries,
@@ -85,6 +87,8 @@ const PDF_MIME_TYPES = {
 
 const CSV_EXTENSIONS = new Set(['.csv']);
 const JSON_VIEWER_EXTENSIONS = new Set(['.json']);
+const HTML_EXTENSIONS = new Set(['.html', '.htm']);
+const RAW_HTML_MIME_TYPE = 'text/html; charset=utf-8';
 
 // Text/source asset mime allowlist. Served as raw bytes via /asset/ so agents
 // (and curl) can fetch markdown, code, and config sources without scraping HTML.
@@ -272,6 +276,7 @@ function createApp(options = {}) {
   const mappings = options.mappings || loadRootMappings();
   const editingEnabled = options.editingEnabled === undefined ? getEditingEnabled() : Boolean(options.editingEnabled);
   const annotationsEnabled = options.annotationsEnabled === undefined ? getAnnotationsEnabled() : Boolean(options.annotationsEnabled);
+  const rawHtmlEnabled = options.rawHtmlEnabled === undefined ? getRawHtmlEnabled() : Boolean(options.rawHtmlEnabled);
   const customThemeCss = options.customThemeCss || '';
   const rawAccessConfig = options.accessConfig === undefined ? getAccessConfig() : options.accessConfig;
   const accessConfig = parseAccessConfig(rawAccessConfig);
@@ -443,7 +448,7 @@ function createApp(options = {}) {
   });
 
   app.get('/healthz', (_req, res) => {
-    res.status(200).json({ status: 'ok', editingEnabled, annotationsEnabled });
+    res.status(200).json({ status: 'ok', editingEnabled, annotationsEnabled, rawHtmlEnabled });
   });
 
   app.get('/api/repos', (req, res) => {
@@ -698,6 +703,7 @@ function createApp(options = {}) {
 
     const source = sourceBuffer.toString('utf8');
     const parentRel = parentPath(relativePath);
+    const isHtmlFile = HTML_EXTENSIONS.has(extension);
     const html = renderDocumentPage({
       repo,
       repoRoot: rootPath,
@@ -708,6 +714,9 @@ function createApp(options = {}) {
       size: formatFileSize(stat.size),
       editHref: editingEnabled && canAccessPath(accessContext, 'edit', repo, relativePath, 'file')
         ? appendAccessToken(buildEditHref(repo, relativePath), accessContext)
+        : null,
+      rawHtmlHref: rawHtmlEnabled && isHtmlFile
+        ? appendAccessToken(buildRawHref(repo, relativePath), accessContext)
         : null,
       customThemeCss,
       queryToken: accessContext.queryToken,
@@ -1350,6 +1359,92 @@ function createApp(options = {}) {
     });
   });
 
+  // Serve trusted HTML files verbatim (FON-11792). See lib/config.js
+  // `getRawHtmlEnabled` for the trust assumption — only HTML extensions, only
+  // when enabled, only inside the configured roots. Inline <script> tags
+  // execute because we do not run them through DOMPurify on this path.
+  app.get('/raw/:repo/*', async (req, res) => {
+    if (!rawHtmlEnabled) {
+      res.status(404).type('text/plain').send('Raw HTML serving is disabled.');
+      return;
+    }
+
+    const accessContext = resolveAccessContext(req);
+    const repo = req.params.repo;
+    const relativePath = req.params[0] || '';
+    const rootPath = mappings[repo];
+
+    if (!rootPath) {
+      res.status(404).type('text/plain').send(`Unknown repository: ${repo}`);
+      return;
+    }
+
+    if (!relativePath) {
+      res.status(400).type('text/plain').send('Raw serving requires a file path.');
+      return;
+    }
+
+    const extension = path.extname(relativePath).toLowerCase();
+    if (!HTML_EXTENSIONS.has(extension)) {
+      res.status(415).type('text/plain').send('Raw mode only supports .html and .htm files.');
+      return;
+    }
+
+    if (!canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+      res.status(403).type('text/plain').send('Access denied.');
+      return;
+    }
+
+    let resolved;
+    try {
+      resolved = await safeResolve(rootPath, relativePath);
+    } catch (error) {
+      if (error && error.code === 'EACCES') {
+        res.status(403).type('text/plain').send('Invalid path.');
+        return;
+      }
+
+      if (error && error.code === 'ENOENT') {
+        res.status(404).type('text/plain').send('File not found.');
+        return;
+      }
+
+      console.error('Failed to resolve raw path', { rootPath, relativePath, error });
+      res.status(500).type('text/plain').send('Failed to resolve raw path.');
+      return;
+    }
+
+    let stat;
+    try {
+      stat = await fs.stat(resolved);
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        res.status(404).type('text/plain').send('File not found.');
+        return;
+      }
+
+      console.error('Failed to stat raw path', { resolved, error });
+      res.status(500).type('text/plain').send('Failed to read file metadata.');
+      return;
+    }
+
+    if (!stat.isFile()) {
+      res.status(404).type('text/plain').send('File not found.');
+      return;
+    }
+
+    res.type(RAW_HTML_MIME_TYPE).sendFile(resolved, (error) => {
+      if (!error) {
+        return;
+      }
+
+      console.error('Failed to serve raw HTML', { resolved, error });
+      if (!res.headersSent) {
+        res.status(500).type('text/plain').send('Failed to read file.');
+      }
+    });
+  });
+
   app.get('/view', (req, res) => {
     res.redirect(302, appendAccessToken('/', resolveAccessContext(req)));
   });
@@ -1372,6 +1467,7 @@ function startServer() {
   const mappings = loadRootMappings();
   const editingEnabled = getEditingEnabled();
   const annotationsEnabled = getAnnotationsEnabled();
+  const rawHtmlEnabled = getRawHtmlEnabled();
   const accessConfig = getAccessConfig();
 
   const customThemes = loadCustomThemes();
@@ -1384,12 +1480,13 @@ function startServer() {
   const allThemes = [...builtInThemes, ...customThemes.map((t) => ({ slug: t.slug, label: t.label }))];
   setThemeList(allThemes);
 
-  const app = createApp({ mappings, editingEnabled, annotationsEnabled, customThemeCss, accessConfig });
+  const app = createApp({ mappings, editingEnabled, annotationsEnabled, rawHtmlEnabled, customThemeCss, accessConfig });
 
   app.listen(port, '0.0.0.0', () => {
     console.log(`Lookie Link listening on http://${hostname}:${port}`);
     console.log(`Editing mode: ${editingEnabled ? 'enabled' : 'disabled'}`);
     console.log(`Annotations: ${annotationsEnabled ? 'enabled' : 'disabled'}`);
+    console.log(`Raw HTML serving: ${rawHtmlEnabled ? 'enabled' : 'disabled'}`);
     if (customThemes.length > 0) {
       console.log(`Custom themes: ${customThemes.map((t) => t.label).join(', ')}`);
     }


### PR DESCRIPTION
## Summary

- New opt-in `/raw/<repo>/<path>.html` endpoint serves HTML files verbatim with `text/html` — no DOMPurify, no viewer chrome — so self-contained interactive artifacts (e.g. NotebookLM flashcards/quiz) actually run.
- Toggle via `LOOKIE_LINK_ENABLE_RAW_HTML=true` or `server.enableRawHtml: true` in YAML. Defaults to **off**.
- Existing `/view/<path>.html` continues to wrap + DOMPurify-sanitise; behaviour unchanged.
- When raw mode is enabled, `/view/*.html` pages surface an **Open raw** toolbar button linking to `/raw/`, so the trusted route is discoverable.
- Trust statement added inline in `lib/config.js` and to `CLAUDE.md`. Same-origin caveat called out explicitly.

## Why opt-in

A raw HTML file under `/raw/` runs on the same origin as `/api/save` and `/api/grants`. The trust model is: only flip it on when every file under the configured roots is authored or vetted (no untrusted upload path). That's true for the private-network deploy where this issue surfaced (NotebookLM exports + Tailscale), but should not be the default.

## Validation

`scripts/validate-raw-html.js` (`npm run validate:raw-html`) exercises the route end-to-end against a tmp repo:

- /raw returns 404 with the disabled flag
- /raw returns 200 `text/html` with the file body byte-for-byte and inline `<script>` preserved when enabled
- /raw returns 415 for non-`.html` extensions
- /raw returns 404 for unknown repos
- directory traversal blocked (no 200)
- /view continues to strip inline `<script>` regardless of flag
- "Open raw" button appears only with the flag
- `/healthz` exposes `rawHtmlEnabled`

Live-tested against the real fixtures from FON-11745:

- `/raw/operations-research/.../artifacts/flashcards.html` → 200, `text/html`, 1.16 MB verbatim, 2 inline `<script>` tags intact
- `/raw/operations-research/.../artifacts/quiz.html` → 200, `text/html`, 1.23 MB verbatim
- `/view/.../flashcards.html` → still wraps with viewer chrome (1.23 MB output, scripts stripped)

`npm run validate:editable` still passes — no regression on the editable mode tests.

## Test plan

- [ ] Pull branch, `LOOKIE_LINK_ENABLE_RAW_HTML=true npm start`
- [ ] Hit `/view/operations-research/infrastructure/remote-access/rustdesk/api-control/artifacts/flashcards.html` — see new "Open raw" button in toolbar
- [ ] Click "Open raw" → flashcards UI loads and cards flip on click
- [ ] Same for `quiz.html` — multiple-choice interaction works
- [ ] Hit `/view/<...>.html` without the flag — no "Open raw" button, sanitised render as before
- [ ] `npm run validate:raw-html` passes locally

## Next

Once merged + deployed, FON-11745 can restore `flashcards.html`/`quiz.html` as primary LookyLinks in `api-control/README.md`.