### PR TITLE
feat: port annotation evolution — redaction, toolbar/stale/line-range, authored targets, write-gated mutations

### DIFF
--- a/docs/ANNOTATIONS-SPEC.md
+++ b/docs/ANNOTATIONS-SPEC.md
@@ -1,6 +1,6 @@
 # Annotations and Agent-Feedback Loop — Spec
 
-**Status**: Draft spec — planning doc, no code changes yet. Source for follow-up implementation issues.
+**Status**: Phase 1 implementation reference. Later-phase sections remain planning guidance.
 
 **Related**:
 
@@ -19,7 +19,7 @@ This doc covers six decision areas. Each ends with a verdict (**adopt**, **adopt
 ## Constraints this spec respects
 
 - **Many repos, many agents, intermittent presence.** The agent that wrote a file may not be running when the human annotates it. Feedback must survive across processes.
-- **Network is the perimeter.** Tailscale + token-scoped access. No new auth needed; the existing access model gates annotation routes the same way it gates `/view` and `/edit`.
+- **Network is the perimeter.** Trusted-network + token-scoped access. Annotation reads require `view`; every sidecar mutation requires the write-class `write` capability (`edit` remains a legacy alias).
 - **Multi-format.** Lookie-Link renders markdown, code, YAML, PDF, audio, and sanitized HTML. The annotation primitive must work for at least the text-shaped formats (markdown, YAML, code). HTML can get a richer treatment in a later phase.
 - **Write-back exists but is opt-in.** Editable mode is off by default for safety ([EDITING.md](EDITING.md)). Any storage choice that requires mutating the source file must therefore be gated on the same flag.
 - **Clean git diffs matter.** Many served repos are git-backed. Annotation noise in the source file pollutes blame and review unless explicitly chosen.
@@ -85,7 +85,7 @@ For other text formats (code, plain text), inline mode is **not supported** in p
 }
 ```
 
-`anchorKind` is one of `heading`, `yamlKey`, `lineRange`, `elementSelector` (HTML phase), `textRange` (HTML phase).
+Phase 1 accepts `heading`, `yamlKey`, or `lineRange`. Deliberate authored-HTML targets use `heading` with a stable `data-lookie-annotation-anchor`; `elementSelector` and `textRange` remain reserved for a later HTML phase.
 
 ## 2. Agent talkback: live polling vs. flat-file pickup
 
@@ -101,6 +101,7 @@ Lookie-Link serves many repos and many intermittent agents. A polling endpoint p
   - `GET /api/annotations/<repo>/<path>?state=open` (HTTP)
   - `lookie annotations list <repo>/<path> --state open` (CLI)
 - The agent marks an annotation `claimed` while it works, then `resolved` when it lands its fix.
+- If content must be removed after posting, `redact` replaces the annotation and reply bodies with placeholders, resolves the item, and preserves authorship, timestamps, and `redactedBy` metadata instead of erasing the audit trail.
 
 **How the agent learns there is new feedback** (without polling):
 
@@ -118,9 +119,9 @@ Lookie-Link already auto-anchors every markdown heading and top-level YAML key (
 
 **Phase 1 gesture:**
 
-- A small `Annotate` affordance appears next to every anchored heading and every YAML key when the viewer loads.
+- The toolbar exposes annotation mode. Existing feedback remains visible, while add-comment affordances appear next to anchored headings and YAML keys only while that mode is active.
 - Clicking it opens an inline editor near that section; submitting writes to the sidecar with `anchorKind: "heading"` (or `yamlKey`) and the existing anchor ID.
-- For files without anchors (plain code, plain text), clicking opens a line-range picker; the annotation records `anchorKind: "lineRange"` with `{ start, end }`.
+- For files without anchors (plain code, plain text), the viewer exposes a line-range picker; the annotation records `anchorKind: "lineRange"` with an anchor such as `#L4-L9`.
 
 **Nested YAML key anchors are a prerequisite.** The Lookie-Link analysis already calls out that nested YAML keys are not currently anchored. Annotations on YAML files are second-class until they are, so extending the anchor generator to nested paths (`a.b.c`) is part of phase 1.
 
@@ -138,6 +139,7 @@ Phase 2 is where Lookie-Link absorbs Lavish's strongest differentiator — preci
 The current pipeline (anchors, link rewriting, DOMPurify) already injects post-processing around the source. The annotation layer extends that pipeline:
 
 - Sidecar annotations are merged into the rendered output at render time as styled inline blocks anchored to the matching heading, key, line range, element, or text range.
+- Sanitized authored HTML can declare a deliberate phase-1 target with `data-lookie-annotation-anchor="anchor-id"`. Annotation cards are collapsed by default so active feedback remains visible without overwhelming rich layouts.
 - Source bytes on disk are unchanged in the default (sidecar) mode.
 - In inline mode, source bytes are modified only for markdown and YAML, only when `enableEditing: true` and a new `enableAnnotations: inline` config flag are both set, and writes go through the same `safeResolve` + mtime guard + temp+rename path that editable mode already uses.
 - The `Raw` toolbar button continues to show the source as it exists on disk. In sidecar mode the raw view is unchanged; in inline mode the raw view shows the comment markers, which is the honest representation.
@@ -184,10 +186,10 @@ A `?annotate=1` URL hint or a CLAUDE.md fragment that tells the agent to drop a 
 - Sidecar storage under `.lookie-link/annotations/<repo>/<relative-path>.json` with the schema above.
 - Nested YAML key anchors in the existing anchor generator (prerequisite).
 - Viewer renders annotations inline next to anchored sections.
-- `Annotate` affordance on every heading, YAML key, and line-range pick.
+- Annotation-mode affordances for headings and YAML keys, plus a line-range picker for code and plain text.
 - `GET /api/annotations/<repo>/<path>` with `?state=` filter.
-- `POST /api/annotations/<repo>/<path>` to create.
-- `PATCH /api/annotations/<repo>/<path>/<id>` to claim, resolve, or reply.
+- `POST /api/annotations/<repo>/<path>` to create (requires `write`).
+- `PATCH /api/annotations/<repo>/<path>` to claim, resolve, reopen, reply, or redact (requires `write`).
 - `bin/lookie-annotations.js` CLI shim.
 - `enableAnnotations: true` config flag, default off, parallel to `enableEditing`.
 
@@ -218,7 +220,7 @@ Phase 1 closes the loop: human leaves a note, agent fetches it on next pass.
 | Nested YAML key anchors | Adopt | Prerequisite — YAML annotations are second-class without it. |
 | Flat-file pickup as default agent contract | Adopt | Matches Lookie-Link's many-repo, many-agent, intermittent-presence reality. |
 | Live polling endpoint | Defer | Adds session and lifetime complexity; only valuable for sub-heartbeat reactivity. Add in phase 3, scoped per path. |
-| Element-level HTML annotations | Defer | High value, ship after phase 1 proves the transport. |
+| Deliberate authored-HTML targets | Adopted | `data-lookie-annotation-anchor="anchor-id"` enables stable element targets; arbitrary selection and generated selectors remain deferred. |
 | Text-range annotations | Defer | Strong differentiator, more brittle anchoring. Ship in phase 2 with quote-plus-offset fallback. |
 | Artifact-preserving render-time injection | Adopt-modified | Extend the existing post-processing pipeline; do not mutate source bytes in default mode. |
 | `bin/lookie-annotations.js` CLI shim | Adopt | Mirrors the existing `bin/lookie-read.js` pattern, gives agent-ergonomic JSON output. |
@@ -234,7 +236,7 @@ Each becomes its own issue against this repo.
 
 1. **Nested YAML key anchors** — extend the anchor generator and `Annotate` affordance to nested YAML paths so YAML files are first-class.
 2. **Annotation sidecar storage and read API** — `.lookie-link/annotations/...` layout, schema, `GET/POST/PATCH /api/annotations/...`, `enableAnnotations` config flag, access-control parity with `/view` and `/edit`.
-3. **Viewer-side annotation UX (phase 1)** — `Annotate` affordances, inline rendering of stored annotations, line-range picker for un-anchored files.
+3. **Viewer-side annotation UX (phase 1)** — annotation-mode affordances, collapsed inline cards, stale-anchor preservation, and a line-range picker for unanchored files.
 4. **`bin/lookie-annotations.js` CLI shim** — list/get/claim/resolve/add/replies subcommands, JSON-first output, env-token auth parity with `lookie-read.js`.
 5. **HTML element + text-range annotations (phase 2)** — element selector, quote-plus-offset, selection gesture, anchor-survival on minor re-render.
 6. **Inline-in-source opt-in mode (phase 3)** — `enableAnnotations: inline` flag, markdown HTML-comment markers, YAML `_lookie_link_annotations` block, `lookie annotations migrate` CLI, integration with `safeResolve` + mtime + temp+rename write path.

--- a/docs/API.md
+++ b/docs/API.md
@@ -3,7 +3,7 @@
 | Route | Description |
 |-------|-------------|
 | `GET /` | Repository index |
-| `GET /healthz` | Health check (returns `{"status":"ok","editingEnabled":bool}`) |
+| `GET /healthz` | Health check, including `editingEnabled`, `annotationsEnabled`, and `rawHtmlEnabled` booleans |
 | `GET /api/repos` | Discover served repos as JSON (filtered by grant scope when a token is presented) |
 | `GET /view/<repo>/<path>` | Rendered file or directory listing |
 | `GET /asset/<repo>/<path>` | Raw asset serving. Supports `Range` requests so `<audio>` can seek, backs the embedded PDF viewer page, and is the agent-facing read path for text/source files (see `lookie-read` CLI in the repo `bin/`). MIME types: images (`.png`/`.jpg`/`.gif`/`.webp`/`.svg`/`.jpeg`), audio (`.m4a`/`.mp3`/`.wav`/`.ogg`/`.oga`/`.opus`/`.flac`/`.aac`), PDF (`.pdf`), markdown (`.md`/`.markdown`/`.mdown` → `text/markdown`), YAML (`.yaml`/`.yml` → `text/yaml`), JSON (`.json`), XML (`.xml`), and the editable text/source set (shell, Python, JS/TS, Go, Rust, C/C++, etc.) returned as `text/plain; charset=utf-8`. Anything else returns `415 Unsupported asset type`. |
@@ -11,8 +11,8 @@
 | `POST /api/save/<repo>/<path>` | Save updated file content (JSON body) |
 | `POST /api/preview/<repo>/<path>` | Render preview HTML from draft content (JSON body) |
 | `GET /api/annotations/<repo>/<path>` | Read sidecar annotations for a file. Supports repeatable `?state=open|claimed|resolved`. Returns an empty schema document when no sidecar exists. |
-| `POST /api/annotations/<repo>/<path>` | Create an annotation. Requires only `view` access and `enableAnnotations: true`. |
-| `PATCH /api/annotations/<repo>/<path>` | Apply `claim`, `resolve`, `reopen`, or `reply` to an annotation with stale-write protection. Requires only `view` access and `enableAnnotations: true`. |
+| `POST /api/annotations/<repo>/<path>` | Create an annotation. Requires `write` access and `enableAnnotations: true`. |
+| `PATCH /api/annotations/<repo>/<path>` | Apply `claim`, `resolve`, `reopen`, `reply`, or `redact` with stale-write protection. Requires `write` access and `enableAnnotations: true`. |
 | `GET /api/grants` | List managed grants (`Authorization: Bearer <admin-token>`) |
 | `POST /api/grants` | Create a managed grant and return token + issue comment helper |
 | `POST /api/grants/:grantId/renew` | Renew a managed grant and return issue comment helper |
