### PR TITLE
feat: FON-11756 — Raw/Pretty labels + default to raw + .yaml.example

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -9,6 +9,17 @@ const { JSDOM } = require('jsdom');
 
 const { escapeHtml } = require('./path-utils');
 
+const SECONDARY_VIEW_EXTENSIONS = new Set(['.example', '.tmpl', '.template', '.dist', '.sample']);
+function effectiveViewExtension(relativePath) {
+  const ext = path.extname(relativePath).toLowerCase();
+  if (!SECONDARY_VIEW_EXTENSIONS.has(ext)) {
+    return ext;
+  }
+  const stripped = relativePath.slice(0, -ext.length);
+  return path.extname(stripped).toLowerCase() || ext;
+}
+
+
 const markdown = new MarkdownIt({
   html: true,
   linkify: true,
@@ -912,7 +923,7 @@ function renderDirectoryPage({ title, repo, currentPath, parentHref, entries, no
 }
 
 function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, mtime, size, editHref = null, rawHtmlHref = null, customThemeCss, queryToken = null, annotationsEnabled = false }) {
-  const extension = path.extname(relativePath).toLowerCase();
+  const extension = effectiveViewExtension(relativePath);
   const isMarkdown = MARKDOWN_EXTENSIONS.has(extension);
   const isHtmlDocument = HTML_EXTENSIONS.has(extension);
   const isYaml = ['.yaml', '.yml'].includes(extension);
@@ -933,16 +944,16 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
       <h2 class="toc-view-title">Contents</h2>
       <nav class="toc-list" data-toc-list aria-label="Table of contents"></nav>
     </article>` : ''}
-    <article class="content ${renderedClass}" data-rendered-view>
+    <article class="content ${renderedClass}" data-rendered-view${isYaml ? ' hidden aria-hidden="true"' : ''}>
       ${rendered.html}
     </article>
-    ${supportsRawToggle ? `<article class="content raw" data-raw-view hidden aria-hidden="true">
+    ${supportsRawToggle ? `<article class="content raw" data-raw-view${isYaml ? '' : ' hidden aria-hidden="true"'}>
       <pre><code class="hljs language-${escapeHtml(rawLanguage)}" data-raw-code></code></pre>
     </article>` : ''}`;
 
   const extraButtons = [
     hasToc ? '<button type="button" class="toolbar-btn" data-toc-toggle aria-label="Toggle table of contents" aria-expanded="false" aria-controls="toc-view">☰</button>' : '',
-    supportsRawToggle ? '<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle raw and rendered views">Raw</button>' : '',
+    supportsRawToggle ? `<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle raw and rendered views" data-pretty-label="${isYaml ? 'Pretty' : 'Rendered'}">${isYaml ? 'Pretty' : 'Raw'}</button>` : '',
     rawHtmlHref ? `<a class="toolbar-btn" href="${escapeHtml(rawHtmlHref)}" target="_blank" rel="noopener" aria-label="Open raw HTML in new tab">Open raw</a>` : '',
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
   ].filter(Boolean).join('\n    ');
@@ -1026,7 +1037,8 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
         if (!rawToggleBtn || !rawView) {
           return;
         }
-        rawToggleBtn.textContent = currentBaseView === 'raw' ? 'Rendered' : 'Raw';
+        var prettyLabel = (rawToggleBtn && rawToggleBtn.dataset && rawToggleBtn.dataset.prettyLabel) || 'Rendered';
+        rawToggleBtn.textContent = currentBaseView === 'raw' ? prettyLabel : 'Raw';
       }
 
       function applyBaseView() {
@@ -1546,14 +1558,14 @@ function structuredToggleScript() {
           rawCode.textContent = '';
         }
       }
