### PR TITLE
feat: port portable link resolution (server-side, no path disclosure)

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -357,9 +357,44 @@ function encodeViewPath(repo, relativePath) {
   return `/view/${encodeURIComponent(repo)}${pathPart}`;
 }
 
+function buildRepoResolutionEntries(context = {}) {
+  const mappings = {
+    ...(context.repoMappings || {}),
+  };
+  if (context.repo && context.repoRoot && !mappings[context.repo]) {
+    mappings[context.repo] = context.repoRoot;
+  }
+
+  return Object.entries(mappings)
+    .filter(([repo, rootPath]) => repo && typeof rootPath === 'string' && rootPath)
+    .map(([repo, rootPath]) => ({ repo, rootPath: path.resolve(rootPath) }))
+    .sort((left, right) => right.rootPath.length - left.rootPath.length);
+}
+
+function redactHostPathsForBrowser(source, context = {}) {
+  let output = String(source || '');
+  for (const { repo, rootPath } of buildRepoResolutionEntries(context)) {
+    output = output.split(rootPath).join(encodeViewPath(repo, ''));
+  }
+
+  const homePath = path.resolve(context.homePath || os.homedir());
+  output = output.split(homePath).join('$HOME');
+  return output.replace(
+    /(^|[\s("'=])\/(?:home|Users)\/[^\s)"'<]+/gm,
+    '$1[host-path]'
+  );
+}
+
+function canResolveTarget(context, repo, relativePath, isDirectory = false) {
+  return typeof context.canResolveLink !== 'function' || context.canResolveLink(repo, relativePath, isDirectory);
+}
+
 function resolvePortableViewHref(href, context = {}) {
   const parsed = splitHrefForResolution(href);
   if (!parsed || !parsed.pathname || !context.repo || !context.repoRoot) {
+    return null;
+  }
+  if (parsed.pathname === '/view' || parsed.pathname.startsWith('/view/')) {
     return null;
   }
 
@@ -381,13 +416,226 @@ function resolvePortableViewHref(href, context = {}) {
     absoluteTarget = path.resolve(sourceDir, parsed.pathname);
   }
 
-  if (!isWithinRoot(absoluteTarget, repoRoot)) {
+  const repoEntries = buildRepoResolutionEntries(context);
+  let targetRepo = repoEntries.find((entry) => isWithinRoot(absoluteTarget, entry.rootPath));
+  if (!targetRepo && /^(?:~|\$HOME)\//.test(parsed.pathname)) {
+    const portableParts = parsed.pathname.replace(/^(?:~|\$HOME)\//, '').split('/');
+    const explicitRepo = repoEntries.find((entry) => entry.repo === portableParts[0]);
+    if (explicitRepo) {
+      targetRepo = explicitRepo;
+      absoluteTarget = path.resolve(explicitRepo.rootPath, portableParts.slice(1).join('/'));
+    }
+  }
+  if (!targetRepo && path.isAbsolute(parsed.pathname)) {
+    if (/^\/(?:home|Users)\//.test(parsed.pathname)) {
+      return '#unresolved-portable-link';
+    }
+    targetRepo = { repo: context.repo, rootPath: repoRoot };
+    absoluteTarget = path.resolve(repoRoot, parsed.pathname.replace(/^\/+/, ''));
+  }
+  if (!targetRepo || !isWithinRoot(absoluteTarget, targetRepo.rootPath)) {
     return null;
   }
 
-  const relativePath = path.relative(repoRoot, absoluteTarget).split(path.sep).join('/');
-  const viewHref = encodeViewPath(context.repo, relativePath === '.' ? '' : relativePath);
+  const relativePath = path.relative(targetRepo.rootPath, absoluteTarget).split(path.sep).join('/');
+  const normalizedRelativePath = relativePath === '.' ? '' : relativePath;
+  if (!canResolveTarget(context, targetRepo.repo, normalizedRelativePath, false)) {
+    return '#unresolved-portable-link';
+  }
+
+  const viewHref = encodeViewPath(targetRepo.repo, normalizedRelativePath);
   return `${viewHref}${escapeHtml(parsed.query)}${escapeHtml(parsed.hash)}`;
+}
+
+function slugKey(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/\.[^.\/]+$/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function wikiKeysForPath(relativePath, isDirectory = false) {
+  const base = path.posix.basename(String(relativePath || '').replace(/\/$/, ''));
+  const ext = isDirectory ? '' : path.posix.extname(base);
+  const stem = ext ? base.slice(0, -ext.length) : base;
+  return [...new Set([
+    base.toLowerCase(),
+    stem.toLowerCase(),
+    slugKey(base),
+    slugKey(stem),
+  ].filter(Boolean))];
+}
+
+function parseWikiTarget(value, { allowBare = false } = {}) {
+  const raw = String(value || '').trim();
+  const wrapped = raw.match(/^\[\[([^\[\]]+)\]\]$/);
+  if (!wrapped && !allowBare) {
+    return null;
+  }
+
+  const inner = wrapped ? wrapped[1] : raw;
+  if (!inner || /[<>]/.test(inner)) {
+    return null;
+  }
+
+  const [targetPart, aliasPart] = inner.split('|', 2);
+  const hashIndex = targetPart.indexOf('#');
+  const name = (hashIndex === -1 ? targetPart : targetPart.slice(0, hashIndex)).trim();
+  if (!name) {
+    return null;
+  }
+
+  return {
+    name,
+    key: slugKey(name),
+    hash: hashIndex === -1 ? '' : targetPart.slice(hashIndex),
+    alias: aliasPart ? aliasPart.trim() : '',
+  };
+}
+
+function walkRepoForWikiIndex(repo, rootPath, context, output, maxEntries = 5000) {
+  let count = 0;
+  function walk(absoluteDir, relativeDir) {
+    if (count >= maxEntries) {
+      return;
+    }
+
+    let dirents;
+    try {
+      dirents = fs.readdirSync(absoluteDir, { withFileTypes: true });
+    } catch (_error) {
+      return;
+    }
+
+    for (const dirent of dirents) {
+      if (count >= maxEntries || dirent.name.startsWith('.')) {
+        continue;
+      }
+
+      const relativePath = relativeDir ? `${relativeDir}/${dirent.name}` : dirent.name;
+      if (dirent.isDirectory()) {
+        if (canResolveTarget(context, repo, relativePath, true)) {
+          output.push({ repo, relativePath: `${relativePath}/`, isDirectory: true });
+        }
+        count += 1;
+        walk(path.join(absoluteDir, dirent.name), relativePath);
+      } else if (dirent.isFile()) {
+        if (canResolveTarget(context, repo, relativePath, false)) {
+          output.push({ repo, relativePath, isDirectory: false });
+        }
+        count += 1;
+      }
+    }
+  }
+
+  walk(rootPath, '');
+}
+
+function buildWikiLinkIndex(context = {}) {
+  const entries = [];
+  for (const { repo, rootPath } of buildRepoResolutionEntries(context)) {
+    walkRepoForWikiIndex(repo, rootPath, context, entries);
+  }
+
+  const byKey = new Map();
+  for (const entry of entries) {
+    for (const key of wikiKeysForPath(entry.relativePath, entry.isDirectory)) {
+      if (!byKey.has(key)) {
+        byKey.set(key, []);
+      }
+      byKey.get(key).push(entry);
+    }
+  }
+  return byKey;
+}
+
+function commonPrefixLength(left, right) {
+  let count = 0;
+  while (count < Math.min(left.length, right.length) && left[count] === right[count]) {
+    count += 1;
+  }
+  return count;
+}
+
+function chooseWikiTarget(candidates, context = {}) {
+  if (!candidates || candidates.length === 0) {
+    return null;
+  }
+
+  const scoped = candidates.some((entry) => entry.repo === context.repo)
+    ? candidates.filter((entry) => entry.repo === context.repo)
+    : candidates;
+  const sourceDirParts = (context.currentDir || '').split('/').filter(Boolean);
+  let best = [];
+  let bestScore = -1;
+
+  for (const entry of scoped) {
+    const entryDir = entry.isDirectory
+      ? entry.relativePath.replace(/\/$/, '')
+      : path.posix.dirname(entry.relativePath);
+    const entryDirParts = (entryDir === '.' ? '' : entryDir).split('/').filter(Boolean);
+    const score = commonPrefixLength(sourceDirParts, entryDirParts);
+    if (score > bestScore) {
+      bestScore = score;
+      best = [entry];
+    } else if (score === bestScore) {
+      best.push(entry);
+    }
+  }
+
+  return best.length === 1 ? best[0] : null;
+}
+
+function resolveWikiViewHref(value, context = {}) {
+  const parsed = parseWikiTarget(value, { allowBare: Boolean(context.allowBareWikiTarget) });
+  if (!parsed) {
+    return null;
+  }
+
+  const index = context.wikiLinkIndex || buildWikiLinkIndex(context);
+  const target = chooseWikiTarget(index.get(parsed.key), context);
+  if (!target) {
+    return null;
+  }
+
+  return `${encodeViewPath(target.repo, target.relativePath)}${escapeHtml(parsed.hash)}`;
+}
+
+function rewriteWikiTextLinks(html, options = {}) {
+  if (!html.includes('[[')) {
+    return html;
+  }
+
+  const parts = splitByCodeBlocks(html);
+  const wikiLinkIndex = options.wikiLinkIndex || buildWikiLinkIndex(options);
+  for (let i = 0; i < parts.length; i += 1) {
+    if (/^<(pre|code)\b/i.test(parts[i])) {
+      continue;
+    }
+
+    const tagParts = parts[i].split(/(<[^>]+>)/g);
+    for (let j = 0; j < tagParts.length; j += 1) {
+      if (tagParts[j].startsWith('<')) {
+        continue;
+      }
+      tagParts[j] = tagParts[j].replace(/\[\[([^\[\]]+)\]\]/g, (match, inner) => {
+        const parsed = parseWikiTarget(inner, { allowBare: true });
+        const href = parsed && resolveWikiViewHref(inner, {
+          ...options,
+          wikiLinkIndex,
+          allowBareWikiTarget: true,
+        });
+        if (!href) {
+          return match;
+        }
+        return `<a href="${appendQueryToken(href, options.queryToken)}" class="cross-link">${escapeHtml(parsed.alias || parsed.name)}</a>`;
+      });
+    }
+    parts[i] = tagParts.join('');
+  }
+
+  return parts.join('');
 }
 
 function rewriteHybridCrossLinks(html, options = {}) {
@@ -441,11 +689,11 @@ function rewritePortableNavigationLinks(html, options = {}) {
     parts[i] = parts[i].replace(
       /<a\b([^>]*?)href="([^"]+)"([^>]*)>/gi,
       (match, before, href, after) => {
-        const portableHref = resolvePortableViewHref(href, options);
-        if (!portableHref) {
+        const rewrittenHref = resolveWikiViewHref(href, options) || resolvePortableViewHref(href, options);
+        if (!rewrittenHref) {
           return match;
         }
-        return `<a${before}href="${appendQueryToken(portableHref, options.queryToken)}"${after}>`;
+        return `<a${before}href="${appendQueryToken(rewrittenHref, options.queryToken)}"${after}>`;
       }
     );
   }
@@ -721,11 +969,15 @@ function sanitizeHtml(html) {
 }
 
 function postProcessHtml(html, options) {
+  const processingOptions = html.includes('[[')
+    ? { ...options, wikiLinkIndex: buildWikiLinkIndex(options) }
+    : options;
   let output = html;
-  output = rewriteHybridCrossLinks(output, options);
-  output = rewriteAudioLinks(output, options);
-  output = rewritePortableNavigationLinks(output, options);
-  output = rewriteImageSources(output, options);
+  output = rewriteHybridCrossLinks(output, processingOptions);
+  output = rewriteWikiTextLinks(output, processingOptions);
+  output = rewriteAudioLinks(output, processingOptions);
+  output = rewritePortableNavigationLinks(output, processingOptions);
+  output = rewriteImageSources(output, processingOptions);
   output = addMissingHeadingIds(output);
   output = addHeadingAnchorLinks(output);
   output = addYamlAnchorLinks(output);
@@ -780,10 +1032,21 @@ function renderContent(filePath, source, options = {}) {
   };
 }
 
-function renderPreviewHtml({ repo, repoRoot, relativePath, source, queryToken = null, homePath = null }) {
+function renderPreviewHtml({
+  repo,
+  repoRoot,
+  repoMappings = null,
+  canResolveLink = null,
+  relativePath,
+  source,
+  queryToken = null,
+  homePath = null,
+}) {
   const rendered = renderContent(relativePath, source, {
     repo,
     repoRoot: repoRoot || null,
+    repoMappings: repoMappings || null,
+    canResolveLink,
     currentDir: path.posix.dirname(relativePath) === '.' ? '' : path.posix.dirname(relativePath),
     queryToken,
     homePath: homePath || null,
@@ -995,7 +1258,7 @@ function renderDirectoryPage({ title, repo, currentPath, parentHref, entries, no
   return baseHtml({ title, body, customThemeCss });
 }
 
-function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, mtime, size, editHref = null, rawHtmlHref = null, customThemeCss, queryToken = null, annotationsEnabled = false }) {
+function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLink = null, relativePath, source, parentHref, mtime, size, editHref = null, rawHtmlHref = null, customThemeCss, queryToken = null, annotationsEnabled = false, homePath = null }) {
   const extension = effectiveViewExtension(relativePath);
   const isMarkdown = MARKDOWN_EXTENSIONS.has(extension);
   const isHtmlDocument = HTML_EXTENSIONS.has(extension);
@@ -1005,11 +1268,19 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
   const rendered = renderContent(relativePath, source, {
     repo,
     repoRoot: repoRoot || null,
+    repoMappings: repoMappings || null,
+    canResolveLink,
     currentDir: path.posix.dirname(relativePath) === '.' ? '' : path.posix.dirname(relativePath),
     queryToken,
+    homePath: homePath || null,
   });
   const heading = `${repo}/${relativePath}`;
-  const rawSourceJson = supportsRawToggle ? jsonForInlineScript(source) : null;
+  const rawSourceJson = supportsRawToggle ? jsonForInlineScript(redactHostPathsForBrowser(source, {
+    repo,
+    repoRoot: repoRoot || null,
+    repoMappings: repoMappings || null,
+    homePath: homePath || null,
+  })) : null;
   const rawLanguage = isMarkdown ? 'markdown' : isHtmlDocument ? 'xml' : isYaml ? 'yaml' : null;
 
   const renderedClass = isMarkdown ? 'markdown' : rendered.kind;
@@ -1826,6 +2097,8 @@ function renderEditPage({
   relativePath,
   source,
   repoRoot,
+  repoMappings = null,
+  canResolveLink = null,
   mtimeMs,
   mtime,
   size,
@@ -1840,6 +2113,8 @@ function renderEditPage({
   const initialPreviewHtml = renderPreviewHtml({
     repo,
     repoRoot,
+    repoMappings,
+    canResolveLink,
     relativePath,
     source,
     queryToken,

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2,6 +2,7 @@
 
 const path = require('node:path');
 const fs = require('node:fs');
+const os = require('node:os');
 const MarkdownIt = require('markdown-it');
 const hljs = require('highlight.js');
 const createDOMPurify = require('dompurify');
@@ -313,8 +314,80 @@ function appendQueryToken(url, queryToken) {
     return url;
   }
 
-  const separator = url.includes('?') ? '&' : '?';
-  return `${url}${separator}token=${encodeURIComponent(queryToken)}`;
+  const hashIndex = url.indexOf('#');
+  const base = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : url.slice(hashIndex);
+  const separator = base.includes('?') ? '&' : '?';
+  return `${base}${separator}token=${encodeURIComponent(queryToken)}${hash}`;
+}
+
+function splitHrefForResolution(rawValue) {
+  const value = String(rawValue || '').trim();
+  if (!value || value === '#' || /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(value)) {
+    return null;
+  }
+
+  const match = value.match(/^([^?#]*)(\?[^#]*)?(#.*)?$/);
+  if (!match) {
+    return null;
+  }
+
+  let pathname;
+  try {
+    pathname = decodeURIComponent(match[1] || '');
+  } catch (_error) {
+    return null;
+  }
+
+  return {
+    pathname,
+    query: match[2] || '',
+    hash: match[3] || '',
+  };
+}
+
+function isWithinRoot(targetPath, rootPath) {
+  return targetPath === rootPath || targetPath.startsWith(`${rootPath}${path.sep}`);
+}
+
+function encodeViewPath(repo, relativePath) {
+  const pathPart = relativePath
+    ? `/${relativePath.split('/').map(encodeURIComponent).join('/')}`
+    : '';
+  return `/view/${encodeURIComponent(repo)}${pathPart}`;
+}
+
+function resolvePortableViewHref(href, context = {}) {
+  const parsed = splitHrefForResolution(href);
+  if (!parsed || !parsed.pathname || !context.repo || !context.repoRoot) {
+    return null;
+  }
+
+  const repoRoot = path.resolve(context.repoRoot);
+  const homePath = path.resolve(context.homePath || os.homedir());
+  const currentDir = context.currentDir || '';
+  const sourceDir = path.join(repoRoot, currentDir);
+  let absoluteTarget;
+
+  if (parsed.pathname === '~' || parsed.pathname === '$HOME') {
+    absoluteTarget = homePath;
+  } else if (parsed.pathname.startsWith('~/')) {
+    absoluteTarget = path.resolve(homePath, parsed.pathname.slice(2));
+  } else if (parsed.pathname.startsWith('$HOME/')) {
+    absoluteTarget = path.resolve(homePath, parsed.pathname.slice('$HOME/'.length));
+  } else if (path.isAbsolute(parsed.pathname)) {
+    absoluteTarget = path.resolve(parsed.pathname);
+  } else {
+    absoluteTarget = path.resolve(sourceDir, parsed.pathname);
+  }
+
+  if (!isWithinRoot(absoluteTarget, repoRoot)) {
+    return null;
+  }
+
+  const relativePath = path.relative(repoRoot, absoluteTarget).split(path.sep).join('/');
+  const viewHref = encodeViewPath(context.repo, relativePath === '.' ? '' : relativePath);
+  return `${viewHref}${escapeHtml(parsed.query)}${escapeHtml(parsed.hash)}`;
 }
 
 function rewriteHybridCrossLinks(html, options = {}) {
@@ -340,15 +413,16 @@ function rewriteHybridCrossLinks(html, options = {}) {
           return match; // inside a <code> span — leave as literal
         }
 
+        const portableHref = resolvePortableViewHref(rawPath, options);
         const hashIndex = rawPath.indexOf('#');
         const pathPart = hashIndex === -1 ? rawPath : rawPath.slice(0, hashIndex);
-        const mappedPath = normalizeRepoAssetPath(pathPart);
-        if (!mappedPath) {
+        const mappedPath = portableHref ? null : normalizeRepoAssetPath(pathPart);
+        if (!portableHref && !mappedPath) {
           return match;
         }
 
         const hash = hashIndex === -1 ? '' : rawPath.slice(hashIndex);
-        const href = appendQueryToken(`/view${mappedPath}${escapeHtml(hash)}`, options.queryToken);
+        const href = appendQueryToken(portableHref || `/view${mappedPath}${escapeHtml(hash)}`, options.queryToken);
         return `<a href="${href}" class="cross-link">${escapeHtml(wikiText.trim())}</a>`;
       }
     );
@@ -357,23 +431,21 @@ function rewriteHybridCrossLinks(html, options = {}) {
   return parts.join('');
 }
 
-function rewriteTildeLinks(html, options = {}) {
+function rewritePortableNavigationLinks(html, options = {}) {
   const parts = splitByCodeBlocks(html);
   for (let i = 0; i < parts.length; i += 1) {
     if (/^<(pre|code)\b/i.test(parts[i])) {
       continue;
     }
 
-    // Rewrite <a href="~/repo/path#section"> → <a href="/view/repo/path#section">
     parts[i] = parts[i].replace(
-      /<a\b([^>]*?)href="~\/([^"#]+)(#[^"]*)?([^>]*)"([^>]*)>/gi,
-      (match, before, tilePath, hash, extra, after) => {
-        const mapped = normalizeRepoAssetPath('~/' + tilePath);
-        if (!mapped) {
+      /<a\b([^>]*?)href="([^"]+)"([^>]*)>/gi,
+      (match, before, href, after) => {
+        const portableHref = resolvePortableViewHref(href, options);
+        if (!portableHref) {
           return match;
         }
-        const href = appendQueryToken(`/view${mapped}${hash || ''}${extra || ''}`, options.queryToken);
-        return `<a${before}href="${href}"${after}>`;
+        return `<a${before}href="${appendQueryToken(portableHref, options.queryToken)}"${after}>`;
       }
     );
   }
@@ -652,7 +724,7 @@ function postProcessHtml(html, options) {
   let output = html;
   output = rewriteHybridCrossLinks(output, options);
   output = rewriteAudioLinks(output, options);
-  output = rewriteTildeLinks(output, options);
+  output = rewritePortableNavigationLinks(output, options);
   output = rewriteImageSources(output, options);
   output = addMissingHeadingIds(output);
   output = addHeadingAnchorLinks(output);
@@ -708,12 +780,13 @@ function renderContent(filePath, source, options = {}) {
   };
 }
 
-function renderPreviewHtml({ repo, repoRoot, relativePath, source, queryToken = null }) {
+function renderPreviewHtml({ repo, repoRoot, relativePath, source, queryToken = null, homePath = null }) {
   const rendered = renderContent(relativePath, source, {
     repo,
     repoRoot: repoRoot || null,
     currentDir: path.posix.dirname(relativePath) === '.' ? '' : path.posix.dirname(relativePath),
     queryToken,
+    homePath: homePath || null,
   });
   return rendered.html;
 }

--- a/server.js
+++ b/server.js
@@ -480,8 +480,9 @@ function createApp(options = {}) {
     }
     const repos = Object.entries(mappings)
       .filter(([repo]) => canAccessPath(accessContext, 'view', repo, '', 'directory'))
-      .map(([repo]) => ({
+      .map(([repo, rootPath]) => ({
         repo,
+        rootPath,
         viewUrl: `/view/${encodeURIComponent(repo)}/`,
         assetUrl: `/asset/${encodeURIComponent(repo)}/`,
       }));

--- a/server.js
+++ b/server.js
@@ -316,6 +316,16 @@ function createApp(options = {}) {
     );
     return grantAccess || accessContext;
   };
+  const linkResolutionContext = (accessContext) => ({
+    repoMappings: mappings,
+    canResolveLink: (repo, relativePath, isDirectory) => canAccessPath(
+      accessContext,
+      'view',
+      repo,
+      relativePath,
+      isDirectory ? 'directory' : 'file'
+    ),
+  });
 
   const authenticateGrantAdmin = (req) => {
     if (!grantStore || !grantStore.isEnabled()) {
@@ -470,9 +480,8 @@ function createApp(options = {}) {
     }
     const repos = Object.entries(mappings)
       .filter(([repo]) => canAccessPath(accessContext, 'view', repo, '', 'directory'))
-      .map(([repo, rootPath]) => ({
+      .map(([repo]) => ({
         repo,
-        rootPath,
         viewUrl: `/view/${encodeURIComponent(repo)}/`,
         assetUrl: `/asset/${encodeURIComponent(repo)}/`,
       }));
@@ -718,6 +727,7 @@ function createApp(options = {}) {
     const html = renderDocumentPage({
       repo,
       repoRoot: rootPath,
+      ...linkResolutionContext(accessContext),
       relativePath,
       source,
       parentHref: appendAccessToken(parentRel === null ? '/view' : buildHref(repo, parentRel), accessContext),
@@ -811,6 +821,7 @@ function createApp(options = {}) {
       repo,
       relativePath,
       repoRoot: rootPath,
+      ...linkResolutionContext(accessContext),
       source: sourceBuffer.toString('utf8'),
       mtimeMs: Math.trunc(stat.mtimeMs),
       mtime: formatMTime(stat.mtime),
@@ -1024,6 +1035,7 @@ function createApp(options = {}) {
     const html = renderPreviewHtml({
       repo,
       repoRoot: rootPath,
+      ...linkResolutionContext(accessContext),
       relativePath,
       source: content,
       queryToken: accessContext.queryToken,

--- a/test/access-control.test.js
+++ b/test/access-control.test.js
@@ -22,7 +22,14 @@ async function makeFixture() {
   await fs.mkdir(betaRoot, { recursive: true });
 
   await fs.writeFile(path.join(alphaRoot, 'README.md'), '# Alpha\n');
-  await fs.writeFile(path.join(alphaRoot, 'docs', 'guide.md'), '# Guide\n![Diagram](diagram.png)\n');
+  await fs.writeFile(path.join(alphaRoot, 'docs', 'guide.md'), [
+    '# Guide',
+    '![Diagram](diagram.png)',
+    '[Beta relative](../../beta/notes.md#beta)',
+    `[Beta absolute](${path.join(betaRoot, 'notes.md')}#beta)`,
+    '[[beta-notes#beta|Beta wiki]]',
+    '',
+  ].join('\n'));
   await fs.writeFile(path.join(alphaRoot, 'docs', 'landing.htm'), htmlFixture);
   await fs.writeFile(
     path.join(alphaRoot, 'docs', 'settings.yaml'),
@@ -40,6 +47,7 @@ async function makeFixture() {
   await fs.writeFile(path.join(alphaRoot, 'docs', 'diagram.png'), 'png-bytes');
   await fs.writeFile(path.join(alphaRoot, 'secret', 'hidden.md'), '# Hidden\n');
   await fs.writeFile(path.join(betaRoot, 'notes.md'), '# Beta\n');
+  await fs.writeFile(path.join(betaRoot, 'beta-notes.md'), '# Beta Notes\n');
 
   return {
     root,
@@ -162,15 +170,35 @@ test('GET /api/repos returns repo discovery payload for unrestricted humans', as
     assert.ok(reposByName.has('beta'));
 
     const alphaEntry = reposByName.get('alpha');
-    assert.equal(alphaEntry.rootPath, fixture.mappings.alpha);
+    assert.equal(Object.prototype.hasOwnProperty.call(alphaEntry, 'rootPath'), false);
     assert.equal(alphaEntry.viewUrl, '/view/alpha/');
     assert.equal(alphaEntry.assetUrl, '/asset/alpha/');
     for (const entry of payload.repos) {
       assert.equal(typeof entry.repo, 'string');
-      assert.equal(typeof entry.rootPath, 'string');
+      assert.equal(Object.prototype.hasOwnProperty.call(entry, 'rootPath'), false);
       assert.equal(typeof entry.viewUrl, 'string');
       assert.equal(typeof entry.assetUrl, 'string');
     }
+  } finally {
+    await server.close();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('rendered views resolve authorized cross-repo and wiki links without disclosing roots', async () => {
+  const fixture = await makeFixture();
+  const server = await startTestServer({ mappings: fixture.mappings });
+
+  try {
+    const response = await server.request('/view/alpha/docs/guide.md');
+    assert.equal(response.status, 200);
+    const html = await response.text();
+
+    assert.match(html, /href="\/view\/beta\/notes\.md#beta">Beta relative<\/a>/);
+    assert.match(html, /href="\/view\/beta\/notes\.md#beta">Beta absolute<\/a>/);
+    assert.match(html, /href="\/view\/beta\/beta-notes\.md#beta" class="cross-link">Beta wiki<\/a>/);
+    assert.doesNotMatch(html, new RegExp(fixture.root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.doesNotMatch(html, /rootPath|repoMappings/);
   } finally {
     await server.close();
     await fs.rm(fixture.root, { recursive: true, force: true });
@@ -212,7 +240,7 @@ test('GET /api/repos filters by grant scope and rejects unauthenticated/invalid 
     assert.equal(scopedPayload.count, 1);
     assert.equal(scopedPayload.repos.length, 1);
     assert.equal(scopedPayload.repos[0].repo, 'alpha');
-    assert.equal(scopedPayload.repos[0].rootPath, fixture.mappings.alpha);
+    assert.equal(Object.prototype.hasOwnProperty.call(scopedPayload.repos[0], 'rootPath'), false);
     assert.equal(scopedPayload.repos[0].viewUrl, '/view/alpha/');
     assert.equal(scopedPayload.repos[0].assetUrl, '/asset/alpha/');
     assert.ok(!scopedPayload.repos.some((entry) => entry.repo === 'beta'));

--- a/test/access-control.test.js
+++ b/test/access-control.test.js
@@ -170,12 +170,12 @@ test('GET /api/repos returns repo discovery payload for unrestricted humans', as
     assert.ok(reposByName.has('beta'));
 
     const alphaEntry = reposByName.get('alpha');
-    assert.equal(Object.prototype.hasOwnProperty.call(alphaEntry, 'rootPath'), false);
+    assert.equal(alphaEntry.rootPath, fixture.mappings.alpha);
     assert.equal(alphaEntry.viewUrl, '/view/alpha/');
     assert.equal(alphaEntry.assetUrl, '/asset/alpha/');
     for (const entry of payload.repos) {
       assert.equal(typeof entry.repo, 'string');
-      assert.equal(Object.prototype.hasOwnProperty.call(entry, 'rootPath'), false);
+      assert.equal(typeof entry.rootPath, 'string');
       assert.equal(typeof entry.viewUrl, 'string');
       assert.equal(typeof entry.assetUrl, 'string');
     }
@@ -240,7 +240,7 @@ test('GET /api/repos filters by grant scope and rejects unauthenticated/invalid 
     assert.equal(scopedPayload.count, 1);
     assert.equal(scopedPayload.repos.length, 1);
     assert.equal(scopedPayload.repos[0].repo, 'alpha');
-    assert.equal(Object.prototype.hasOwnProperty.call(scopedPayload.repos[0], 'rootPath'), false);
+    assert.equal(scopedPayload.repos[0].rootPath, fixture.mappings.alpha);
     assert.equal(scopedPayload.repos[0].viewUrl, '/view/alpha/');
     assert.equal(scopedPayload.repos[0].assetUrl, '/asset/alpha/');
     assert.ok(!scopedPayload.repos.some((entry) => entry.repo === 'beta'));

--- a/test/portable-links.test.js
+++ b/test/portable-links.test.js
@@ -2,8 +2,11 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
 
-const { renderPreviewHtml } = require('../lib/renderer');
+const { renderDocumentPage, renderPreviewHtml } = require('../lib/renderer');
 
 test('rendered links resolve repo-relative, absolute, tilde, and $HOME paths server-side', () => {
   const homePath = '/home/test-user';
@@ -36,4 +39,96 @@ test('rendered links resolve repo-relative, absolute, tilde, and $HOME paths ser
   assert.match(html, /href="https:\/\/example\.test\/guide\.md">external<\/a>/);
   assert.match(html, /href="#local">fragment<\/a>/);
   assert.match(html, /<code>\$HOME\/projects\/alpha\/private\.md<\/code>/);
+});
+
+test('cross-repo and wiki links resolve while ambiguous wiki names remain unlinked', async () => {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-portable-links-'));
+  const alphaRoot = path.join(fixtureRoot, 'alpha');
+  const betaRoot = path.join(fixtureRoot, 'beta');
+
+  try {
+    await fs.mkdir(path.join(alphaRoot, 'docs'), { recursive: true });
+    await fs.mkdir(path.join(alphaRoot, 'one'), { recursive: true });
+    await fs.mkdir(path.join(alphaRoot, 'two'), { recursive: true });
+    await fs.mkdir(betaRoot, { recursive: true });
+    await fs.writeFile(path.join(alphaRoot, 'README.md'), '# Alpha\n');
+    await fs.writeFile(path.join(alphaRoot, 'one', 'project-notes.md'), '# One\n');
+    await fs.writeFile(path.join(alphaRoot, 'two', 'project-notes.md'), '# Two\n');
+    await fs.writeFile(path.join(betaRoot, 'notes.md'), '# Notes\n');
+    await fs.writeFile(path.join(betaRoot, 'beta-notes.md'), '# Beta Notes\n');
+
+    const html = renderPreviewHtml({
+      repo: 'alpha',
+      repoRoot: alphaRoot,
+      repoMappings: { alpha: alphaRoot, beta: betaRoot },
+      relativePath: 'docs/guide.md',
+      source: [
+        '[cross relative](../../beta/notes.md#beta)',
+        `[cross absolute](${path.join(betaRoot, 'notes.md')}?mode=full#beta)`,
+        '[cross portable](~/beta/notes.md)',
+        '[[beta-notes#beta|Beta wiki]]',
+        '[[project-notes]]',
+        '`[[beta-notes]]`',
+      ].join('\n\n'),
+    });
+
+    assert.match(html, /href="\/view\/beta\/notes\.md#beta">cross relative<\/a>/);
+    assert.match(html, /href="\/view\/beta\/notes\.md\?mode=full#beta">cross absolute<\/a>/);
+    assert.match(html, /href="\/view\/beta\/notes\.md">cross portable<\/a>/);
+    assert.match(html, /<a href="\/view\/beta\/beta-notes\.md#beta" class="cross-link">Beta wiki<\/a>/);
+    assert.match(html, /<p>\[\[project-notes\]\]<\/p>/);
+    assert.doesNotMatch(html, /href="[^"]+project-notes/);
+    assert.match(html, /<code>\[\[beta-notes\]\]<\/code>/);
+  } finally {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('rendered output never discloses home paths or repository root mappings', async () => {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-link-disclosure-'));
+  const betaRoot = path.join(fixtureRoot, 'beta');
+  const genericHome = '/home/generic-user';
+  const alphaRoot = `${genericHome}/projects/alpha`;
+
+  try {
+    await fs.mkdir(path.join(betaRoot, 'one'), { recursive: true });
+    await fs.mkdir(path.join(betaRoot, 'two'), { recursive: true });
+    await fs.writeFile(path.join(betaRoot, 'beta-notes.md'), '# Beta\n');
+    await fs.writeFile(path.join(betaRoot, 'one', 'duplicate.md'), '# One\n');
+    await fs.writeFile(path.join(betaRoot, 'two', 'duplicate.md'), '# Two\n');
+
+    const source = [
+      '[relative](../README.md)',
+      `[absolute](${alphaRoot}/docs/guide.md)`,
+      '[tilde](~/projects/alpha/README.md)',
+      '[home]($HOME/projects/alpha/docs/guide.md)',
+      `[cross repo](${path.join(betaRoot, 'beta-notes.md')})`,
+      '[[beta-notes]]',
+      '[[duplicate]]',
+      `[host home](${path.join(os.homedir(), 'outside.md')})`,
+      '[mac home](/Users/generic-user/outside.md)',
+    ].join('\n\n');
+
+    const html = renderDocumentPage({
+      repo: 'alpha',
+      repoRoot: alphaRoot,
+      repoMappings: { alpha: alphaRoot, beta: betaRoot },
+      relativePath: 'docs/guide.md',
+      source,
+      parentHref: '/view/alpha/docs',
+      mtime: '2026-01-01',
+      size: '1 KB',
+      homePath: genericHome,
+    });
+
+    assert.match(html, /href="\/view\/beta\/beta-notes\.md" class="cross-link">beta-notes<\/a>/);
+    assert.match(html, /<p>\[\[duplicate\]\]<\/p>/);
+    assert.doesNotMatch(html, /\/home\//);
+    assert.doesNotMatch(html, /\/Users\//);
+    assert.doesNotMatch(html, new RegExp(os.homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.doesNotMatch(html, new RegExp(fixtureRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.doesNotMatch(html, /repoMappings|repoRoot|rootPath/);
+  } finally {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
 });

--- a/test/portable-links.test.js
+++ b/test/portable-links.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { renderPreviewHtml } = require('../lib/renderer');
+
+test('rendered links resolve repo-relative, absolute, tilde, and $HOME paths server-side', () => {
+  const homePath = '/home/test-user';
+  const repoRoot = `${homePath}/projects/alpha`;
+  const source = [
+    '[relative](../README.md)',
+    '[same directory](./chapter/index.md)',
+    `[absolute](${repoRoot}/docs/guide.md?mode=full#details)`,
+    '[tilde](~/projects/alpha/README.md#top)',
+    '[home]($HOME/projects/alpha/docs/guide.md)',
+    '[external](https://example.test/guide.md)',
+    '[fragment](#local)',
+    '`$HOME/projects/alpha/private.md`',
+  ].join('\n\n');
+
+  const html = renderPreviewHtml({
+    repo: 'alpha',
+    repoRoot,
+    relativePath: 'docs/guide.md',
+    source,
+    queryToken: 'viewer-token',
+    homePath,
+  });
+
+  assert.match(html, /href="\/view\/alpha\/README\.md\?token=viewer-token">relative<\/a>/);
+  assert.match(html, /href="\/view\/alpha\/docs\/chapter\/index\.md\?token=viewer-token">same directory<\/a>/);
+  assert.match(html, /href="\/view\/alpha\/docs\/guide\.md\?mode=full&amp;token=viewer-token#details">absolute<\/a>/);
+  assert.match(html, /href="\/view\/alpha\/README\.md\?token=viewer-token#top">tilde<\/a>/);
+  assert.match(html, /href="\/view\/alpha\/docs\/guide\.md\?token=viewer-token">home<\/a>/);
+  assert.match(html, /href="https:\/\/example\.test\/guide\.md">external<\/a>/);
+  assert.match(html, /href="#local">fragment<\/a>/);
+  assert.match(html, /<code>\$HOME\/projects\/alpha\/private\.md<\/code>/);
+});


### PR DESCRIPTION
Part of #91 (reconciliation Step 5.2). Ports the deployed tree's link-resolution capability with a security redesign the reconciliation plan mandates:

1. **Repo-relative, root-relative, absolute, `~`/`$HOME` link resolution** in rendered Markdown/HTML views — resolved server-side to opaque `/view/<repo>/<path>` URLs (query strings/fragments preserved).
2. **Cross-repo + wiki-link (`[[...]]`) resolution with ambiguity handling** (ambiguous wiki targets render as plain text, not a guess).

**Not ported, by design**: the deployed implementation serialized `os.homedir()`, source roots, and all repo root mappings into client-side JavaScript. That mechanism is replaced entirely by server-side resolution; a negative test asserts rendered output contains no `/home/`, `/Users/`, homedir, or fixture-root strings for documents exercising every link form.

**Scope correction during verification** (third commit): the worker had also removed `rootPath` from the authenticated `/api/repos` payload. That field is a pre-existing discovery contract consumed by `bin/lookie-read`'s same-host local-read optimization — removing it silently degraded that feature. Restored; whether authenticated discovery should expose roots (and to whom) is deferred to the discovery workstream as a deliberate capability-scoping decision. The non-disclosure invariant here applies to rendered output.

Verification: 16/16 tests on this branch; added-line scan clean of private values. Based on the #140 tip per the descent rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)