@@ -33,9 +33,9 @@ Route enforcement in phase 1:
 
 - `/` and `/view/*` require `view` access when `access.humanDefault` is not `full`
 - `/asset/*` requires `view`
-- `/edit/*` and `/api/save/*` require `edit`
+- `/edit/*` and `/api/save/*` require `write` (`edit` remains a backward-compatible alias)
 - `/api/preview/*` requires `view` and still respects global editing mode
-- `/api/annotations/*` requires `view` and returns `404` when annotations are disabled
+- annotation reads require `view`; annotation creates and updates require `write`; all annotation routes return `404` when annotations are disabled
 
 Invalid tokens return `403`. Missing tokens return `401` when unauthenticated human access is restricted.
 
@@ -95,10 +95,12 @@ Returns `{"ok": true, "html": "rendered HTML"}`.
 
 - Requires `server.enableAnnotations: true`
 - Requires `view` access to the target file
-- Returns `{ "schema": 1, "file": "<repo>/<path>", "annotations": [] }` when no sidecar exists yet
+- Returns `{ "schema": 1, "file": "<repo>/<path>", "annotations": [], "mtimeMs": null }` when no sidecar exists yet
 - Optional `?state=` filter can be repeated, for example `?state=open&state=claimed`
 
 `POST /api/annotations/<repo>/<path>`
+
+- Requires `write` access to the target file
 
 Request body:
 
@@ -118,6 +120,8 @@ Request body:
 
 `PATCH /api/annotations/<repo>/<path>`
 
+- Requires `write` access to the target file
+
 Request body:
 
 ```json
@@ -131,8 +135,9 @@ Request body:
 }
 ```
 
-- Supported `op` values: `claim`, `resolve`, `reopen`, `reply`
+- Supported `op` values: `claim`, `resolve`, `reopen`, `reply`, `redact`
 - `reply` payload requires `author` and `body`
+- `redact` payload requires `redactedBy` (or `author`). It replaces the annotation and reply bodies with placeholders, marks the item resolved, and preserves authorship and timestamp metadata for audit history.
 - Stale `expectedMtimeMs` returns `409` with the current annotation document in `current`
 
 ## Managed Grant Lifecycle

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -36,17 +36,17 @@ access:
             - README.md
       permissions:
         view: true
-        edit: false
+        write: false
 
-    builder_edit:
-      secretEnv: LOOKIE_TOKEN_BUILDER_EDIT
+    builder_write:
+      secretEnv: LOOKIE_TOKEN_BUILDER_WRITE
       repos:
         docs:
           paths:
             - drafts/
       permissions:
         view: true
