### PR TITLE
feat: port video serving and rendering

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -273,6 +273,7 @@ function addYamlAnchors(source, highlightedHtml) {
 
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg']);
 const AUDIO_EXTENSIONS = new Set(['.m4a', '.mp3', '.wav', '.ogg', '.oga', '.opus', '.flac', '.aac']);
+const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mov', '.m4v']);
 const AUDIO_MIME_BY_EXT = {
   '.m4a': 'audio/mp4',
   '.mp3': 'audio/mpeg',
@@ -282,6 +283,12 @@ const AUDIO_MIME_BY_EXT = {
   '.opus': 'audio/ogg',
   '.flac': 'audio/flac',
   '.aac': 'audio/aac',
+};
+const VIDEO_MIME_BY_EXT = {
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  '.m4v': 'video/mp4',
 };
 
 function splitByCodeBlocks(html) {
@@ -452,6 +459,10 @@ function resolveLocalAudioHref(src, context) {
   return resolveLocalAssetHref(src, context, AUDIO_EXTENSIONS);
 }
 
+function resolveLocalVideoHref(src, context) {
+  return resolveLocalAssetHref(src, context, VIDEO_EXTENSIONS);
+}
+
 // Recognise absolute URLs that point back at our own /view/<repo>/<path>.<audio-ext>
 // route, regardless of host. The user routinely pastes fully-qualified Tailscale
 // URLs into markdown; we want those to inline-embed like relative paths do.
@@ -473,6 +484,30 @@ function resolveAbsoluteViewAudioHref(href) {
 
   const ext = path.extname(url.pathname).toLowerCase();
   if (!AUDIO_EXTENSIONS.has(ext)) {
+    return null;
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function resolveAbsoluteViewVideoHref(href) {
+  if (!/^https?:\/\//i.test(href)) {
+    return null;
+  }
+
+  let url;
+  try {
+    url = new URL(href);
+  } catch (_error) {
+    return null;
+  }
+
+  if (!url.pathname.startsWith('/view/')) {
+    return null;
+  }
+
+  const ext = path.extname(url.pathname).toLowerCase();
+  if (!VIDEO_EXTENSIONS.has(ext)) {
     return null;
   }
 
@@ -509,6 +544,96 @@ function rewriteAudioLinks(html, context) {
   </audio>
   <a class="audio-embed-link" href="${viewHref}">${inner}</a>
 </div>`;
+      }
+    );
+  }
+
+  return parts.join('');
+}
+
+function rewriteVideoLinks(html, context) {
+  const parts = splitByCodeBlocks(html);
+  for (let i = 0; i < parts.length; i += 1) {
+    if (/^<(pre|code)\b/i.test(parts[i])) {
+      continue;
+    }
+
+    parts[i] = parts[i].replace(
+      /<a\b([^>]*?)href="([^"]+)"([^>]*)>([\s\S]*?)<\/a>/gi,
+      (match, before, href, after, inner) => {
+        const rewrittenViewHref =
+          resolveLocalVideoHref(href, context) || resolveAbsoluteViewVideoHref(href);
+        if (!rewrittenViewHref) {
+          return match;
+        }
+
+        const assetHref = appendQueryToken(
+          rewrittenViewHref.replace(/^\/view\//, '/asset/'),
+          context.queryToken
+        );
+        const viewHref = appendQueryToken(rewrittenViewHref, context.queryToken);
+        const pathOnly = rewrittenViewHref.split(/[?#]/)[0];
+        const ext = path.extname(pathOnly).toLowerCase();
+        const mime = VIDEO_MIME_BY_EXT[ext] || 'video/mp4';
+        return `<div class="video-embed">
+  <video controls preload="metadata" src="${assetHref}" type="${mime}">
+    Your browser does not support the video element. <a href="${viewHref}">Open file</a>
+  </video>
+  <a class="video-embed-link" href="${viewHref}">${inner}</a>
+</div>`;
+      }
+    );
+  }
+
+  return parts.join('');
+}
+
+function rewriteInlineVideoSources(html, context) {
+  const parts = splitByCodeBlocks(html);
+  for (let i = 0; i < parts.length; i += 1) {
+    if (/^<(pre|code)\b/i.test(parts[i])) {
+      continue;
+    }
+
+    parts[i] = parts[i].replace(
+      /<video\b[\s\S]*?<\/video>/gi,
+      (videoHtml) => videoHtml.replace(
+        /<(video|source)\b([^>]*?)\ssrc="([^"]+)"([^>]*)>/gi,
+        (match, tagName, before, src, after) => {
+          if (src.startsWith('/asset/')) {
+            return match;
+          }
+
+          const rewrittenViewHref = resolveLocalVideoHref(src, context);
+          if (!rewrittenViewHref) {
+            return match;
+          }
+
+          const assetHref = appendQueryToken(
+            rewrittenViewHref.replace(/^\/view\//, '/asset/'),
+            context.queryToken
+          );
+          return `<${tagName}${before} src="${assetHref}"${after}>`;
+        }
+      )
+    );
+    parts[i] = parts[i].replace(
+      /<video\b([^>]*?)\ssrc="([^"]+)"([^>]*)\/>/gi,
+      (match, before, src, after) => {
+        if (src.startsWith('/asset/')) {
+          return match;
+        }
+
+        const rewrittenViewHref = resolveLocalVideoHref(src, context);
+        if (!rewrittenViewHref) {
+          return match;
+        }
+
+        const assetHref = appendQueryToken(
+          rewrittenViewHref.replace(/^\/view\//, '/asset/'),
+          context.queryToken
+        );
+        return `<video${before} src="${assetHref}"${after}/>`;
       }
     );
   }
@@ -642,8 +767,8 @@ function renderFrontmatterPanel(frontmatterSource) {
 
 function sanitizeHtml(html) {
   return DOMPurify.sanitize(html, {
-    ADD_TAGS: ['iframe'],
-    ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'height', 'loading', 'referrerpolicy', 'sandbox', 'style', 'title', 'width'],
+    ADD_TAGS: ['iframe', 'video', 'source', 'track'],
+    ADD_ATTR: ['allow', 'allowfullscreen', 'controls', 'frameborder', 'height', 'kind', 'label', 'loading', 'loop', 'muted', 'playsinline', 'poster', 'preload', 'referrerpolicy', 'sandbox', 'src', 'srclang', 'style', 'title', 'type', 'width'],
     FORBID_TAGS: ['script', 'object', 'embed', 'form'],
   });
 }
@@ -652,8 +777,10 @@ function postProcessHtml(html, options) {
   let output = html;
   output = rewriteHybridCrossLinks(output, options);
   output = rewriteAudioLinks(output, options);
+  output = rewriteVideoLinks(output, options);
   output = rewriteTildeLinks(output, options);
   output = rewriteImageSources(output, options);
+  output = rewriteInlineVideoSources(output, options);
   output = addMissingHeadingIds(output);
   output = addHeadingAnchorLinks(output);
   output = addYamlAnchorLinks(output);
@@ -1414,6 +1541,36 @@ function renderAudioPage({ repo, relativePath, parentHref, audioHref, mimeType, 
   });
 }
 
+function renderVideoPage({ repo, relativePath, parentHref, videoHref, mimeType, mtime, size, customThemeCss, queryToken = null }) {
+  const heading = `${repo}/${relativePath}`;
+  const safeMime = mimeType || 'video/mp4';
+  const body = `${toolbarHtml()}
+  <main class="layout">
+    <header class="topbar">
+      <h1>${escapeHtml(path.basename(relativePath))}</h1>
+      <p class="subtitle">${escapeHtml(heading)}</p>
+      ${breadcrumbs(repo, relativePath, queryToken)}
+      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · video</p>
+      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
+    </header>
+
+    <article class="content video-view">
+      <video controls preload="metadata" src="${escapeHtml(videoHref)}" type="${escapeHtml(safeMime)}">
+        Your browser does not support the video element.
+        <a href="${escapeHtml(videoHref)}">Download file</a>
+      </video>
+      <p class="video-download"><a href="${escapeHtml(videoHref)}" download>Download</a></p>
+    </article>
+  </main>
+  ${themeScript()}`;
+
+  return baseHtml({
+    title: heading,
+    body,
+    customThemeCss,
+  });
+}
+
 function renderPdfPage({ repo, relativePath, parentHref, pdfHref, mtime, size, customThemeCss, queryToken = null }) {
   const heading = `${repo}/${relativePath}`;
   const body = `${toolbarHtml()}
@@ -1821,6 +1978,7 @@ module.exports = {
   renderDirectoryPage,
   renderImagePage,
   renderAudioPage,
+  renderVideoPage,
   renderPdfPage,
   renderCsvPage,
   renderJsonPage,

--- a/server.js
+++ b/server.js
@@ -47,6 +47,7 @@ const {
   renderDirectoryPage,
   renderImagePage,
   renderAudioPage,
+  renderVideoPage,
   renderPdfPage,
   renderCsvPage,
   renderJsonPage,
@@ -615,6 +616,24 @@ function createApp(options = {}) {
         parentHref: appendAccessToken(parentRel === null ? '/view' : buildHref(repo, parentRel), accessContext),
         audioHref: appendAccessToken(buildAssetHref(repo, relativePath), accessContext),
         mimeType: AUDIO_MIME_TYPES[extension],
+        mtime: formatMTime(stat.mtime),
+        size: formatFileSize(stat.size),
+        customThemeCss,
+        queryToken: accessContext.queryToken,
+      });
+
+      res.status(200).type('html').send(html);
+      return;
+    }
+
+    if (VIDEO_EXTENSIONS.has(extension)) {
+      const parentRel = parentPath(relativePath);
+      const html = renderVideoPage({
+        repo,
+        relativePath,
+        parentHref: appendAccessToken(parentRel === null ? '/view' : buildHref(repo, parentRel), accessContext),
+        videoHref: appendAccessToken(buildAssetHref(repo, relativePath), accessContext),
+        mimeType: VIDEO_MIME_TYPES[extension],
         mtime: formatMTime(stat.mtime),
         size: formatFileSize(stat.size),
         customThemeCss,

--- a/server.js
+++ b/server.js
@@ -81,6 +81,13 @@ const AUDIO_MIME_TYPES = {
   '.aac': 'audio/aac',
 };
 
+const VIDEO_MIME_TYPES = {
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  '.m4v': 'video/mp4',
+};
+
 const PDF_MIME_TYPES = {
   '.pdf': 'application/pdf',
 };
@@ -149,11 +156,13 @@ const TEXT_MIME_TYPES = {
 const ASSET_MIME_TYPES = {
   ...IMAGE_MIME_TYPES,
   ...AUDIO_MIME_TYPES,
+  ...VIDEO_MIME_TYPES,
   ...PDF_MIME_TYPES,
   ...TEXT_MIME_TYPES,
 };
 const IMAGE_EXTENSIONS = new Set(Object.keys(IMAGE_MIME_TYPES));
 const AUDIO_EXTENSIONS = new Set(Object.keys(AUDIO_MIME_TYPES));
+const VIDEO_EXTENSIONS = new Set(Object.keys(VIDEO_MIME_TYPES));
 const PDF_EXTENSIONS = new Set(Object.keys(PDF_MIME_TYPES));
 const EDITABLE_EXTENSIONS = new Set([
   '.md', '.markdown', '.mdown',
@@ -195,7 +204,7 @@ function isEditableFile(relativePath) {
     return false;
   }
 
-  if (IMAGE_EXTENSIONS.has(extension) || AUDIO_EXTENSIONS.has(extension) || PDF_EXTENSIONS.has(extension)) {
+  if (IMAGE_EXTENSIONS.has(extension) || AUDIO_EXTENSIONS.has(extension) || VIDEO_EXTENSIONS.has(extension) || PDF_EXTENSIONS.has(extension)) {
     return false;
   }
 

--- a/test/fixtures/html/render-demo.htm
+++ b/test/fixtures/html/render-demo.htm
@@ -1,5 +1,6 @@
 <section>
   <h1>Hello</h1>
   <p><img src="./diagram.png" alt="Diagram"></p>
+  <video controls src="./walkthrough.mp4"></video>
   <script>alert(1)</script>
 </section>

--- a/test/video-routes.test.js
+++ b/test/video-routes.test.js
@@ -7,6 +7,9 @@ const path = require('node:path');
 const fs = require('node:fs/promises');
 
 const { createApp } = require('../server');
+const { renderPreviewHtml, renderVideoPage } = require('../lib/renderer');
+
+const HTML_FIXTURE_PATH = path.join(__dirname, 'fixtures', 'html', 'render-demo.htm');
 
 function routeHandler(app, routePath) {
   const layer = app._router.stack.find((candidate) => (
@@ -106,6 +109,83 @@ test('asset handler rejects extensions outside the allowlist', async () => {
     assert.equal(response.contentType, 'text/plain');
     assert.equal(response.body, 'Unsupported asset type.');
     assert.equal(response.filePath, null);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('video page renderer builds a dedicated player with escaped metadata', () => {
+  const html = renderVideoPage({
+    repo: 'demo',
+    relativePath: 'media/demo<clip>.webm',
+    parentHref: '/view/demo/media',
+    videoHref: '/asset/demo/media/demo%3Cclip%3E.webm?token=read-only',
+    mimeType: 'video/webm',
+    mtime: '2026-07-20',
+    size: '12 KB',
+  });
+
+  assert.match(html, /<article class="content video-view">/);
+  assert.match(html, /<video controls preload="metadata" src="\/asset\/demo\/media\/demo%3Cclip%3E\.webm\?token=read-only" type="video\/webm">/);
+  assert.match(html, /demo&lt;clip&gt;\.webm/);
+  assert.match(html, /12 KB · 2026-07-20 · video/);
+});
+
+test('document renderer embeds linked and authored video with asset URLs', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-video-renderer-'));
+
+  try {
+    await fs.writeFile(path.join(root, 'walkthrough.mp4'), 'mp4-bytes');
+    const linkedHtml = renderPreviewHtml({
+      repo: 'demo',
+      repoRoot: root,
+      relativePath: 'guide.md',
+      source: '[Watch the walkthrough](./walkthrough.mp4)\n',
+      queryToken: 'viewer-token',
+    });
+    assert.match(linkedHtml, /<div class="video-embed">/);
+    assert.match(linkedHtml, /<video controls="" preload="metadata" src="\/asset\/demo\/walkthrough\.mp4\?token=viewer-token" type="video\/mp4">/);
+    assert.match(linkedHtml, /class="video-embed-link" href="\/view\/demo\/walkthrough\.mp4\?token=viewer-token"/);
+
+    const source = await fs.readFile(HTML_FIXTURE_PATH, 'utf8');
+    const authoredHtml = renderPreviewHtml({
+      repo: 'demo',
+      repoRoot: root,
+      relativePath: 'landing.htm',
+      source,
+    });
+    assert.match(authoredHtml, /<video controls="" src="\/asset\/demo\/walkthrough\.mp4"><\/video>/);
+    assert.doesNotMatch(authoredHtml, /<script>alert\(1\)<\/script>/);
+
+    const sourceElementHtml = renderPreviewHtml({
+      repo: 'demo',
+      repoRoot: root,
+      relativePath: 'landing.htm',
+      source: '<video controls><source src="./walkthrough.mp4" type="video/mp4"></video>',
+    });
+    assert.match(sourceElementHtml, /<source src="\/asset\/demo\/walkthrough\.mp4" type="video\/mp4">/);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('view handler renders a video file in the dedicated viewer', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-video-view-'));
+
+  try {
+    await fs.writeFile(path.join(root, 'walkthrough.mp4'), 'mp4-bytes');
+    const app = createApp({ mappings: { demo: root }, editingEnabled: true });
+    const handler = routeHandler(app, '/view/*');
+    const response = await invokeHandler(handler, {
+      params: { 0: 'demo/walkthrough.mp4' },
+      accessContext: unrestrictedAccess(),
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.contentType, 'html');
+    assert.match(response.body, /<article class="content video-view">/);
+    assert.match(response.body, /<video controls preload="metadata" src="\/asset\/demo\/walkthrough\.mp4" type="video\/mp4">/);
+    assert.doesNotMatch(response.body, />Edit</);
   } finally {
     await fs.rm(root, { recursive: true, force: true });
   }

--- a/test/video-routes.test.js
+++ b/test/video-routes.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+
+const { createApp } = require('../server');
+
+function routeHandler(app, routePath) {
+  const layer = app._router.stack.find((candidate) => (
+    candidate.route && candidate.route.path === routePath
+  ));
+  assert.ok(layer, `route ${routePath} is registered`);
+  return layer.route.stack[0].handle;
+}
+
+function unrestrictedAccess() {
+  return {
+    mode: 'unrestricted',
+    queryToken: null,
+    permissions: { view: true, edit: true },
+    allRepos: true,
+    repos: {},
+  };
+}
+
+function invokeHandler(handler, req) {
+  return new Promise((resolve, reject) => {
+    const response = {
+      statusCode: 200,
+      headersSent: false,
+      contentType: null,
+      body: null,
+      filePath: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      type(value) {
+        this.contentType = value;
+        return this;
+      },
+      send(value) {
+        this.body = value;
+        this.headersSent = true;
+        resolve(this);
+        return this;
+      },
+      sendFile(filePath, callback) {
+        this.filePath = filePath;
+        this.headersSent = true;
+        callback(null);
+        resolve(this);
+      },
+    };
+
+    Promise.resolve(handler(req, response)).catch(reject);
+  });
+}
+
+test('asset handler serves each allowed video extension with its MIME type', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-video-assets-'));
+  const expectedTypes = new Map([
+    ['clip.mp4', 'video/mp4'],
+    ['clip.webm', 'video/webm'],
+    ['clip.mov', 'video/quicktime'],
+    ['clip.m4v', 'video/mp4'],
+  ]);
+
+  try {
+    await Promise.all([...expectedTypes.keys()].map((fileName) => (
+      fs.writeFile(path.join(root, fileName), 'video-bytes')
+    )));
+    const app = createApp({ mappings: { demo: root }, editingEnabled: false });
+    const handler = routeHandler(app, '/asset/:repo/*');
+
+    for (const [fileName, mimeType] of expectedTypes) {
+      const response = await invokeHandler(handler, {
+        params: { repo: 'demo', 0: fileName },
+        accessContext: unrestrictedAccess(),
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.contentType, mimeType);
+      assert.equal(response.filePath, path.join(root, fileName));
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('asset handler rejects extensions outside the allowlist', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-video-assets-'));
+
+  try {
+    const app = createApp({ mappings: { demo: root }, editingEnabled: false });
+    const handler = routeHandler(app, '/asset/:repo/*');
+    const response = await invokeHandler(handler, {
+      params: { repo: 'demo', 0: 'clip.exe' },
+      accessContext: unrestrictedAccess(),
+    });
+
+    assert.equal(response.statusCode, 415);
+    assert.equal(response.contentType, 'text/plain');
+    assert.equal(response.body, 'Unsupported asset type.');
+    assert.equal(response.filePath, null);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Recreation of #143 (closed by GitHub when #140's base branch was deleted — original body there). Part of #91 Step 5.1. 17/17 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)