### PR TITLE
test: add /asset CSV MIME regression coverage

### DIFF
--- a/test/asset-mime.test.js
+++ b/test/asset-mime.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { Duplex } = require('node:stream');
+const fs = require('node:fs/promises');
+
+const { createApp } = require('../server');
+
+async function makeFixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-link-asset-mime-'));
+  const repoRoot = path.join(root, 'demo');
+  await fs.mkdir(repoRoot, { recursive: true });
+
+  await fs.writeFile(path.join(repoRoot, 'table.csv'), 'col_a,col_b\n1,2\n3,4\n');
+  await fs.writeFile(path.join(repoRoot, 'data.json'), '{"ok":true}\n');
+  await fs.writeFile(path.join(repoRoot, 'README.md'), '# Demo\n');
+  await fs.writeFile(path.join(repoRoot, 'blocked.exe'), 'not really executable\n');
+
+  return {
+    root,
+    mappings: { demo: repoRoot },
+  };
+}
+
+async function requestApp(app, targetPath) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    const socket = new Duplex({
+      read() {},
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    });
+
+    socket.on('error', reject);
+
+    const req = new http.IncomingMessage(socket);
+    req.method = 'GET';
+    req.url = targetPath;
+    req.headers = { host: 'localhost' };
+
+    const res = new http.ServerResponse(req);
+    res.assignSocket(socket);
+    res.on('finish', () => {
+      const response = Buffer.concat(chunks);
+      const headerEnd = response.indexOf('\r\n\r\n');
+      resolve({
+        status: res.statusCode,
+        headers: res.getHeaders(),
+        body: response.subarray(headerEnd + 4).toString('utf8'),
+      });
+    });
+
+    app(req, res);
+  });
+}
+
+test('GET /asset serves CSV with text/csv MIME', async (t) => {
+  const fixture = await makeFixture();
+  t.after(() => fs.rm(fixture.root, { recursive: true, force: true }));
+  const app = createApp({ mappings: fixture.mappings, editingEnabled: false, accessConfig: {} });
+
+  const response = await requestApp(app, '/asset/demo/table.csv');
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers['content-type'] || '', /^text\/csv/);
+  assert.match(response.body, /col_a,col_b/);
+});
+
+test('GET /asset still serves JSON and markdown as expected', async (t) => {
+  const fixture = await makeFixture();
+  t.after(() => fs.rm(fixture.root, { recursive: true, force: true }));
+  const app = createApp({ mappings: fixture.mappings, editingEnabled: false, accessConfig: {} });
+
+  const jsonResponse = await requestApp(app, '/asset/demo/data.json');
+  assert.equal(jsonResponse.status, 200);
+  assert.match(jsonResponse.headers['content-type'] || '', /^application\/json/);
+
+  const markdownResponse = await requestApp(app, '/asset/demo/README.md');
+  assert.equal(markdownResponse.status, 200);
+  assert.match(markdownResponse.headers['content-type'] || '', /^text\/markdown/);
+});
+
+test('GET /asset refuses a disallowed extension', async (t) => {
+  const fixture = await makeFixture();
+  t.after(() => fs.rm(fixture.root, { recursive: true, force: true }));
+  const app = createApp({ mappings: fixture.mappings, editingEnabled: false, accessConfig: {} });
+
+  const response = await requestApp(app, '/asset/demo/blocked.exe');
+
+  assert.equal(response.status, 415);
+  assert.equal(response.body, 'Unsupported asset type.');
+});


### PR DESCRIPTION
Part of #91 (reconciliation Step 3 — preserves the only unpushed commits, `b460e5e` + `5d92957` on `fix/csv-asset-mime-allowlist`).

Main already serves `.csv` via `/asset` (`TEXT_MIME_TYPES`) and the dedicated viewer — but had zero regression coverage. This transplants and adapts the preserved `test/asset-mime.test.js` as a test-only change: CSV served with `text/csv; charset=utf-8`, plus negative cases (disallowed extension refused).

Disposition of the preserved commits: `b460e5e`'s fix is already on main (test transplanted here); `5d92957`'s docs cross-link points at an external research doc and is intentionally not ported (recorded in the #91 evidence). The stale local branch is deleted only after this merges and archives re-verify, per the reconciliation plan.

Verification: 15/15 tests pass (12 baseline + 3 new) on this branch. Based on the #140 sanitization tip per the plan's descent requirement — will retarget to main automatically when #140 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)