-        edit: true
+        write: true
 ```
 
 Notes:
@@ -55,6 +55,7 @@ Notes:
 - `humanDefault: restricted` or `none` requires a token for `/`, `/view/*`, `/asset/*`, `/edit/*`, and `/api/*`.
 - Paths ending in `/` grant a directory subtree. Paths without a trailing slash grant a single file.
 - Tokens can also use `secret:` directly for local development, but that should not be committed.
+- Static tokens still accept legacy `edit: true|false` and normalize it to `write` for backward compatibility.
 - Static tokens may carry optional `subject`, `issuer`, and `audit` metadata so future agent-facing `whoami/repos/grant` APIs can identify the Paperclip issue, agent, or projected grant behind a token without changing the phase 1 config shape.
 - Query-string tokens are preserved across rendered links so tokenized browser sessions can keep navigating.
 
@@ -117,6 +118,7 @@ Settings resolve in this order (first wins):
 - Precedence: `LOOKIE_LINK_ENABLE_ANNOTATIONS` env var, then user/project YAML, then default
 - Independent of `enableEditing`
 - When disabled, `GET|POST|PATCH /api/annotations/<repo>/<path>` return `404`
+- `GET` requires `view`; `POST` and `PATCH` require the write-class `write` permission (including legacy `edit` aliases)
 - Annotation sidecars live inside each served repo at `.lookie-link/annotations/<repo>/<relative-path>.json`
 
 ## Custom Themes

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -129,11 +129,16 @@ Behavior:
 
 When `server.enableAnnotations: true`, the document viewer adds an inline annotation layer to every rendered file.
 
-- A small 💬 button appears next to every anchored heading (markdown) and YAML key path. Clicking it opens an inline form to attach an annotation to that anchor.
-- Stored annotations render inline next to their anchor as a styled card, showing author, body, state (`open` / `claimed` / `resolved`), claim metadata, and replies.
-- State controls: **Claim**, **Resolve**, **Reopen**, **Reply**. Each action calls the `/api/annotations/<repo>/<path>` API and refreshes inline.
+- The toolbar exposes a `💬 Annotate` mode. Existing annotations stay visible; add-comment icons appear next to anchored markdown/HTML headings and YAML key paths only while annotation mode is active.
+- Authored HTML can declare a deliberate target with `data-lookie-annotation-anchor="anchor-id"`; Lookie-Link assigns that ID, adds an annotation affordance, and mounts its annotation cards after the target.
+- Stored annotations render as collapsed cards by default. The summary shows state (`open` / `claimed` / `resolved`), author/time, a body preview, and reply count; expanding it reveals the full thread and actions.
+- State controls include **Claim**, **Resolve**, **Reopen**, **Reply**, and **Redact**. Redaction scrubs annotation and reply bodies, resolves the item, and preserves minimal audit metadata.
+- The `💬 N` toolbar chip reports the total count and toggles resolved annotations, which are hidden by default.
+- Plain-text and code views expose a `#L<start>-L<end>` line-range picker.
+- Annotations whose anchors no longer exist remain available in a `Stale anchors` section instead of being dropped.
 - Annotation data lives at `<repoRoot>/.lookie-link/annotations/<repo>/<relative-path>.json` (sidecar). Source files are never mutated.
 - The flag is independent of `enableEditing` — annotations are available on the default safe configuration.
+- Reads require `view` access. Creating, claiming, resolving, reopening, replying, and redacting require `write` access.
 
 See `docs/ANNOTATIONS-SPEC.md` for the full sidecar schema, phase split, and the agent-feedback loop the API enables. The HTTP transport and viewer UX are both available.
 

--- a/lib/access-control.js
+++ b/lib/access-control.js
@@ -24,6 +24,20 @@ function normalizeHumanDefault(value) {
   return 'full';
 }
 
+function normalizePermissions(tokenConfig) {
+  const permissions = tokenConfig && typeof tokenConfig === 'object' && tokenConfig.permissions && typeof tokenConfig.permissions === 'object'
+    ? tokenConfig.permissions
+    : {};
+  const write = permissions.write === true || permissions.edit === true || tokenConfig.allowEditing === true;
+  const view = permissions.view !== false || write;
+
+  return {
+    view,
+    write,
+    edit: write,
+  };
+}
+
 function normalizeScopeEntry(rawScope) {
   const normalized = toPosixPath(rawScope);
   if (!normalized || normalized === '*') {
@@ -133,12 +147,7 @@ function parseAccessConfig(rawConfig) {
         continue;
       }
 
-      const permissions = tokenConfig && typeof tokenConfig === 'object' && tokenConfig.permissions && typeof tokenConfig.permissions === 'object'
-        ? tokenConfig.permissions
-        : {};
-
-      const canEdit = permissions.edit === true || tokenConfig.allowEditing === true;
-      const canView = permissions.view !== false || canEdit;
+      const permissions = normalizePermissions(tokenConfig);
       const repoScopes = normalizeRepoScopes(tokenConfig.repos);
 
       tokens.push({
@@ -149,10 +158,7 @@ function parseAccessConfig(rawConfig) {
           : typeof tokenConfig.secret === 'string' && tokenConfig.secret.trim()
             ? { type: 'inline' }
             : null,
-        permissions: {
-          view: canView,
-          edit: canEdit,
-        },
+        permissions,
         allRepos: repoScopes.allRepos,
         repos: repoScopes.repos,
         subject: tokenConfig.subject || null,
@@ -210,6 +216,7 @@ function authenticateRequest(req, accessConfig) {
       queryToken: null,
       permissions: {
         view: true,
+        write: true,
         edit: true,
       },
       allRepos: true,
@@ -227,6 +234,7 @@ function authenticateRequest(req, accessConfig) {
       queryToken: queryToken || null,
       permissions: {
         view: false,
+        write: false,
         edit: false,
       },
       allRepos: false,
@@ -302,11 +310,11 @@ function canAccessPath(accessContext, action, repo, relativePath, pathType = 'fi
     return false;
   }
 
-  if (action === 'edit' && !accessContext.permissions.edit) {
-    return false;
-  }
-
-  if (action === 'view' && !accessContext.permissions.view) {
+  const permission = action === 'edit' ? 'write' : action;
+  const allowed = permission === 'write'
+    ? accessContext.permissions.write === true || accessContext.permissions.edit === true
+    : accessContext.permissions[permission] === true;
+  if (!allowed) {
     return false;
   }
 

--- a/lib/annotations.js
+++ b/lib/annotations.js
@@ -175,6 +175,19 @@ function buildReply(payload) {
   };
 }
 
+function redactReplies(replies, redactedAt, redactedBy) {
+  if (!Array.isArray(replies) || replies.length === 0) {
+    return [];
+  }
+
+  return replies.map((reply) => ({
+    ...reply,
+    body: '[reply redacted]',
+    redactedAt,
+    redactedBy,
+  }));
+}
+
 function applyAnnotationOperation(annotation, op, payload) {
   if (!annotation) {
     throw new Error('Annotation not found.');
@@ -217,8 +230,26 @@ function applyAnnotationOperation(annotation, op, payload) {
         ...annotation,
         replies: [...(Array.isArray(annotation.replies) ? annotation.replies : []), buildReply(payload)],
       };
+    case 'redact': {
+      const redactedBy = requireNonEmptyString(
+        payload && (payload.redactedBy || payload.author),
+        'payload.redactedBy'
+      );
+      const redactedAt = new Date().toISOString();
+      return {
+        ...annotation,
+        body: '[annotation redacted]',
+        state: 'resolved',
+        claimedBy: null,
+        claimedAt: null,
+        resolvedAt: redactedAt,
+        redactedAt,
+        redactedBy,
+        replies: redactReplies(annotation.replies, redactedAt, redactedBy),
+      };
+    }
     default:
-      throw new Error('Unsupported op. Expected claim, resolve, reopen, or reply.');
+      throw new Error('Unsupported op. Expected claim, resolve, reopen, reply, or redact.');
   }
 }
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -666,6 +666,34 @@ function decorateRenderedHtmlForAnnotations(html) {
     target.insertAdjacentHTML('afterend', mountMarkup);
   }
 
+  for (const target of document.querySelectorAll('[data-lookie-annotation-anchor]')) {
+    const declaredAnchor = (target.getAttribute('data-lookie-annotation-anchor') || '').trim();
+    const anchorId = declaredAnchor || target.id || slugify(target.textContent || '');
+    if (!anchorId) {
+      continue;
+    }
+
+    target.id = anchorId;
+    target.setAttribute('data-lookie-annotation-anchor', anchorId);
+    const anchorKind = 'heading';
+    const hasTargetButton = Array.from(target.querySelectorAll('[data-annotate-trigger]'))
+      .some((button) => button.getAttribute('data-anchor-id') === anchorId);
+    if (!hasTargetButton) {
+      const heading = target.matches('h1, h2, h3, h4, h5, h6')
+        ? target
+        : target.querySelector('h1, h2, h3, h4, h5, h6');
+      if (heading) {
+        heading.insertAdjacentHTML('beforeend', buildAnnotateButton(anchorId, anchorKind));
+      } else {
+        target.insertAdjacentHTML('beforeend', buildAnnotateButton(anchorId, anchorKind));
+      }
+    }
+
+    if (!hasAnnotationMount(document, anchorId)) {
+      target.insertAdjacentHTML('afterend', annotationMountMarkup(anchorId, anchorKind));
+    }
+  }
+
   return document.body.innerHTML;
 }
 
@@ -1018,6 +1046,7 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
   const heading = `${repo}/${relativePath}`;
   const rawSourceJson = supportsRawToggle ? jsonForInlineScript(source) : null;
   const rawLanguage = isMarkdown ? 'markdown' : isHtmlDocument ? 'xml' : isYaml ? 'yaml' : null;
+  const supportsLineRangeAnnotations = rendered.kind === 'code' || rendered.kind === 'text';
 
   const renderedClass = isMarkdown ? 'markdown' : rendered.kind;
   const contentHtml = `${hasToc ? `<article class="content toc-view" id="toc-view" data-toc-view hidden aria-hidden="true">
@@ -1052,6 +1081,7 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
     </header>
 
     ${contentHtml}
+    ${annotationsEnabled ? '<section class="lookie-line-range-root" data-annotations-line-range-root hidden></section>' : ''}
     ${annotationsEnabled ? '<aside class="lookie-annotations-stale" data-annotations-stale hidden></aside>' : ''}
   </main>`;
 
@@ -1060,6 +1090,8 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
         repo,
         relativePath,
         queryToken,
+        supportsLineRangeAnnotations,
+        sourceLineCount: source.split(/\r?\n/).length,
       })}</script>
   <script>
     (function () {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -614,6 +614,61 @@ function addYamlAnchorLinks(html) {
   );
 }
 
+function buildAnnotateButton(anchorId, anchorKind) {
+  return `<button type="button" class="lookie-annotate-btn" data-annotate-trigger data-anchor-id="${escapeHtml(anchorId)}" data-anchor-kind="${escapeHtml(anchorKind)}" aria-label="Annotate ${escapeHtml(anchorId)}" title="Annotate this section">💬</button>`;
+}
+
+function annotationMountMarkup(anchorId, anchorKind) {
+  return `<section class="lookie-annotations-mount" data-annotations-mount data-anchor-id="${escapeHtml(anchorId)}" data-anchor-kind="${escapeHtml(anchorKind)}"></section>`;
+}
+
+function hasAnnotationMount(document, anchorId) {
+  return Boolean(document.querySelector(`[data-annotations-mount][data-anchor-id="${anchorId}"]`));
+}
+
+function decorateRenderedHtmlForAnnotations(html) {
+  const dom = new JSDOM(`<body>${html}</body>`);
+  const { document } = dom.window;
+  const handledYamlPre = new WeakMap();
+
+  for (const link of document.querySelectorAll('.anchor-link[data-anchor-id]')) {
+    const anchorId = link.getAttribute('data-anchor-id');
+    if (!anchorId) {
+      continue;
+    }
+
+    const target = link.closest('h1, h2, h3, h4, h5, h6, .yaml-anchor-wrap');
+    if (!target) {
+      continue;
+    }
+
+    const anchorKind = /^H[1-6]$/.test(target.tagName) ? 'heading' : 'yamlKey';
+    if (!target.querySelector('[data-annotate-trigger]')) {
+      link.insertAdjacentHTML('afterend', buildAnnotateButton(anchorId, anchorKind));
+    }
+
+    if (hasAnnotationMount(document, anchorId)) {
+      continue;
+    }
+
+    const mountMarkup = annotationMountMarkup(anchorId, anchorKind);
+    if (target.classList.contains('yaml-anchor-wrap')) {
+      const pre = target.closest('pre');
+      if (!pre || !pre.parentNode) {
+        continue;
+      }
+      const prior = handledYamlPre.get(pre) || pre;
+      prior.insertAdjacentHTML('afterend', mountMarkup);
+      handledYamlPre.set(pre, prior.nextElementSibling || prior);
+      continue;
+    }
+
+    target.insertAdjacentHTML('afterend', mountMarkup);
+  }
+
+  return document.body.innerHTML;
+}
+
 function extractFrontmatter(markdownSource) {
   // Allow leading HTML comments, blank lines, or whitespace before ---
   const match = markdownSource.match(/^(?:\s*<!--[\s\S]*?-->\s*)*---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?/);
@@ -739,12 +794,20 @@ function getThemeList() {
   ];
 }
 
-function toolbarHtml(extraButtons = '') {
+function toolbarHtml(extraButtons = '', options = {}) {
   const themes = getThemeList();
-  const options = themes.map(t => `<option value="${t.slug}">${t.label}</option>`).join('');
+  const themeOptions = themes.map(t => `<option value="${t.slug}">${t.label}</option>`).join('');
+  const annotationChip = options.annotationsEnabled
+    ? '<button type="button" class="toolbar-btn toolbar-btn-annotation-count" data-annotations-toggle aria-label="Show or hide resolved annotations" aria-pressed="false" hidden>💬 0</button>'
+    : '';
+  const annotationModeButton = options.annotationModeAvailable
+    ? '<button type="button" class="toolbar-btn" data-annotation-mode-toggle aria-label="Show annotation targets" aria-pressed="false" title="Show annotation targets">💬 Annotate</button>'
+    : '';
   return `<div class="viewer-toolbar" role="toolbar" aria-label="Viewer controls">
     ${extraButtons}
-    <select class="toolbar-select" data-theme-picker aria-label="Select color theme">${options}</select>
+    ${annotationModeButton}
+    ${annotationChip}
+    <select class="toolbar-select" data-theme-picker aria-label="Select color theme">${themeOptions}</select>
     <button type="button" class="toolbar-btn" data-theme-toggle aria-label="Toggle light and dark mode">☀</button>
   </div>`;
 }
@@ -792,6 +855,20 @@ function themeScript() {
           var next = isLight ? 'dark' : 'light';
           applyTheme(next);
           localStorage.setItem('lookie-link-theme', next);
+        });
+      }
+
+      var annotationModeBtn = document.querySelector('[data-annotation-mode-toggle]');
+      if (annotationModeBtn) {
+        function setAnnotationMode(enabled) {
+          rootEl.classList.toggle('lookie-annotations-active', enabled);
+          annotationModeBtn.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+          annotationModeBtn.title = enabled ? 'Hide annotation targets' : 'Show annotation targets';
+          annotationModeBtn.setAttribute('aria-label', annotationModeBtn.title);
+        }
+
+        annotationModeBtn.addEventListener('click', function () {
+          setAnnotationMode(!rootEl.classList.contains('lookie-annotations-active'));
         });
       }
     }());
@@ -935,6 +1012,9 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
     currentDir: path.posix.dirname(relativePath) === '.' ? '' : path.posix.dirname(relativePath),
     queryToken,
   });
+  if (annotationsEnabled) {
+    rendered.html = decorateRenderedHtmlForAnnotations(rendered.html);
+  }
   const heading = `${repo}/${relativePath}`;
   const rawSourceJson = supportsRawToggle ? jsonForInlineScript(source) : null;
   const rawLanguage = isMarkdown ? 'markdown' : isHtmlDocument ? 'xml' : isYaml ? 'yaml' : null;
@@ -958,7 +1038,10 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
   ].filter(Boolean).join('\n    ');
 
-  const body = `${toolbarHtml(extraButtons)}
+  const body = `${toolbarHtml(extraButtons, {
+    annotationsEnabled,
+    annotationModeAvailable: annotationsEnabled,
+  })}
   <main class="layout">
     <header class="topbar">
       <h1>${escapeHtml(path.basename(relativePath))}</h1>
@@ -969,6 +1052,7 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
     </header>
 
     ${contentHtml}
+    ${annotationsEnabled ? '<aside class="lookie-annotations-stale" data-annotations-stale hidden></aside>' : ''}
   </main>`;
 
   const annotationsBootstrap = annotationsEnabled

--- a/public/annotations.js
+++ b/public/annotations.js
@@ -674,19 +674,6 @@
   }
 
   ready(() => {
-    window.addEventListener('message', (event) => {
-      if (event.origin !== window.location.origin) {
-        return;
-      }
-
-      const data = event.data || {};
-      if (data.type !== 'lookie-link:set-annotation-mode') {
-        return;
-      }
-
-      document.documentElement.classList.toggle('lookie-annotations-active', Boolean(data.enabled));
-    });
-
     bindAnnotateButtons();
     if (toolbarToggle) {
       toolbarToggle.addEventListener('click', () => {

--- a/public/annotations.js
+++ b/public/annotations.js
@@ -2,179 +2,243 @@
 
 (function () {
   const bootstrap = window.__lookieLinkAnnotations;
-  if (!bootstrap || !bootstrap.repo || !bootstrap.relativePath) return;
+  if (!bootstrap || !bootstrap.repo || !bootstrap.relativePath) {
+    return;
+  }
 
   const repo = bootstrap.repo;
   const relativePath = bootstrap.relativePath;
   const queryToken = bootstrap.queryToken || null;
+  const supportsLineRanges = Boolean(bootstrap.supportsLineRangeAnnotations);
   const apiBase = `/api/annotations/${encodeURIComponent(repo)}/${relativePath
     .split('/').map(encodeURIComponent).join('/')}`;
 
+  const mountSelector = '[data-annotations-mount][data-anchor-id]';
+  const toolbarToggle = document.querySelector('[data-annotations-toggle]');
+  const staleBucket = document.querySelector('[data-annotations-stale]');
+  const lineRangeRoot = document.querySelector('[data-annotations-line-range-root]');
+  const renderedView = document.querySelector('[data-rendered-view]');
+
+  let cachedDocument = null;
+  let cachedMtimeMs = null;
+  let showResolved = false;
+
   function withToken(url) {
-    if (!queryToken) return url;
-    const sep = url.includes('?') ? '&' : '?';
-    return `${url}${sep}token=${encodeURIComponent(queryToken)}`;
+    if (!queryToken) {
+      return url;
+    }
+    return `${url}${url.includes('?') ? '&' : '?'}token=${encodeURIComponent(queryToken)}`;
   }
 
   function getDefaultAuthor() {
     try {
       const stored = window.localStorage.getItem('lookieLinkAnnotationAuthor');
-      if (stored && stored.trim()) return stored.trim();
-    } catch (_) {}
+      if (stored && stored.trim()) {
+        return stored.trim();
+      }
+    } catch (_error) {
+      // Ignore storage failures.
+    }
     return '';
   }
 
   function setDefaultAuthor(value) {
-    if (!value) return;
-    try { window.localStorage.setItem('lookieLinkAnnotationAuthor', value); } catch (_) {}
+    if (!value) {
+      return;
+    }
+    try {
+      window.localStorage.setItem('lookieLinkAnnotationAuthor', value);
+    } catch (_error) {
+      // Ignore storage failures.
+    }
   }
 
   function el(tag, attrs, ...children) {
     const node = document.createElement(tag);
     if (attrs) {
-      for (const [k, v] of Object.entries(attrs)) {
-        if (k === 'class') node.className = v;
-        else if (k === 'dataset') {
-          for (const [dk, dv] of Object.entries(v)) node.dataset[dk] = dv;
-        } else if (k.startsWith('on') && typeof v === 'function') {
-          node.addEventListener(k.slice(2), v);
-        } else if (v !== null && v !== undefined) {
-          node.setAttribute(k, v);
+      for (const [key, value] of Object.entries(attrs)) {
+        if (value === null || value === undefined) {
+          continue;
+        }
+        if (key === 'class') {
+          node.className = value;
+        } else if (key === 'dataset') {
+          for (const [dataKey, dataValue] of Object.entries(value)) {
+            node.dataset[dataKey] = dataValue;
+          }
+        } else if (key === 'text') {
+          node.textContent = value;
+        } else if (key.startsWith('on') && typeof value === 'function') {
+          node.addEventListener(key.slice(2), value);
+        } else if (key === 'hidden') {
+          node.hidden = Boolean(value);
+        } else {
+          node.setAttribute(key, value);
         }
       }
     }
+
     for (const child of children) {
-      if (child === null || child === undefined) continue;
-      if (typeof child === 'string') node.appendChild(document.createTextNode(child));
-      else node.appendChild(child);
+      if (child === null || child === undefined) {
+        continue;
+      }
+      if (typeof child === 'string') {
+        node.appendChild(document.createTextNode(child));
+      } else {
+        node.appendChild(child);
+      }
     }
     return node;
   }
 
   function formatTimestamp(iso) {
-    if (!iso) return '';
-    try { return new Date(iso).toLocaleString(); } catch (_) { return iso; }
+    if (!iso) {
+      return '';
+    }
+    try {
+      return new Date(iso).toLocaleString();
+    } catch (_error) {
+      return iso;
+    }
   }
-
-  function classifyAnchor(element) {
-    if (!element) return 'lineRange';
-    if (/^H[1-6]$/.test(element.tagName)) return 'heading';
-    if (element.classList.contains('yaml-anchor-wrap')) return 'yamlKey';
-    return 'heading';
-  }
-
-  let cachedMtimeMs = null;
-  const annotationsByAnchor = new Map();
 
   async function api(method, path, body) {
-    const init = { method, headers: { 'Content-Type': 'application/json' } };
-    if (body !== undefined) init.body = JSON.stringify(body);
-    const res = await fetch(withToken(path), init);
-    let data = null;
-    try { data = await res.json(); } catch (_) {}
-    if (!res.ok) {
-      const message = (data && data.error) || `HTTP ${res.status}`;
-      const err = new Error(message);
-      err.status = res.status;
-      err.data = data;
-      throw err;
+    const init = {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+    };
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
     }
+
+    const response = await fetch(withToken(path), init);
+    let data = null;
+    try {
+      data = await response.json();
+    } catch (_error) {
+      data = null;
+    }
+
+    if (!response.ok) {
+      const error = new Error((data && data.error) || `HTTP ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
     return data;
   }
 
-  function buildAnnotateButton(anchorId, anchorKind) {
-    const btn = el('button', {
-      type: 'button',
-      class: 'lookie-annotate-btn',
-      'aria-label': `Annotate ${anchorId}`,
-      title: 'Add annotation',
-      dataset: { anchorId, anchorKind },
-    }, '💬');
-    btn.addEventListener('click', (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      openAnnotateForm(anchorId, anchorKind);
-    });
-    return btn;
+  function parseLineRange(anchor) {
+    const match = String(anchor || '').match(/^#L(\d+)-L(\d+)$/);
+    if (!match) {
+      return null;
+    }
+    return {
+      start: Number(match[1]),
+      end: Number(match[2]),
+    };
   }
 
-  function getOrCreateAnchorCard(anchorId) {
-    let card = document.querySelector(
-      `.lookie-annotation-card[data-anchor-id="${CSS.escape(anchorId)}"]`);
-    if (card) return card;
-
-    const target = document.getElementById(anchorId);
-    if (!target) return null;
-
-    card = el('aside', { class: 'lookie-annotation-card', dataset: { anchorId } });
-    let insertAfter = target;
-    if (target.classList.contains('yaml-anchor-wrap')) {
-      const preParent = target.closest('pre');
-      if (preParent) insertAfter = preParent;
+  function getSourceLineCount() {
+    if (Number.isFinite(Number(bootstrap.sourceLineCount))) {
+      return Number(bootstrap.sourceLineCount);
     }
-    if (insertAfter.parentNode) {
-      insertAfter.parentNode.insertBefore(card, insertAfter.nextSibling);
-    }
-    return card;
+    const codeNode = renderedView ? renderedView.querySelector('pre code, pre') : null;
+    const raw = codeNode ? codeNode.textContent || '' : '';
+    return raw ? raw.split(/\r?\n/).length : 1;
   }
 
-  function renderAnnotationList(anchorId) {
-    const card = getOrCreateAnchorCard(anchorId);
-    if (!card) return;
-    card.innerHTML = '';
-    const items = annotationsByAnchor.get(anchorId) || [];
-    if (items.length === 0) { card.remove(); return; }
-    card.appendChild(el('div', { class: 'lookie-annotation-card-header' },
-      `Annotations on ${anchorId} (${items.length})`));
-    for (const annotation of items) {
-      card.appendChild(renderAnnotationItem(annotation));
+  function getMount(anchorId) {
+    return document.querySelector(`${mountSelector}[data-anchor-id="${CSS.escape(anchorId)}"]`);
+  }
+
+  function lineRangeAnchorId(anchor) {
+    return String(anchor || '').replace(/^#/, '');
+  }
+
+  function updateToolbarCount(total, resolvedCount) {
+    if (!toolbarToggle) {
+      return;
     }
+    toolbarToggle.hidden = false;
+    toolbarToggle.textContent = `💬 ${total}`;
+    toolbarToggle.setAttribute('aria-pressed', showResolved ? 'true' : 'false');
+    toolbarToggle.title = showResolved
+      ? 'Hide resolved annotations'
+      : resolvedCount > 0
+        ? `Show ${resolvedCount} resolved annotation${resolvedCount === 1 ? '' : 's'}`
+        : 'Resolved annotations are hidden';
+  }
+
+  function summarizeText(value, maxLength) {
+    const text = String(value || '').replace(/\s+/g, ' ').trim();
+    if (text.length <= maxLength) {
+      return text;
+    }
+
+    return `${text.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
   }
 
   function renderAnnotationItem(annotation) {
-    const stateClass = `lookie-annotation-state lookie-annotation-state-${annotation.state}`;
-    const item = el('article', {
+    const replyCount = Array.isArray(annotation.replies) ? annotation.replies.length : 0;
+    const item = el('details', {
       class: 'lookie-annotation-item',
-      dataset: { annotationId: annotation.id, state: annotation.state },
+      dataset: {
+        annotationId: annotation.id,
+        state: annotation.state,
+      },
     });
-    item.appendChild(el('header', { class: 'lookie-annotation-item-header' },
-      el('span', { class: stateClass }, annotation.state),
+
+    item.appendChild(el(
+      'summary',
+      { class: 'lookie-annotation-summary' },
+      el('span', { class: `lookie-annotation-state lookie-annotation-state-${annotation.state}` }, annotation.state),
       el('span', { class: 'lookie-annotation-author' }, annotation.author || 'anonymous'),
-      el('time', { class: 'lookie-annotation-time', datetime: annotation.createdAt },
-        formatTimestamp(annotation.createdAt)),
+      el('time', { class: 'lookie-annotation-time', datetime: annotation.createdAt }, formatTimestamp(annotation.createdAt)),
+      replyCount > 0
+        ? el('span', { class: 'lookie-annotation-reply-count' }, `${replyCount} repl${replyCount === 1 ? 'y' : 'ies'}`)
+        : el('span', { class: 'lookie-annotation-reply-count lookie-annotation-reply-count-empty', 'aria-hidden': 'true' }, ''),
+      el('span', { class: 'lookie-annotation-preview' }, summarizeText(annotation.body, 110))
     ));
-    item.appendChild(el('p', { class: 'lookie-annotation-body' }, annotation.body));
+
+    const detail = el('div', { class: 'lookie-annotation-detail' });
+    detail.appendChild(el('p', { class: 'lookie-annotation-body' }, annotation.body));
 
     if (Array.isArray(annotation.replies) && annotation.replies.length > 0) {
       const replies = el('ul', { class: 'lookie-annotation-replies' });
       for (const reply of annotation.replies) {
-        replies.appendChild(el('li', { class: 'lookie-annotation-reply' },
+        replies.appendChild(el(
+          'li',
+          { class: 'lookie-annotation-reply' },
           el('span', { class: 'lookie-annotation-author' }, reply.author || 'anonymous'),
           el('time', { datetime: reply.createdAt }, formatTimestamp(reply.createdAt)),
-          el('p', { class: 'lookie-annotation-body' }, reply.body),
+          el('p', { class: 'lookie-annotation-body' }, reply.body)
         ));
       }
-      item.appendChild(replies);
+      detail.appendChild(replies);
     }
 
     const actions = el('div', { class: 'lookie-annotation-actions' });
     if (annotation.state === 'open') {
-      actions.appendChild(makeOpBtn('Claim', annotation, 'claim'));
-      actions.appendChild(makeOpBtn('Resolve', annotation, 'resolve'));
+      actions.appendChild(makeOpButton('Claim', annotation, 'claim'));
+      actions.appendChild(makeOpButton('Resolve', annotation, 'resolve'));
     } else if (annotation.state === 'claimed') {
-      actions.appendChild(el('span', { class: 'lookie-annotation-claimed-by' },
-        `claimed by ${annotation.claimedBy || 'unknown'}`));
-      actions.appendChild(makeOpBtn('Resolve', annotation, 'resolve'));
-      actions.appendChild(makeOpBtn('Reopen', annotation, 'reopen'));
+      actions.appendChild(el('span', { class: 'lookie-annotation-claimed-by' }, `claimed by ${annotation.claimedBy || 'unknown'}`));
+      actions.appendChild(makeOpButton('Resolve', annotation, 'resolve'));
+      actions.appendChild(makeOpButton('Reopen', annotation, 'reopen'));
     } else if (annotation.state === 'resolved') {
-      actions.appendChild(makeOpBtn('Reopen', annotation, 'reopen'));
+      actions.appendChild(makeOpButton('Reopen', annotation, 'reopen'));
     }
-    actions.appendChild(makeReplyBtn(annotation));
-    item.appendChild(actions);
+    actions.appendChild(makeOpButton('Redact', annotation, 'redact'));
+    actions.appendChild(makeReplyButton(annotation));
+    detail.appendChild(actions);
+    item.appendChild(detail);
+
     return item;
   }
 
-  function makeOpBtn(label, annotation, op) {
+  function makeOpButton(label, annotation, op) {
     return el('button', {
       type: 'button',
       class: `lookie-annotation-op lookie-annotation-op-${op}`,
@@ -183,12 +247,24 @@
           const payload = {};
           if (op === 'claim') {
             const claimedBy = window.prompt('Claim as (your name)?', getDefaultAuthor() || '');
-            if (!claimedBy) return;
-            setDefaultAuthor(claimedBy);
-            payload.claimedBy = claimedBy;
+            if (!claimedBy || !claimedBy.trim()) {
+              return;
+            }
+            payload.claimedBy = claimedBy.trim();
+            setDefaultAuthor(payload.claimedBy);
+          } else if (op === 'redact') {
+            const redactedBy = window.prompt('Redact as (your name)?', getDefaultAuthor() || '');
+            if (!redactedBy || !redactedBy.trim()) {
+              return;
+            }
+            const confirmed = window.confirm('Redact this annotation body and all reply bodies? This cannot be undone.');
+            if (!confirmed) {
+              return;
+            }
+            payload.redactedBy = redactedBy.trim();
+            setDefaultAuthor(payload.redactedBy);
           }
           await patchAnnotation(annotation.id, op, payload);
-          await refreshAnnotations();
         } catch (error) {
           window.alert(`Annotation ${op} failed: ${error.message}`);
         }
@@ -196,19 +272,25 @@
     }, label);
   }
 
-  function makeReplyBtn(annotation) {
+  function makeReplyButton(annotation) {
     return el('button', {
       type: 'button',
       class: 'lookie-annotation-op lookie-annotation-op-reply',
       onclick: async () => {
         const author = window.prompt('Your name?', getDefaultAuthor() || '');
-        if (!author) return;
+        if (!author || !author.trim()) {
+          return;
+        }
         const body = window.prompt('Reply body?');
-        if (!body || !body.trim()) return;
-        setDefaultAuthor(author);
+        if (!body || !body.trim()) {
+          return;
+        }
+        setDefaultAuthor(author.trim());
         try {
-          await patchAnnotation(annotation.id, 'reply', { author, body: body.trim() });
-          await refreshAnnotations();
+          await patchAnnotation(annotation.id, 'reply', {
+            author: author.trim(),
+            body: body.trim(),
+          });
         } catch (error) {
           window.alert(`Annotation reply failed: ${error.message}`);
         }
@@ -216,28 +298,210 @@
     }, 'Reply');
   }
 
-  async function patchAnnotation(id, op, payload) {
-    return api('PATCH', apiBase, { id, op, payload, expectedMtimeMs: cachedMtimeMs });
+  function clearAnchorMounts() {
+    document.querySelectorAll(mountSelector).forEach((mount) => {
+      mount.innerHTML = '';
+      mount.hidden = true;
+    });
   }
 
-  function openAnnotateForm(anchorId, anchorKind) {
-    document.querySelectorAll('.lookie-annotate-form').forEach((node) => node.remove());
-    const card = getOrCreateAnchorCard(anchorId);
-    if (!card) return;
+  function clearLineRangeRoot() {
+    if (!lineRangeRoot) {
+      return;
+    }
+    lineRangeRoot.innerHTML = '';
+    lineRangeRoot.hidden = true;
+  }
 
-    const form = el('form', { class: 'lookie-annotate-form', dataset: { anchorId } });
+  function clearStaleBucket() {
+    if (!staleBucket) {
+      return;
+    }
+    staleBucket.innerHTML = '';
+    staleBucket.hidden = true;
+  }
+
+  function createCard(title, anchorId) {
+    return el(
+      'section',
+      {
+        class: 'lookie-annotation-card',
+        dataset: anchorId ? { anchorId } : {},
+      },
+      el('div', { class: 'lookie-annotation-card-header' }, title)
+    );
+  }
+
+  function renderGroup(card, annotations) {
+    for (const annotation of annotations) {
+      card.appendChild(renderAnnotationItem(annotation));
+    }
+  }
+
+  function ensureLineRangePicker() {
+    if (!supportsLineRanges || !lineRangeRoot) {
+      return;
+    }
+
+    lineRangeRoot.hidden = false;
+    const lineCount = Math.max(1, getSourceLineCount());
+    const title = el('div', { class: 'lookie-annotation-card-header' }, `Line-range annotations (${lineCount} lines)`);
+    const groups = el('div', { class: 'lookie-line-range-groups', dataset: { role: 'groups' } });
+
+    const form = el('form', { class: 'lookie-line-range-form', dataset: { role: 'lineRangeForm' } });
+    const startInput = el('input', {
+      type: 'number',
+      min: '1',
+      max: String(lineCount),
+      name: 'start',
+      placeholder: 'Start line',
+      required: 'required',
+      value: '1',
+    });
+    const endInput = el('input', {
+      type: 'number',
+      min: '1',
+      max: String(lineCount),
+      name: 'end',
+      placeholder: 'End line',
+      required: 'required',
+      value: '1',
+    });
     const authorInput = el('input', {
-      type: 'text', name: 'author', placeholder: 'Your name',
-      required: 'required', value: getDefaultAuthor(),
+      type: 'text',
+      name: 'author',
+      placeholder: 'Your name',
+      required: 'required',
+      value: getDefaultAuthor(),
     });
     const bodyInput = el('textarea', {
-      name: 'body', placeholder: 'What needs attention?',
-      required: 'required', rows: '3',
+      name: 'body',
+      rows: '3',
+      placeholder: 'What needs attention in this range?',
+      required: 'required',
+    });
+    const submit = el('button', { type: 'submit', class: 'lookie-annotation-submit' }, 'Annotate lines');
+
+    form.appendChild(el('div', { class: 'lookie-line-range-row' }, startInput, endInput, authorInput));
+    form.appendChild(bodyInput);
+    form.appendChild(el('div', { class: 'lookie-annotate-form-actions' }, submit));
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const start = Number(startInput.value);
+      const end = Number(endInput.value);
+      const author = authorInput.value.trim();
+      const body = bodyInput.value.trim();
+      if (!Number.isInteger(start) || !Number.isInteger(end) || start < 1 || end < start || end > lineCount) {
+        window.alert(`Choose a valid line range between 1 and ${lineCount}.`);
+        return;
+      }
+      if (!author || !body) {
+        return;
+      }
+
+      setDefaultAuthor(author);
+      submit.disabled = true;
+      try {
+        await createAnnotation({
+          anchor: `#L${start}-L${end}`,
+          anchorKind: 'lineRange',
+          author,
+          body,
+        });
+        bodyInput.value = '';
+      } catch (error) {
+        window.alert(`Save annotation failed: ${error.message}`);
+      } finally {
+        submit.disabled = false;
+      }
+    });
+
+    lineRangeRoot.appendChild(title);
+    lineRangeRoot.appendChild(form);
+    lineRangeRoot.appendChild(groups);
+  }
+
+  function addLineRangeGroups(annotations) {
+    if (!supportsLineRanges || !lineRangeRoot) {
+      return;
+    }
+
+    const groups = lineRangeRoot.querySelector('[data-role="groups"]');
+    if (!groups) {
+      return;
+    }
+
+    const sortedEntries = Array.from(annotations.entries()).sort((left, right) => {
+      const leftRange = parseLineRange(left[0]);
+      const rightRange = parseLineRange(right[0]);
+      return (leftRange ? leftRange.start : 0) - (rightRange ? rightRange.start : 0);
+    });
+
+    for (const [anchor, items] of sortedEntries) {
+      const range = parseLineRange(anchor);
+      if (!range) {
+        continue;
+      }
+      const card = createCard(`Lines ${range.start}-${range.end}`, lineRangeAnchorId(anchor));
+      renderGroup(card, items);
+      groups.appendChild(card);
+    }
+  }
+
+  function renderStaleAnnotations(annotations) {
+    if (!staleBucket || annotations.length === 0) {
+      return;
+    }
+
+    staleBucket.hidden = false;
+    staleBucket.appendChild(el('h2', { class: 'lookie-stale-title' }, `Stale anchors (${annotations.length})`));
+    for (const annotation of annotations) {
+      const label = annotation.anchorKind === 'lineRange'
+        ? `Missing line range ${annotation.anchor}`
+        : `Missing anchor ${annotation.anchor}`;
+      const card = createCard(label, lineRangeAnchorId(annotation.anchor));
+      renderGroup(card, [annotation]);
+      staleBucket.appendChild(card);
+    }
+  }
+
+  function openAnchorForm(anchorId, anchorKind) {
+    const mount = getMount(anchorId);
+    if (!mount) {
+      return;
+    }
+
+    mount.hidden = false;
+    const prior = mount.querySelector('.lookie-annotate-form');
+    if (prior) {
+      prior.remove();
+    }
+
+    const form = el('form', { class: 'lookie-annotate-form' });
+    const authorInput = el('input', {
+      type: 'text',
+      name: 'author',
+      placeholder: 'Your name',
+      required: 'required',
+      value: getDefaultAuthor(),
+    });
+    const bodyInput = el('textarea', {
+      name: 'body',
+      rows: '3',
+      placeholder: 'What needs attention?',
+      required: 'required',
     });
     const submit = el('button', { type: 'submit', class: 'lookie-annotation-submit' }, 'Save annotation');
     const cancel = el('button', {
-      type: 'button', class: 'lookie-annotation-cancel',
-      onclick: () => form.remove(),
+      type: 'button',
+      class: 'lookie-annotation-cancel',
+      onclick: () => {
+        form.remove();
+        if (!mount.querySelector('.lookie-annotation-item')) {
+          mount.hidden = true;
+        }
+      },
     }, 'Cancel');
 
     form.appendChild(authorInput);
@@ -248,71 +512,157 @@
       event.preventDefault();
       const author = authorInput.value.trim();
       const body = bodyInput.value.trim();
-      if (!author || !body) return;
+      if (!author || !body) {
+        return;
+      }
       setDefaultAuthor(author);
       submit.disabled = true;
       try {
-        await api('POST', apiBase, {
-          anchor: `#${anchorId}`, anchorKind, author, body,
+        await createAnnotation({
+          anchor: `#${anchorId}`,
+          anchorKind,
+          author,
+          body,
         });
-        form.remove();
-        await refreshAnnotations();
       } catch (error) {
         window.alert(`Save annotation failed: ${error.message}`);
         submit.disabled = false;
+        return;
       }
+      form.remove();
     });
 
-    card.appendChild(form);
+    mount.appendChild(form);
     bodyInput.focus();
+  }
+
+  function applyDocument(doc, mtimeMs) {
+    cachedDocument = doc;
+    cachedMtimeMs = mtimeMs === undefined ? null : mtimeMs;
+
+    clearAnchorMounts();
+    clearLineRangeRoot();
+    clearStaleBucket();
+
+    if (!doc || !Array.isArray(doc.annotations)) {
+      updateToolbarCount(0, 0);
+      if (supportsLineRanges) {
+        ensureLineRangePicker();
+      }
+      return;
+    }
+
+    const totalCount = doc.annotations.length;
+    const resolvedCount = doc.annotations.filter((annotation) => annotation.state === 'resolved').length;
+    updateToolbarCount(totalCount, resolvedCount);
+
+    const anchored = new Map();
+    const lineRanges = new Map();
+    const stale = [];
+    const sourceLineCount = Math.max(1, getSourceLineCount());
+
+    for (const annotation of doc.annotations) {
+      if (annotation.state === 'resolved' && !showResolved) {
+        continue;
+      }
+
+      if (annotation.anchorKind === 'lineRange') {
+        const range = parseLineRange(annotation.anchor);
+        if (!range || range.end > sourceLineCount) {
+          stale.push(annotation);
+          continue;
+        }
+        const bucket = lineRanges.get(annotation.anchor) || [];
+        bucket.push(annotation);
+        lineRanges.set(annotation.anchor, bucket);
+        continue;
+      }
+
+      const anchorId = lineRangeAnchorId(annotation.anchor);
+      const mount = getMount(anchorId);
+      const anchorNode = document.getElementById(anchorId);
+      if (!mount || !anchorNode) {
+        stale.push(annotation);
+        continue;
+      }
+      const bucket = anchored.get(anchorId) || [];
+      bucket.push(annotation);
+      anchored.set(anchorId, bucket);
+    }
+
+    for (const [anchorId, annotations] of anchored.entries()) {
+      const mount = getMount(anchorId);
+      if (!mount) {
+        continue;
+      }
+      const title = mount.dataset.anchorKind === 'yamlKey'
+        ? `Annotations on ${anchorId}`
+        : `Annotations on ${anchorId}`;
+      const card = createCard(title, anchorId);
+      renderGroup(card, annotations);
+      mount.hidden = false;
+      mount.appendChild(card);
+    }
+
+    if (supportsLineRanges) {
+      ensureLineRangePicker();
+      addLineRangeGroups(lineRanges);
+    }
+
+    renderStaleAnnotations(stale);
   }
 
   async function refreshAnnotations() {
     try {
       const doc = await api('GET', apiBase);
-      cachedMtimeMs = doc.mtimeMs || null;
-      annotationsByAnchor.clear();
-      for (const annotation of doc.annotations || []) {
-        const anchorId = String(annotation.anchor || '').replace(/^#/, '');
-        if (!anchorId) continue;
-        const list = annotationsByAnchor.get(anchorId) || [];
-        list.push(annotation);
-        annotationsByAnchor.set(anchorId, list);
-      }
-      const seen = new Set();
-      for (const [anchorId] of annotationsByAnchor) {
-        renderAnnotationList(anchorId);
-        seen.add(anchorId);
-      }
-      document.querySelectorAll('.lookie-annotation-card').forEach((node) => {
-        if (!seen.has(node.dataset.anchorId)) node.remove();
-      });
+      applyDocument(doc, doc.mtimeMs);
     } catch (error) {
       console.warn('Lookie-Link: failed to load annotations', error);
     }
   }
 
-  function injectAnnotateButtons() {
-    const root = document.querySelector('article.content[data-rendered-view]')
-      || document.querySelector('article.content');
-    if (!root) return;
-    const targets = root.querySelectorAll(
-      'h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], span.yaml-anchor-wrap[id]'
-    );
-    for (const target of targets) {
-      if (target.dataset.lookieAnnotateInjected) continue;
-      target.dataset.lookieAnnotateInjected = '1';
-      const anchorId = target.id;
-      if (!anchorId) continue;
-      const kind = classifyAnchor(target);
-      const btn = buildAnnotateButton(anchorId, kind);
-      if (/^H[1-6]$/.test(target.tagName)) {
-        target.appendChild(document.createTextNode(' '));
-        target.appendChild(btn);
-      } else {
-        target.appendChild(btn);
+  async function createAnnotation(payload) {
+    const result = await api('POST', apiBase, payload);
+    cachedMtimeMs = result.mtimeMs === undefined ? cachedMtimeMs : result.mtimeMs;
+    await refreshAnnotations();
+    return result;
+  }
+
+  async function patchAnnotation(id, op, payload) {
+    try {
+      const result = await api('PATCH', apiBase, {
+        id,
+        op,
+        payload,
+        expectedMtimeMs: cachedMtimeMs,
+      });
+      cachedMtimeMs = result.mtimeMs === undefined ? cachedMtimeMs : result.mtimeMs;
+      await refreshAnnotations();
+      return result;
+    } catch (error) {
+      if (error.status === 409 && error.data && error.data.current) {
+        applyDocument(error.data.current, error.data.currentMtimeMs);
       }
+      throw error;
     }
+  }
+
+  function bindAnnotateButtons() {
+    document.querySelectorAll('[data-annotate-trigger][data-anchor-id]').forEach((button) => {
+      if (button.dataset.lookieBound === '1') {
+        return;
+      }
+      button.dataset.lookieBound = '1';
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        const anchorId = button.dataset.anchorId;
+        const anchorKind = button.dataset.anchorKind || 'heading';
+        if (!anchorId) {
+          return;
+        }
+        openAnchorForm(anchorId, anchorKind);
+      });
+    });
   }
 
   function ready(callback) {
@@ -324,7 +674,28 @@
   }
 
   ready(() => {
-    injectAnnotateButtons();
+    window.addEventListener('message', (event) => {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+
+      const data = event.data || {};
+      if (data.type !== 'lookie-link:set-annotation-mode') {
+        return;
+      }
+
+      document.documentElement.classList.toggle('lookie-annotations-active', Boolean(data.enabled));
+    });
+
+    bindAnnotateButtons();
+    if (toolbarToggle) {
+      toolbarToggle.addEventListener('click', () => {
+        showResolved = !showResolved;
+        if (cachedDocument) {
+          applyDocument(cachedDocument, cachedMtimeMs);
+        }
+      });
+    }
     refreshAnnotations();
   });
 })();

--- a/public/style.css
+++ b/public/style.css
@@ -1059,15 +1059,24 @@ tbody tr:last-child td {
 
 /* Annotations (Phase 1) */
 .lookie-annotate-btn {
-  display: inline-block; margin-left: 0.4rem; padding: 0 0.3rem;
-  font-size: 0.8em; line-height: 1.4; background: transparent;
-  border: 1px solid var(--border); border-radius: 4px;
-  color: var(--text-soft); cursor: pointer; opacity: 0.55;
+  display: inline-flex; align-items: center; gap: 0.2rem;
+  margin-left: 0.4rem; padding: 0.08rem 0.45rem;
+  font-size: 0.76em; line-height: 1.4; background: transparent;
+  border: 1px solid var(--border); border-radius: 999px;
+  color: var(--text-soft); cursor: pointer; opacity: 0.72;
   vertical-align: baseline;
   transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
+.lookie-annotate-btn { display: none; }
+.lookie-annotations-active .lookie-annotate-btn {
+  display: inline-flex;
+}
 .lookie-annotate-btn:hover, .lookie-annotate-btn:focus {
   opacity: 1; color: var(--accent); border-color: var(--accent);
+}
+.toolbar-btn-annotation-count[aria-pressed="true"] {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 .lookie-annotation-card {
   margin: 0.4rem 0 1.1rem; padding: 0.7rem 0.85rem 0.85rem;
@@ -1076,11 +1085,51 @@ tbody tr:last-child td {
   font-size: 0.93em;
 }
 .lookie-annotation-card-header { font-weight: 600; color: var(--text-soft); margin-bottom: 0.55rem; }
-.lookie-annotation-item { padding: 0.45rem 0; border-top: 1px dashed var(--border); }
+.lookie-annotation-item { padding: 0.32rem 0; border-top: 1px dashed var(--border); }
 .lookie-annotation-item:first-of-type { border-top: none; }
-.lookie-annotation-item-header {
-  display: flex; align-items: center; gap: 0.55rem;
-  margin-bottom: 0.3rem; font-size: 0.85em; color: var(--text-soft);
+.lookie-annotation-summary {
+  display: grid;
+  grid-template-columns: auto auto auto auto minmax(0, 1fr);
+  align-items: center;
+  column-gap: 0.48rem;
+  row-gap: 0.14rem;
+  min-width: 0;
+  font-size: 0.85em; color: var(--text-soft);
+  cursor: pointer;
+  list-style: none;
+}
+.lookie-annotation-summary::-webkit-details-marker { display: none; }
+.lookie-annotation-summary::before {
+  content: '▸';
+  color: var(--text-soft);
+  transform: translateY(-0.02rem);
+}
+.lookie-annotation-item[open] > .lookie-annotation-summary { margin-bottom: 0.3rem; }
+.lookie-annotation-item[open] > .lookie-annotation-summary::before { content: '▾'; }
+.lookie-annotation-preview {
+  min-width: 0;
+  grid-column: 1 / -1;
+  padding-left: 1.35rem;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+.lookie-annotation-reply-count {
+  flex: 0 0 auto;
+  justify-self: end;
+  padding: 0.05rem 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-soft);
+  font-size: 0.78em;
+}
+.lookie-annotation-reply-count-empty {
+  visibility: hidden;
+}
+.lookie-annotation-detail {
+  padding-left: 1.4rem;
 }
 .lookie-annotation-state {
   text-transform: uppercase; font-size: 0.72em; letter-spacing: 0.07em;
@@ -1091,7 +1140,11 @@ tbody tr:last-child td {
 .lookie-annotation-state-claimed { background: rgba(0, 132, 255, 0.16); color: #196edc; }
 .lookie-annotation-state-resolved { background: rgba(0, 168, 92, 0.16); color: #008a4d; }
 .lookie-annotation-author { font-weight: 600; color: var(--text); }
-.lookie-annotation-time { margin-left: auto; font-variant-numeric: tabular-nums; }
+.lookie-annotation-time {
+  color: var(--text-soft);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
 .lookie-annotation-body { white-space: pre-wrap; margin: 0.15rem 0 0.45rem; color: var(--text); }
 .lookie-annotation-replies {
   margin: 0.3rem 0 0.4rem 0.4rem; padding-left: 0.6rem;
@@ -1125,3 +1178,48 @@ tbody tr:last-child td {
 }
 .lookie-annotation-submit { background: var(--accent); color: var(--bg); border-color: var(--accent); }
 .lookie-annotation-cancel { background: transparent; color: var(--text-soft); }
+.lookie-line-range-root,
+.lookie-annotations-stale {
+  margin: 1rem 0 1.4rem;
+}
+.lookie-line-range-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin: 0 0 0.9rem;
+  padding: 0.7rem 0.85rem 0.85rem;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  background: var(--bg-elev);
+}
+.lookie-line-range-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+.lookie-line-range-form input,
+.lookie-line-range-form textarea {
+  font: inherit;
+  padding: 0.35rem 0.5rem;
+  background: var(--bg-code);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.lookie-line-range-form textarea {
+  min-height: 4.5rem;
+  resize: vertical;
+}
+.lookie-line-range-groups:empty {
+  display: none;
+}
+.lookie-stale-title {
+  margin: 0 0 0.65rem;
+  font-size: 0.95rem;
+  color: var(--text-soft);
+}
+@media (max-width: 720px) {
+  .lookie-line-range-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/scripts/validate-editable-mode.js
+++ b/scripts/validate-editable-mode.js
@@ -102,6 +102,7 @@ async function run() {
   await fs.mkdir(path.join(repoDir, 'images'));
 
   await fs.writeFile(path.join(repoDir, 'doc.md'), '# Hello\n\nInitial\n', 'utf8');
+  await fs.writeFile(path.join(repoDir, 'notes.txt'), 'alpha\nbeta\ngamma\ndelta\n', 'utf8');
   await fs.writeFile(path.join(repoDir, 'config.yaml'), 'name: before\n', 'utf8');
   await fs.writeFile(
     path.join(repoDir, 'nested.yaml'),
@@ -283,6 +284,7 @@ async function run() {
       schema: 1,
       file: 'docs/doc.md',
       annotations: [],
+      mtimeMs: null,
     }, 'annotation GET empty shape mismatch');
   }
 
@@ -403,6 +405,7 @@ async function run() {
 
     assert.equal(res.statusCode, 200, 'annotation GET filter failed');
     assert.equal(res.body.annotations.length, 1, 'annotation open filter mismatch');
+    assert.equal(typeof res.body.mtimeMs, 'number', 'annotation GET missing current mtime');
 
     const filteredResolved = createMockRes();
     await annotationsGet({
@@ -470,6 +473,10 @@ async function run() {
     assert(typeof res.body === 'string', 'annotations-enabled view body missing');
     assert(res.body.includes('/public/annotations.js'), 'annotations script not injected when enabled');
     assert(res.body.includes('lookie-link-annotations-bootstrap'), 'annotations bootstrap script tag missing when enabled');
+    assert(res.body.includes('data-annotate-trigger'), 'server-rendered annotate affordance missing');
+    assert(res.body.includes('data-annotations-mount'), 'server-rendered annotation mount missing');
+    assert(res.body.includes('data-annotations-stale'), 'stale annotations slot missing');
+    assert(res.body.includes('data-annotations-toggle'), 'annotation toolbar chip missing');
   }
 
   {
@@ -478,6 +485,15 @@ async function run() {
     assert.equal(res.statusCode, 200, 'annotations-disabled view failed');
     assert(!res.body.includes('/public/annotations.js'), 'annotations script leaked into view when disabled');
     assert(!res.body.includes('lookie-link-annotations-bootstrap'), 'annotations bootstrap leaked into view when disabled');
+  }
+
+  {
+    const res = createMockRes();
+    await viewWithAnnotations({ params: { 0: 'docs/notes.txt' } }, res);
+    assert.equal(res.statusCode, 200, 'annotations-enabled text view failed');
+    assert(typeof res.body === 'string', 'annotations-enabled text view body missing');
+    assert(res.body.includes('"supportsLineRangeAnnotations":true'), 'line-range bootstrap missing for plain-text view');
+    assert(res.body.includes('data-annotations-line-range-root'), 'line-range root missing for plain-text view');
   }
 
   // CLI shim coverage — spawn the CLI against a real HTTP listener

--- a/server.js
+++ b/server.js
@@ -1142,7 +1142,7 @@ function createApp(options = {}) {
       return;
     }
 
-    if (!canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+    if (!canAccessPath(accessContext, 'write', repo, relativePath, 'file')) {
       sendAccessError(res, accessContext, true);
       return;
     }
@@ -1224,7 +1224,7 @@ function createApp(options = {}) {
       return;
     }
 
-    if (!canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+    if (!canAccessPath(accessContext, 'write', repo, relativePath, 'file')) {
       sendAccessError(res, accessContext, true);
       return;
     }
@@ -1280,6 +1280,7 @@ function createApp(options = {}) {
         error.message === 'payload.claimedBy is required.' ||
         error.message === 'payload.author is required.' ||
         error.message === 'payload.body is required.' ||
+        error.message === 'payload.redactedBy is required.' ||
         error.message === 'Invalid expectedMtimeMs value.'
       ) {
         const status = error.message === 'Annotation not found.' ? 404 : 400;

--- a/server.js
+++ b/server.js
@@ -1104,7 +1104,10 @@ function createApp(options = {}) {
           ? [req.query.state]
           : [];
       const filtered = filterAnnotationsByState(result.document, states);
-      res.status(200).json(filtered);
+      res.status(200).json({
+        ...filtered,
+        mtimeMs: result.mtimeMs,
+      });
     } catch (error) {
       if (error instanceof SyntaxError) {
         res.status(500).json({ ok: false, error: 'Annotation sidecar contains invalid JSON.' });

--- a/test/annotations-client.test.js
+++ b/test/annotations-client.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'public', 'annotations.js');
+const SCRIPT_SOURCE = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function bootDom({ body, bootstrap, fetchImpl }) {
+  const dom = new JSDOM(`<!doctype html><html><body>${body}</body></html>`, {
+    url: 'http://127.0.0.1:9876/view/docs/doc.md',
+    runScripts: 'outside-only',
+  });
+
+  const { window } = dom;
+  window.__lookieLinkAnnotations = bootstrap;
+  window.fetch = fetchImpl;
+  window.alert = () => {};
+  window.prompt = () => '';
+  window.confirm = () => false;
+  if (!window.CSS) {
+    window.CSS = {};
+  }
+  if (!window.CSS.escape) {
+    window.CSS.escape = (value) => String(value).replace(/"/g, '\\"');
+  }
+
+  window.eval(SCRIPT_SOURCE);
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  await flush();
+  await flush();
+  return dom;
+}
+
+test('annotation client renders stale annotations and toggles resolved visibility', async () => {
+  let getCount = 0;
+  const dom = await bootDom({
+    body: `
+      <button type="button" data-annotations-toggle hidden></button>
+      <main>
+        <article class="content markdown" data-rendered-view>
+          <h1 id="intro">
+            Intro
+            <a class="anchor-link" href="#intro" data-anchor-id="intro">🔗</a>
+            <button type="button" data-annotate-trigger data-anchor-id="intro" data-anchor-kind="heading">💬 Annotate</button>
+          </h1>
+          <section data-annotations-mount data-anchor-id="intro" data-anchor-kind="heading"></section>
+        </article>
+        <aside data-annotations-stale hidden></aside>
+      </main>
+    `,
+    bootstrap: {
+      repo: 'docs',
+      relativePath: 'doc.md',
+      queryToken: null,
+      supportsLineRangeAnnotations: false,
+      sourceLineCount: 3,
+    },
+    fetchImpl: async () => {
+      getCount += 1;
+      return {
+        ok: true,
+        async json() {
+          return {
+            schema: 1,
+            file: 'docs/doc.md',
+            mtimeMs: 42,
+            annotations: [
+              {
+                id: '2026-06-09-001',
+                anchor: '#intro',
+                anchorKind: 'heading',
+                body: 'Open note',
+                author: 'builder',
+                createdAt: '2026-06-09T10:00:00.000Z',
+                state: 'open',
+                claimedBy: null,
+                claimedAt: null,
+                resolvedAt: null,
+                replies: [
+                  {
+                    author: 'reviewer',
+                    body: 'Reply note',
+                    createdAt: '2026-06-09T10:05:00.000Z',
+                  },
+                ],
+              },
+              {
+                id: '2026-06-09-002',
+                anchor: '#intro',
+                anchorKind: 'heading',
+                body: 'Resolved note',
+                author: 'builder',
+                createdAt: '2026-06-09T11:00:00.000Z',
+                state: 'resolved',
+                claimedBy: null,
+                claimedAt: null,
+                resolvedAt: '2026-06-09T11:30:00.000Z',
+                replies: [],
+              },
+              {
+                id: '2026-06-09-003',
+                anchor: '#missing-anchor',
+                anchorKind: 'heading',
+                body: 'Stale note',
+                author: 'builder',
+                createdAt: '2026-06-09T12:00:00.000Z',
+                state: 'open',
+                claimedBy: null,
+                claimedAt: null,
+                resolvedAt: null,
+                replies: [],
+              },
+            ],
+          };
+        },
+      };
+    },
+  });
+
+  const { document } = dom.window;
+  assert.equal(getCount, 1);
+
+  const mount = document.querySelector('[data-annotations-mount][data-anchor-id="intro"]');
+  assert.ok(mount.textContent.includes('Open note'));
+  assert.ok(!mount.textContent.includes('Resolved note'));
+  const annotationItem = mount.querySelector('details.lookie-annotation-item');
+  assert.ok(annotationItem);
+  assert.equal(annotationItem.open, false);
+  assert.equal(annotationItem.querySelector('summary.lookie-annotation-summary .lookie-annotation-preview').textContent, 'Open note');
+  assert.equal(annotationItem.querySelector('summary.lookie-annotation-summary .lookie-annotation-reply-count').textContent, '1 reply');
+  assert.equal(annotationItem.querySelector('.lookie-annotation-detail .lookie-annotation-body').textContent, 'Open note');
+  assert.ok(annotationItem.querySelector('.lookie-annotation-detail').textContent.includes('Reply note'));
+  assert.equal(document.documentElement.classList.contains('lookie-annotations-active'), false);
+  dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+    origin: dom.window.location.origin,
+    data: {
+      type: 'lookie-link:set-annotation-mode',
+      enabled: true,
+    },
+  }));
+  assert.equal(document.documentElement.classList.contains('lookie-annotations-active'), true);
+
+  const stale = document.querySelector('[data-annotations-stale]');
+  assert.equal(stale.hidden, false);
+  assert.ok(stale.textContent.includes('Stale anchors (1)'));
+  assert.ok(stale.textContent.includes('Stale note'));
+
+  const toggle = document.querySelector('[data-annotations-toggle]');
+  assert.equal(toggle.hidden, false);
+  assert.equal(toggle.textContent.trim(), '💬 3');
+
+  toggle.click();
+  await flush();
+
+  assert.ok(mount.textContent.includes('Resolved note'));
+  dom.window.close();
+});

--- a/test/annotations-client.test.js
+++ b/test/annotations-client.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const { JSDOM } = require('jsdom');
+const { renderDocumentPage } = require('../lib/renderer');
 
 const SCRIPT_PATH = path.join(__dirname, '..', 'public', 'annotations.js');
 const SCRIPT_SOURCE = fs.readFileSync(SCRIPT_PATH, 'utf8');
@@ -138,15 +139,6 @@ test('annotation client renders stale annotations and toggles resolved visibilit
   assert.equal(annotationItem.querySelector('summary.lookie-annotation-summary .lookie-annotation-reply-count').textContent, '1 reply');
   assert.equal(annotationItem.querySelector('.lookie-annotation-detail .lookie-annotation-body').textContent, 'Open note');
   assert.ok(annotationItem.querySelector('.lookie-annotation-detail').textContent.includes('Reply note'));
-  assert.equal(document.documentElement.classList.contains('lookie-annotations-active'), false);
-  dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
-    origin: dom.window.location.origin,
-    data: {
-      type: 'lookie-link:set-annotation-mode',
-      enabled: true,
-    },
-  }));
-  assert.equal(document.documentElement.classList.contains('lookie-annotations-active'), true);
 
   const stale = document.querySelector('[data-annotations-stale]');
   assert.equal(stale.hidden, false);
@@ -161,5 +153,139 @@ test('annotation client renders stale annotations and toggles resolved visibilit
   await flush();
 
   assert.ok(mount.textContent.includes('Resolved note'));
+  dom.window.close();
+});
+
+test('annotation toolbar toggles normal viewer annotation mode', () => {
+  const html = renderDocumentPage({
+    repo: 'docs',
+    repoRoot: '/tmp/example-docs',
+    relativePath: 'doc.md',
+    source: '# Intro\n',
+    parentHref: '/view/docs',
+    mtime: 'just now',
+    size: '8 B',
+    annotationsEnabled: true,
+  });
+  const dom = new JSDOM(html, {
+    url: 'http://127.0.0.1:9876/view/docs/doc.md',
+    runScripts: 'outside-only',
+  });
+  const themeScript = Array.from(dom.window.document.querySelectorAll('script'))
+    .find((node) => node.textContent.includes('var annotationModeBtn'));
+  assert.ok(themeScript);
+  dom.window.eval(themeScript.textContent);
+
+  const button = dom.window.document.querySelector('[data-annotation-mode-toggle]');
+  assert.ok(button);
+  assert.equal(dom.window.document.documentElement.classList.contains('lookie-annotations-active'), false);
+  button.click();
+  assert.equal(dom.window.document.documentElement.classList.contains('lookie-annotations-active'), true);
+  assert.equal(button.getAttribute('aria-pressed'), 'true');
+  button.click();
+  assert.equal(dom.window.document.documentElement.classList.contains('lookie-annotations-active'), false);
+  assert.equal(button.getAttribute('aria-pressed'), 'false');
+  dom.window.close();
+});
+
+test('annotation client submits line-range annotations with anchorKind lineRange', async () => {
+  const requests = [];
+  const dom = await bootDom({
+    body: `
+      <button type="button" data-annotations-toggle hidden></button>
+      <main>
+        <article class="content code" data-rendered-view>
+          <pre><code>alpha
+beta
+gamma
+delta</code></pre>
+        </article>
+        <section data-annotations-line-range-root hidden></section>
+        <aside data-annotations-stale hidden></aside>
+      </main>
+    `,
+    bootstrap: {
+      repo: 'docs',
+      relativePath: 'notes.txt',
+      queryToken: null,
+      supportsLineRangeAnnotations: true,
+      sourceLineCount: 4,
+    },
+    fetchImpl: async (url, init = {}) => {
+      const method = init.method || 'GET';
+      requests.push({ url, method, body: init.body ? JSON.parse(init.body) : null });
+      if (method === 'GET') {
+        const payload = requests.length > 1
+          ? {
+              schema: 1,
+              file: 'docs/notes.txt',
+              mtimeMs: 11,
+              annotations: [
+                {
+                  id: '2026-06-09-001',
+                  anchor: '#L2-L4',
+                  anchorKind: 'lineRange',
+                  body: 'Check these lines',
+                  author: 'builder',
+                  createdAt: '2026-06-09T10:00:00.000Z',
+                  state: 'open',
+                  claimedBy: null,
+                  claimedAt: null,
+                  resolvedAt: null,
+                  replies: [],
+                },
+              ],
+            }
+          : {
+              schema: 1,
+              file: 'docs/notes.txt',
+              mtimeMs: null,
+              annotations: [],
+            };
+        return {
+          ok: true,
+          async json() {
+            return payload;
+          },
+        };
+      }
+      return {
+        ok: true,
+        async json() {
+          return {
+            ok: true,
+            mtimeMs: 11,
+            annotation: {
+              id: '2026-06-09-001',
+            },
+          };
+        },
+      };
+    },
+  });
+
+  const { document } = dom.window;
+  const form = document.querySelector('.lookie-line-range-form');
+  assert.ok(form);
+
+  form.querySelector('input[name="start"]').value = '2';
+  form.querySelector('input[name="end"]').value = '4';
+  form.querySelector('input[name="author"]').value = 'builder';
+  form.querySelector('textarea[name="body"]').value = 'Check these lines';
+
+  form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+  await flush();
+  await flush();
+
+  const post = requests.find((request) => request.method === 'POST');
+  assert.ok(post);
+  assert.equal(post.body.anchor, '#L2-L4');
+  assert.equal(post.body.anchorKind, 'lineRange');
+  assert.equal(post.body.author, 'builder');
+
+  const lineRangeRoot = document.querySelector('[data-annotations-line-range-root]');
+  assert.equal(lineRangeRoot.hidden, false);
+  assert.ok(lineRangeRoot.textContent.includes('Lines 2-4'));
+  assert.ok(lineRangeRoot.textContent.includes('Check these lines'));
   dom.window.close();
 });

--- a/test/annotations-server.test.js
+++ b/test/annotations-server.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const fs = require('node:fs/promises');
 
 const { createApp } = require('../server');
+const { renderDocumentPage } = require('../lib/renderer');
 const {
   parseAccessConfig,
   authenticateRequest,
@@ -187,4 +188,34 @@ test('legacy edit permission and explicit write permission normalize to write au
     assert.equal(canAccessPath(access, 'write', 'docs', 'guide.md'), true);
     assert.equal(canAccessPath(access, 'edit', 'docs', 'guide.md'), true);
   }
+});
+
+test('document rendering exposes line ranges and deliberate authored-HTML annotation targets', () => {
+  const shared = {
+    repo: 'docs',
+    repoRoot: '/tmp/example-docs',
+    parentHref: '/view/docs',
+    mtime: 'just now',
+    size: '1 KB',
+    annotationsEnabled: true,
+  };
+
+  const textHtml = renderDocumentPage({
+    ...shared,
+    relativePath: 'notes.txt',
+    source: 'alpha\nbeta\ngamma\ndelta',
+  });
+  assert.match(textHtml, /"supportsLineRangeAnnotations":true/);
+  assert.match(textHtml, /"sourceLineCount":4/);
+  assert.match(textHtml, /data-annotations-line-range-root/);
+
+  const authoredHtml = renderDocumentPage({
+    ...shared,
+    relativePath: 'report.html',
+    source: '<section data-lookie-annotation-anchor="review-target"><h2>Review panel</h2></section>',
+  });
+  assert.match(authoredHtml, /data-lookie-annotation-anchor="review-target"/);
+  assert.match(authoredHtml, /id="review-target"/);
+  assert.match(authoredHtml, /data-annotate-trigger(?:="")? data-anchor-id="review-target"/);
+  assert.match(authoredHtml, /data-annotations-mount(?:="")? data-anchor-id="review-target"/);
 });

--- a/test/annotations-server.test.js
+++ b/test/annotations-server.test.js
@@ -1,0 +1,190 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+
+const { createApp } = require('../server');
+const {
+  parseAccessConfig,
+  authenticateRequest,
+  canAccessPath,
+} = require('../lib/access-control');
+const { createAnnotation, readAnnotationDocument, updateAnnotation } = require('../lib/annotations');
+
+async function makeFixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-link-annotations-'));
+  await fs.writeFile(path.join(root, 'guide.md'), '# Guide\n');
+  return root;
+}
+
+function getRouteHandler(app, method) {
+  const routePath = '/api/annotations/:repo/*';
+  const layer = app._router.stack.find((entry) => (
+    entry.route && entry.route.path === routePath && entry.route.methods[method]
+  ));
+  assert.ok(layer, `Missing route ${method.toUpperCase()} ${routePath}`);
+  return layer.route.stack[0].handle;
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+function requestWithToken(token, body) {
+  return {
+    params: { repo: 'docs', 0: 'guide.md' },
+    query: { token },
+    headers: {},
+    body,
+  };
+}
+
+test('redact operation scrubs annotation and reply payloads while preserving audit metadata', async () => {
+  const root = await makeFixture();
+
+  try {
+    const created = await createAnnotation(root, 'docs', 'guide.md', {
+      anchor: '#guide',
+      anchorKind: 'heading',
+      author: 'builder',
+      body: 'Original annotation body',
+    });
+
+    const replied = await updateAnnotation(root, 'docs', 'guide.md', {
+      id: created.annotation.id,
+      op: 'reply',
+      payload: {
+        author: 'reviewer',
+        body: 'Quoted payload should disappear too',
+      },
+      expectedMtimeMs: created.mtimeMs,
+    });
+
+    const redacted = await updateAnnotation(root, 'docs', 'guide.md', {
+      id: created.annotation.id,
+      op: 'redact',
+      payload: {
+        redactedBy: 'builder',
+      },
+      expectedMtimeMs: replied.mtimeMs,
+    });
+
+    assert.equal(redacted.annotation.body, '[annotation redacted]');
+    assert.equal(redacted.annotation.state, 'resolved');
+    assert.equal(redacted.annotation.redactedBy, 'builder');
+    assert.ok(redacted.annotation.redactedAt);
+    assert.equal(redacted.annotation.replies.length, 1);
+    assert.equal(redacted.annotation.replies[0].body, '[reply redacted]');
+    assert.equal(redacted.annotation.replies[0].redactedBy, 'builder');
+
+    const stored = await readAnnotationDocument(root, 'docs', 'guide.md');
+    const [annotation] = stored.document.annotations;
+    assert.equal(annotation.body, '[annotation redacted]');
+    assert.equal(annotation.state, 'resolved');
+    assert.equal(annotation.redactedBy, 'builder');
+    assert.equal(annotation.replies[0].body, '[reply redacted]');
+    assert.equal(annotation.replies[0].redactedBy, 'builder');
+    assert.doesNotMatch(JSON.stringify(annotation), /Original annotation body/);
+    assert.doesNotMatch(JSON.stringify(annotation), /Quoted payload should disappear too/);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('annotation mutations require write authority and view-only attempts leave the sidecar unchanged', async () => {
+  const root = await makeFixture();
+
+  try {
+    const created = await createAnnotation(root, 'docs', 'guide.md', {
+      anchor: '#guide',
+      anchorKind: 'heading',
+      author: 'builder',
+      body: 'Must remain unchanged',
+    });
+    const sidecarPath = (await readAnnotationDocument(root, 'docs', 'guide.md')).sidecarPath;
+    const before = await fs.readFile(sidecarPath);
+    const app = createApp({
+      mappings: { docs: root },
+      annotationsEnabled: true,
+      accessConfig: {
+        humanDefault: 'restricted',
+        tokens: {
+          viewer: {
+            secret: 'viewer-token',
+            repos: { docs: { paths: ['*'] } },
+            permissions: { view: true, write: false },
+          },
+        },
+      },
+    });
+    const post = getRouteHandler(app, 'post');
+    const patch = getRouteHandler(app, 'patch');
+
+    const postRes = createMockRes();
+    await post(requestWithToken('viewer-token', {
+      anchor: '#guide',
+      anchorKind: 'heading',
+      author: 'viewer',
+      body: 'Unauthorized create',
+    }), postRes);
+    assert.equal(postRes.statusCode, 403);
+
+    const patchCases = [
+      ['claim', { claimedBy: 'viewer' }],
+      ['resolve', {}],
+      ['reopen', {}],
+      ['reply', { author: 'viewer', body: 'Unauthorized reply' }],
+      ['redact', { redactedBy: 'viewer' }],
+      ['delete', {}],
+    ];
+    for (const [op, payload] of patchCases) {
+      const patchRes = createMockRes();
+      await patch(requestWithToken('viewer-token', {
+        id: created.annotation.id,
+        op,
+        payload,
+        expectedMtimeMs: created.mtimeMs,
+      }), patchRes);
+      assert.equal(patchRes.statusCode, 403, `${op} should require write authority`);
+    }
+
+    const after = await fs.readFile(sidecarPath);
+    assert.deepEqual(after, before);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('legacy edit permission and explicit write permission normalize to write authority', () => {
+  const config = parseAccessConfig({
+    humanDefault: 'restricted',
+    tokens: {
+      legacy_writer: {
+        secret: 'legacy-token',
+        repos: { docs: { paths: ['*'] } },
+        permissions: { view: true, edit: true },
+      },
+      writer: {
+        secret: 'writer-token',
+        repos: { docs: { paths: ['*'] } },
+        permissions: { view: true, write: true },
+      },
+    },
+  });
+
+  for (const token of ['legacy-token', 'writer-token']) {
+    const access = authenticateRequest({ query: { token }, headers: {} }, config);
+    assert.equal(access.permissions.write, true);
+    assert.equal(access.permissions.edit, true);
+    assert.equal(canAccessPath(access, 'write', 'docs', 'guide.md'), true);
+    assert.equal(canAccessPath(access, 'edit', 'docs', 'guide.md'), true);
+  }
+});


### PR DESCRIPTION
Recreation of #142 (closed by GitHub when #140's base branch was deleted — original body + independent Opus review verdict APPROVE are recorded there). Part of #91 Step 4. 19/19 tests + both validators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)