-      var current = 'structured';
+      var current = 'raw';
       function applyView() {
         var isStructured = current === 'structured';
         renderedView.hidden = !isStructured;
         renderedView.setAttribute('aria-hidden', isStructured ? 'false' : 'true');
         rawView.hidden = isStructured;
         rawView.setAttribute('aria-hidden', isStructured ? 'true' : 'false');
-        rawToggleBtn.textContent = isStructured ? 'Raw' : 'Structured';
+        rawToggleBtn.textContent = isStructured ? 'Raw' : 'Pretty';
         rawToggleBtn.setAttribute('aria-pressed', isStructured ? 'false' : 'true');
       }
       rawToggleBtn.addEventListener('click', function () {
@@ -1604,7 +1616,7 @@ function renderCsvPage({ repo, relativePath, source, parentHref, rawHref, mtime,
     : `csv · ${dataRows.length} ${rowLabel} × ${colCount} ${colLabel}`;
 
   const extraButtons = [
-    '<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle structured and raw views" aria-pressed="false">Raw</button>',
+    '<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle pretty and raw views" aria-pressed="true">Pretty</button>',
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
   ].filter(Boolean).join('\n    ');
 
@@ -1619,10 +1631,10 @@ function renderCsvPage({ repo, relativePath, source, parentHref, rawHref, mtime,
       <p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>
     </header>
 
-    <article class="content csv-view" data-rendered-view>
+    <article class="content csv-view" data-rendered-view hidden aria-hidden="true">
       ${tableHtml}
     </article>
-    <article class="content raw" data-raw-view hidden aria-hidden="true">
+    <article class="content raw" data-raw-view>
       <pre><code class="hljs language-csv" data-raw-code></code></pre>
     </article>
   </main>
@@ -1703,7 +1715,7 @@ function renderJsonPage({ repo, relativePath, source, parentHref, rawHref, mtime
   }
 
   const extraButtons = [
-    '<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle structured and raw views" aria-pressed="false">Raw</button>',
+    '<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle pretty and raw views" aria-pressed="true">Pretty</button>',
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
   ].filter(Boolean).join('\n    ');
 
@@ -1718,10 +1730,10 @@ function renderJsonPage({ repo, relativePath, source, parentHref, rawHref, mtime
       <p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>
     </header>
 
-    <article class="content json-view" data-rendered-view>
+    <article class="content json-view" data-rendered-view hidden aria-hidden="true">
       ${treeHtml}
     </article>
-    <article class="content raw" data-raw-view hidden aria-hidden="true">
+    <article class="content raw" data-raw-view>
       <pre><code class="hljs language-json" data-raw-code></code></pre>
     </article>
   </main>

--- a/server.js
+++ b/server.js
@@ -85,6 +85,17 @@ const PDF_MIME_TYPES = {
   '.pdf': 'application/pdf',
 };
 
+
+const SECONDARY_VIEW_EXTENSIONS = new Set(['.example', '.tmpl', '.template', '.dist', '.sample']);
+function effectiveViewExtension(relativePath) {
+  const ext = path.extname(relativePath).toLowerCase();
+  if (!SECONDARY_VIEW_EXTENSIONS.has(ext)) {
+    return ext;
+  }
+  const stripped = relativePath.slice(0, -ext.length);
+  return path.extname(stripped).toLowerCase() || ext;
+}
+
 const CSV_EXTENSIONS = new Set(['.csv']);
 const JSON_VIEWER_EXTENSIONS = new Set(['.json']);
 const HTML_EXTENSIONS = new Set(['.html', '.htm']);
@@ -569,7 +580,7 @@ function createApp(options = {}) {
       return;
     }
 
-    const extension = path.extname(relativePath).toLowerCase();
+    const extension = effectiveViewExtension(relativePath);
     if (IMAGE_EXTENSIONS.has(extension)) {
       const parentRel = parentPath(relativePath);
       const html = renderImagePage({


### PR DESCRIPTION
## Summary

Implements the three follow-up decisions from the FON-11756 review thread:

1. **Default to Raw** on all three viewers (CSV, JSON, YAML).
2. **Labels: Raw / Pretty.** Replaces "Structured" everywhere on the new viewers; matches devtools/jq nomenclature.
3. **`.yaml.example` / `.yml.example` (and `.json.example`, etc.)** now route through the correct viewer.

Markdown's existing toggle is unchanged — still defaults to rendered, button still says "Raw" / "Rendered" since "rendered markdown" is the natural term there.

## Implementation

- `lib/renderer.js`:
  - `structuredToggleScript()` now starts with `current = 'raw'` and labels flip between `Raw` and `Pretty`.
  - `renderCsvPage` / `renderJsonPage` swap initial hidden states so raw is visible on load (no flash from JS having to flip after paint).
  - `renderDocumentPage` reads a new `data-pretty-label` data-attribute on the Raw button — set to `Pretty` for YAML, `Rendered` for markdown — so the existing markdown toggle and the new YAML toggle can share the same JS while showing per-type labels.
  - New `effectiveViewExtension(relativePath)` helper strips a secondary extension (`.example`, `.tmpl`, `.template`, `.dist`, `.sample`) and re-checks. `lookie-link.yaml.example` → `.yaml`.
- `server.js`:
  - Same `effectiveViewExtension` helper for the `/view/` extension routing. `.json.example` now reaches `renderJsonPage`, etc.

## Test plan

- [x] CSV: `renderCsvPage` produces `data-rendered-view hidden` + visible `data-raw-view` + button text `Pretty` + script defaults to raw.
- [x] JSON: same.
- [x] YAML via `renderDocumentPage`: defaults to raw; button text `Pretty`; `data-pretty-label="Pretty"` set on button.
- [x] Markdown via `renderDocumentPage`: still defaults to rendered; button text `Raw`; `data-pretty-label="Rendered"`.
- [x] `.yaml.example` via `renderDocumentPage`: routes through YAML (language-yaml raw block + Pretty button).
- [ ] After deploy: open `lookie-link.yaml.example` and confirm the YAML viewer kicks in (Raw default, Pretty button toggles to highlighted+anchored YAML).
- [ ] After deploy: open `/view/operations-research/.../notebooklm-data-table.csv` and `/view/operations-research/.../notebooklm-flashcards.json` and confirm both default to raw with a Pretty button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)