### PR TITLE
feat: port auth foundations — write normalization, publish capability, managed API keys, grant policy

### DIFF
--- a/lib/access-control.js
+++ b/lib/access-control.js
@@ -6,12 +6,8 @@ const path = require('node:path');
 const { toPosixPath } = require('./path-utils');
 
 function constantTimeEqual(left, right) {
-  const leftBuffer = Buffer.from(String(left || ''), 'utf8');
-  const rightBuffer = Buffer.from(String(right || ''), 'utf8');
-
-  if (leftBuffer.length !== rightBuffer.length) {
-    return false;
-  }
+  const leftBuffer = crypto.createHash('sha256').update(String(left || ''), 'utf8').digest();
+  const rightBuffer = crypto.createHash('sha256').update(String(right || ''), 'utf8').digest();
 
   return crypto.timingSafeEqual(leftBuffer, rightBuffer);
 }
@@ -305,22 +301,12 @@ function resolveCredentialAccess(req, accessConfig, apiKeyStore, grantStore) {
 }
 
 function mutationUsesQueryToken(req) {
-  if (!extractQueryToken(req)) {
+  if (!req.query || !Object.prototype.hasOwnProperty.call(req.query, 'token')) {
     return false;
   }
 
   const method = String(req.method || '').toUpperCase();
-  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
-    return false;
-  }
-
-  const requestPath = String(req.path || req.url || '').split('?', 1)[0];
-  return requestPath.startsWith('/api/save/')
-    || requestPath.startsWith('/api/annotations/')
-    || requestPath === '/api/grants'
-    || requestPath.startsWith('/api/grants/')
-    || requestPath === '/api/agent-keys'
-    || requestPath.startsWith('/api/agent-keys/');
+  return ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method);
 }
 
 function isAncestorPath(ancestor, value) {

--- a/lib/access-control.js
+++ b/lib/access-control.js
@@ -29,12 +29,14 @@ function normalizePermissions(tokenConfig) {
     ? tokenConfig.permissions
     : {};
   const write = permissions.write === true || permissions.edit === true || tokenConfig.allowEditing === true;
-  const view = permissions.view !== false || write;
+  const publish = permissions.publish === true;
+  const view = permissions.view !== false || write || publish;
 
   return {
     view,
     write,
     edit: write,
+    publish,
   };
 }
 
@@ -218,6 +220,7 @@ function authenticateRequest(req, accessConfig) {
         view: true,
         write: true,
         edit: true,
+        publish: true,
       },
       allRepos: true,
       repos: {},
@@ -236,6 +239,7 @@ function authenticateRequest(req, accessConfig) {
         view: false,
         write: false,
         edit: false,
+        publish: false,
       },
       allRepos: false,
       repos: {},

--- a/lib/access-control.js
+++ b/lib/access-control.js
@@ -24,6 +24,20 @@ function normalizeHumanDefault(value) {
   return 'full';
 }
 
+function normalizePermissions(tokenConfig) {
+  const permissions = tokenConfig && typeof tokenConfig === 'object' && tokenConfig.permissions && typeof tokenConfig.permissions === 'object'
+    ? tokenConfig.permissions
+    : {};
+  const write = permissions.write === true || permissions.edit === true || tokenConfig.allowEditing === true;
+  const view = permissions.view !== false || write;
+
+  return {
+    view,
+    write,
+    edit: write,
+  };
+}
+
 function normalizeScopeEntry(rawScope) {
   const normalized = toPosixPath(rawScope);
   if (!normalized || normalized === '*') {
@@ -133,12 +147,7 @@ function parseAccessConfig(rawConfig) {
         continue;
       }
 
-      const permissions = tokenConfig && typeof tokenConfig === 'object' && tokenConfig.permissions && typeof tokenConfig.permissions === 'object'
-        ? tokenConfig.permissions
-        : {};
-
-      const canEdit = permissions.edit === true || tokenConfig.allowEditing === true;
-      const canView = permissions.view !== false || canEdit;
+      const permissions = normalizePermissions(tokenConfig);
       const repoScopes = normalizeRepoScopes(tokenConfig.repos);
 
       tokens.push({
@@ -149,10 +158,7 @@ function parseAccessConfig(rawConfig) {
           : typeof tokenConfig.secret === 'string' && tokenConfig.secret.trim()
             ? { type: 'inline' }
             : null,
-        permissions: {
-          view: canView,
-          edit: canEdit,
-        },
+        permissions,
         allRepos: repoScopes.allRepos,
         repos: repoScopes.repos,
         subject: tokenConfig.subject || null,
@@ -210,6 +216,7 @@ function authenticateRequest(req, accessConfig) {
       queryToken: null,
       permissions: {
         view: true,
+        write: true,
         edit: true,
       },
       allRepos: true,
@@ -227,6 +234,7 @@ function authenticateRequest(req, accessConfig) {
       queryToken: queryToken || null,
       permissions: {
         view: false,
+        write: false,
         edit: false,
       },
       allRepos: false,
@@ -302,11 +310,11 @@ function canAccessPath(accessContext, action, repo, relativePath, pathType = 'fi
     return false;
   }
 
-  if (action === 'edit' && !accessContext.permissions.edit) {
-    return false;
-  }
-
-  if (action === 'view' && !accessContext.permissions.view) {
+  const permission = action === 'edit' ? 'write' : action;
+  const allowed = permission === 'write'
+    ? accessContext.permissions.write === true || accessContext.permissions.edit === true
+    : accessContext.permissions[permission] === true;
+  if (!allowed) {
     return false;
   }
 

--- a/lib/access-control.js
+++ b/lib/access-control.js
@@ -214,6 +214,7 @@ function authenticateRequest(req, accessConfig) {
   if (!presentedToken) {
     return {
       mode: accessConfig.humanDefault === 'full' ? 'unrestricted' : 'denied',
+      authType: accessConfig.humanDefault === 'full' ? 'human' : 'none',
       source: null,
       queryToken: null,
       permissions: {
@@ -233,6 +234,7 @@ function authenticateRequest(req, accessConfig) {
   if (!token) {
     return {
       mode: 'denied',
+      authType: 'none',
       source: headerToken ? 'header' : 'query',
       queryToken: queryToken || null,
       permissions: {
@@ -250,6 +252,7 @@ function authenticateRequest(req, accessConfig) {
 
   return {
     mode: 'scoped',
+    authType: 'static_token',
     tokenName: token.name,
     source: headerToken ? 'header' : 'query',
     queryToken: headerToken ? null : queryToken,
@@ -263,6 +266,61 @@ function authenticateRequest(req, accessConfig) {
     denialStatus: 403,
     denialMessage: 'Access denied.',
   };
+}
+
+function storeIsEnabled(store) {
+  return Boolean(store && typeof store.isEnabled === 'function' && store.isEnabled());
+}
+
+function resolveCredentialAccess(req, accessConfig, apiKeyStore, grantStore) {
+  const staticAccess = authenticateRequest(req, accessConfig);
+  if (staticAccess.mode === 'scoped') {
+    return staticAccess;
+  }
+
+  const headerToken = extractBearerToken(req);
+  const queryToken = extractQueryToken(req);
+  const presentedToken = headerToken || queryToken;
+  if (!presentedToken) {
+    return staticAccess;
+  }
+
+  const source = headerToken ? 'header' : 'query';
+  const propagatedQueryToken = headerToken ? null : queryToken;
+  if (storeIsEnabled(apiKeyStore)) {
+    const apiKeyAccess = apiKeyStore.authenticateKey(presentedToken, source, propagatedQueryToken);
+    if (apiKeyAccess) {
+      return apiKeyAccess;
+    }
+  }
+
+  if (storeIsEnabled(grantStore)) {
+    const grantAccess = grantStore.authenticateGrantToken(presentedToken, source, propagatedQueryToken);
+    if (grantAccess) {
+      return grantAccess;
+    }
+  }
+
+  return staticAccess;
+}
+
+function mutationUsesQueryToken(req) {
+  if (!extractQueryToken(req)) {
+    return false;
+  }
+
+  const method = String(req.method || '').toUpperCase();
+  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+    return false;
+  }
+
+  const requestPath = String(req.path || req.url || '').split('?', 1)[0];
+  return requestPath.startsWith('/api/save/')
+    || requestPath.startsWith('/api/annotations/')
+    || requestPath === '/api/grants'
+    || requestPath.startsWith('/api/grants/')
+    || requestPath === '/api/agent-keys'
+    || requestPath.startsWith('/api/agent-keys/');
 }
 
 function isAncestorPath(ancestor, value) {
@@ -355,4 +413,6 @@ module.exports = {
   extractBearerToken,
   extractQueryToken,
   extractPresentedToken,
+  mutationUsesQueryToken,
+  resolveCredentialAccess,
 };

--- a/lib/api-key-store.js
+++ b/lib/api-key-store.js
@@ -1,0 +1,530 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const { toPosixPath } = require('./path-utils');
+
+const DEFAULT_STORE = {
+  version: 1,
+  keys: [],
+  auditEvents: [],
+};
+
+function constantTimeEqual(left, right) {
+  const leftBuffer = Buffer.from(String(left || ''), 'utf8');
+  const rightBuffer = Buffer.from(String(right || ''), 'utf8');
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function isYamlPath(filePath) {
+  return filePath.endsWith('.yaml') || filePath.endsWith('.yml');
+}
+
+function cloneStore(store) {
+  return {
+    version: store.version,
+    keys: store.keys.map((entry) => ({
+      ...entry,
+      subject: { ...entry.subject },
+      permissions: { ...entry.permissions },
+      repos: JSON.parse(JSON.stringify(entry.repos || {})),
+    })),
+    auditEvents: store.auditEvents.map((event) => ({ ...event })),
+  };
+}
+
+function readStoreFromDisk(storePath) {
+  try {
+    const raw = fs.readFileSync(storePath, 'utf8');
+    fs.chmodSync(storePath, 0o600);
+    const parsed = isYamlPath(storePath) ? yaml.load(raw) : JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return cloneStore(DEFAULT_STORE);
+    }
+
+    return {
+      version: Number.isInteger(parsed.version) ? parsed.version : 1,
+      keys: Array.isArray(parsed.keys) ? parsed.keys : [],
+      auditEvents: Array.isArray(parsed.auditEvents) ? parsed.auditEvents : [],
+    };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return cloneStore(DEFAULT_STORE);
+    }
+    throw error;
+  }
+}
+
+function writeSerializedFile(targetPath, serialized, prefix) {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const tempPath = path.join(
+    path.dirname(targetPath),
+    `.${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+  try {
+    fs.writeFileSync(tempPath, serialized, { encoding: 'utf8', mode: 0o600 });
+    fs.renameSync(tempPath, targetPath);
+    fs.chmodSync(targetPath, 0o600);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch (_cleanupError) {
+      // Best effort cleanup; preserve the original write error.
+    }
+    throw error;
+  }
+}
+
+function writeStoreToDisk(storePath, store) {
+  const serialized = isYamlPath(storePath)
+    ? yaml.dump(store, { noRefs: true, sortKeys: true })
+    : `${JSON.stringify(store, null, 2)}\n`;
+  writeSerializedFile(storePath, serialized, 'lookie-link-api-keys');
+}
+
+function hashSecret(secret) {
+  return crypto.createHash('sha256').update(String(secret), 'utf8').digest('hex');
+}
+
+function normalizePermissions(rawPermissions) {
+  const permissions = rawPermissions && typeof rawPermissions === 'object' ? rawPermissions : {};
+  const write = permissions.write === true || permissions.edit === true;
+  const publish = permissions.publish === true;
+  const view = permissions.view !== false || write || publish;
+
+  if (!view && !write && !publish) {
+    throw new Error('API key must allow at least one permission.');
+  }
+
+  return {
+    view,
+    write,
+    edit: write,
+    publish,
+  };
+}
+
+function normalizeScopeEntry(rawScope) {
+  const normalized = toPosixPath(rawScope);
+  if (!normalized || normalized === '*') {
+    return { type: 'all', path: '' };
+  }
+
+  if (normalized.endsWith('/')) {
+    return {
+      type: 'directory',
+      path: normalized.slice(0, -1),
+    };
+  }
+
+  return {
+    type: 'file',
+    path: normalized,
+  };
+}
+
+function normalizeRepoScopes(rawRepos) {
+  const normalized = {
+    allRepos: false,
+    repos: {},
+  };
+
+  if (rawRepos === 'all') {
+    normalized.allRepos = true;
+    return normalized;
+  }
+
+  if (Array.isArray(rawRepos)) {
+    for (const repoName of rawRepos) {
+      const repo = String(repoName || '').trim();
+      if (!repo) {
+        continue;
+      }
+      normalized.repos[repo] = [{ type: 'all', path: '' }];
+    }
+    return normalized;
+  }
+
+  if (!rawRepos || typeof rawRepos !== 'object') {
+    return normalized;
+  }
+
+  for (const [repoName, rawScopeConfig] of Object.entries(rawRepos)) {
+    const repo = String(repoName || '').trim();
+    if (!repo) {
+      continue;
+    }
+
+    if (rawScopeConfig === 'all' || rawScopeConfig === true || rawScopeConfig === null) {
+      normalized.repos[repo] = [{ type: 'all', path: '' }];
+      continue;
+    }
+
+    const rawPaths = Array.isArray(rawScopeConfig)
+      ? rawScopeConfig
+      : Array.isArray(rawScopeConfig && rawScopeConfig.paths)
+        ? rawScopeConfig.paths
+        : null;
+
+    if (!rawPaths || rawPaths.length === 0) {
+      normalized.repos[repo] = [{ type: 'all', path: '' }];
+      continue;
+    }
+
+    const scopes = rawPaths
+      .map(normalizeScopeEntry)
+      .filter(Boolean);
+
+    if (scopes.length > 0) {
+      normalized.repos[repo] = scopes;
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeSubject(rawSubject) {
+  const subject = rawSubject && typeof rawSubject === 'object' ? rawSubject : {};
+  const agentId = String(subject.agentId || '').trim();
+  const companyId = String(subject.companyId || '').trim();
+  const label = subject.label == null ? null : String(subject.label).trim() || null;
+
+  if (!agentId) {
+    throw new Error('subject.agentId is required.');
+  }
+  if (!companyId) {
+    throw new Error('subject.companyId is required.');
+  }
+
+  return { agentId, companyId, label };
+}
+
+function normalizeIssuer(rawIssuer, adminTokenName) {
+  const issuer = rawIssuer && typeof rawIssuer === 'object' ? rawIssuer : {};
+
+  return {
+    adminTokenName: adminTokenName || null,
+    actorType: issuer.actorType == null ? null : String(issuer.actorType).trim() || null,
+    actorId: issuer.actorId == null ? null : String(issuer.actorId).trim() || null,
+  };
+}
+
+function expandHome(input) {
+  if (input === '~') {
+    return os.homedir();
+  }
+  if (input.startsWith('~/')) {
+    return path.join(os.homedir(), input.slice(2));
+  }
+  return input;
+}
+
+function resolveSecret(config) {
+  if (!config || typeof config !== 'object') {
+    return null;
+  }
+
+  if (typeof config.secretEnv === 'string' && config.secretEnv.trim()) {
+    const value = process.env[config.secretEnv.trim()];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  if (typeof config.secret === 'string' && config.secret.trim()) {
+    return config.secret.trim();
+  }
+
+  return null;
+}
+
+function parseAdminTokens(rawAdminTokens) {
+  if (!rawAdminTokens || typeof rawAdminTokens !== 'object') {
+    return [];
+  }
+
+  return Object.entries(rawAdminTokens)
+    .map(([name, config]) => {
+      const secret = resolveSecret(config);
+      if (!secret) {
+        return null;
+      }
+      return { name, secret };
+    })
+    .filter(Boolean);
+}
+
+function computeKeyState(apiKey) {
+  if (apiKey.revokedAt) {
+    return 'revoked';
+  }
+  return 'active';
+}
+
+function serializeApiKey(apiKey) {
+  return {
+    id: apiKey.id,
+    label: apiKey.label,
+    subject: { ...apiKey.subject },
+    permissions: { ...apiKey.permissions },
+    allRepos: apiKey.allRepos,
+    repos: JSON.parse(JSON.stringify(apiKey.repos || {})),
+    createdAt: apiKey.createdAt,
+    rotatedAt: apiKey.rotatedAt,
+    lastUsedAt: apiKey.lastUsedAt,
+    revokedAt: apiKey.revokedAt,
+    revokedReason: apiKey.revokedReason,
+    state: computeKeyState(apiKey),
+  };
+}
+
+function createAuditEvent(type, payload = {}) {
+  return {
+    id: crypto.randomUUID(),
+    type,
+    createdAt: new Date().toISOString(),
+    ...payload,
+  };
+}
+
+function buildAccessContextForKey(apiKey, source, queryToken) {
+  return {
+    mode: 'scoped',
+    authType: 'api_key',
+    tokenName: `api-key:${apiKey.id}`,
+    keyId: apiKey.id,
+    subject: { ...apiKey.subject },
+    principal: {
+      kind: 'agent',
+      id: apiKey.subject.agentId,
+      credentialKind: 'api_key',
+      credentialId: apiKey.id,
+    },
+    source,
+    queryToken: source === 'query' ? queryToken : null,
+    permissions: { ...apiKey.permissions },
+    allRepos: apiKey.allRepos,
+    repos: JSON.parse(JSON.stringify(apiKey.repos || {})),
+    denialStatus: 403,
+    denialMessage: 'Access denied.',
+  };
+}
+
+class ApiKeyStore {
+  constructor(config) {
+    this.storePath = config.storePath;
+    this.adminTokens = config.adminTokens;
+  }
+
+  static fromAccessConfig(rawApiKeysConfig) {
+    const apiKeysConfig = rawApiKeysConfig && typeof rawApiKeysConfig === 'object' ? rawApiKeysConfig : {};
+    const storePath = typeof apiKeysConfig.storePath === 'string' && apiKeysConfig.storePath.trim()
+      ? path.resolve(expandHome(apiKeysConfig.storePath.trim()))
+      : null;
+
+    if (!storePath) {
+      return null;
+    }
+
+    return new ApiKeyStore({
+      storePath,
+      adminTokens: parseAdminTokens(apiKeysConfig.adminTokens),
+    });
+  }
+
+  isEnabled() {
+    return Boolean(this.storePath);
+  }
+
+  readStore() {
+    return readStoreFromDisk(this.storePath);
+  }
+
+  writeStore(store) {
+    writeStoreToDisk(this.storePath, store);
+  }
+
+  authenticateAdminToken(secret) {
+    if (!secret) {
+      return null;
+    }
+
+    return this.adminTokens.find((token) => constantTimeEqual(token.secret, secret)) || null;
+  }
+
+  authenticateKey(secret, source, queryToken) {
+    if (!secret) {
+      return null;
+    }
+
+    const store = this.readStore();
+    const hash = hashSecret(secret);
+
+    let matchedKey = null;
+    for (const apiKey of store.keys) {
+      const secretMatches = constantTimeEqual(apiKey.secretHash, hash);
+      if (secretMatches && computeKeyState(apiKey) === 'active') {
+        matchedKey = apiKey;
+      }
+    }
+
+    if (matchedKey) {
+      matchedKey.lastUsedAt = new Date().toISOString();
+      this.writeStore(store);
+      return buildAccessContextForKey(matchedKey, source, queryToken);
+    }
+
+    return null;
+  }
+
+  listKeys(filters = {}) {
+    const store = this.readStore();
+    const keys = store.keys
+      .filter((apiKey) => !filters.state || computeKeyState(apiKey) === filters.state)
+      .filter((apiKey) => !filters.agentId || apiKey.subject.agentId === filters.agentId)
+      .map((apiKey) => serializeApiKey(apiKey));
+
+    return {
+      keys,
+      auditEvents: filters.includeAudit === true ? store.auditEvents.map((event) => ({ ...event })) : undefined,
+    };
+  }
+
+  createKey(input, admin) {
+    const label = String(input.label || '').trim();
+    if (!label) {
+      throw new Error('label is required.');
+    }
+
+    const subject = normalizeSubject(input.subject);
+    const permissions = normalizePermissions(input.permissions);
+    const repoScopes = normalizeRepoScopes(input.repos);
+    const issuer = normalizeIssuer(input.issuer, admin && admin.name);
+    const store = this.readStore();
+    const id = crypto.randomUUID();
+    const secret = crypto.randomBytes(24).toString('base64url');
+    const apiKey = {
+      id,
+      label,
+      subject,
+      permissions,
+      allRepos: repoScopes.allRepos,
+      repos: repoScopes.repos,
+      createdAt: new Date().toISOString(),
+      rotatedAt: null,
+      lastUsedAt: null,
+      revokedAt: null,
+      revokedReason: null,
+      secretHash: hashSecret(secret),
+    };
+
+    store.keys.push(apiKey);
+    store.auditEvents.push(createAuditEvent('api_key.created', {
+      keyId: apiKey.id,
+      subjectAgentId: apiKey.subject.agentId,
+      subjectCompanyId: apiKey.subject.companyId,
+      issuer,
+      permissions: { ...apiKey.permissions },
+    }));
+    this.writeStore(store);
+
+    return {
+      key: serializeApiKey(apiKey),
+      token: secret,
+    };
+  }
+
+  rotateKey(keyId, input, admin) {
+    const reason = String(input.reason || '').trim();
+    const issuer = normalizeIssuer(input.issuer, admin && admin.name);
+    const store = this.readStore();
+    const apiKey = store.keys.find((entry) => entry.id === keyId);
+    if (!apiKey || computeKeyState(apiKey) !== 'active') {
+      const error = new Error('Agent API key not found.');
+      error.code = 'ENOTFOUND';
+      throw error;
+    }
+
+    const secret = crypto.randomBytes(24).toString('base64url');
+    apiKey.secretHash = hashSecret(secret);
+    apiKey.rotatedAt = new Date().toISOString();
+    store.auditEvents.push(createAuditEvent('api_key.rotated', {
+      keyId: apiKey.id,
+      subjectAgentId: apiKey.subject.agentId,
+      subjectCompanyId: apiKey.subject.companyId,
+      issuer,
+      reasonProvided: Boolean(reason),
+    }));
+    this.writeStore(store);
+
+    return {
+      key: serializeApiKey(apiKey),
+      token: secret,
+    };
+  }
+
+  revokeKey(keyId, input, admin) {
+    const reason = String(input.reason || '').trim();
+    if (!reason) {
+      throw new Error('reason is required.');
+    }
+
+    const issuer = normalizeIssuer(input.issuer, admin && admin.name);
+    const store = this.readStore();
+    const apiKey = store.keys.find((entry) => entry.id === keyId);
+    if (!apiKey || computeKeyState(apiKey) !== 'active') {
+      const error = new Error('Agent API key not found.');
+      error.code = 'ENOTFOUND';
+      throw error;
+    }
+
+    apiKey.revokedAt = new Date().toISOString();
+    apiKey.revokedReason = reason;
+    store.auditEvents.push(createAuditEvent('api_key.revoked', {
+      keyId: apiKey.id,
+      subjectAgentId: apiKey.subject.agentId,
+      subjectCompanyId: apiKey.subject.companyId,
+      issuer,
+      reasonProvided: true,
+    }));
+    this.writeStore(store);
+
+    return {
+      key: serializeApiKey(apiKey),
+    };
+  }
+
+  recordAuditEvent(type, accessContext, target, metadata = {}) {
+    if (!accessContext || accessContext.authType !== 'api_key' || !accessContext.keyId) {
+      return null;
+    }
+
+    const store = this.readStore();
+    const event = createAuditEvent(type, {
+      keyId: accessContext.keyId,
+      actorAgentId: accessContext.subject && accessContext.subject.agentId ? accessContext.subject.agentId : null,
+      actorCompanyId: accessContext.subject && accessContext.subject.companyId ? accessContext.subject.companyId : null,
+      resourceKind: target && target.repo ? 'repo' : null,
+      resourceId: target && target.repo ? String(target.repo) : null,
+      outcome: typeof metadata.outcome === 'string' ? metadata.outcome : null,
+      requestId: typeof metadata.requestId === 'string' ? metadata.requestId : null,
+      byteCount: Number.isSafeInteger(metadata.byteCount) && metadata.byteCount >= 0 ? metadata.byteCount : null,
+    });
+    store.auditEvents.push(event);
+    this.writeStore(store);
+    return event;
+  }
+}
+
+module.exports = {
+  ApiKeyStore,
+};

--- a/lib/api-key-store.js
+++ b/lib/api-key-store.js
@@ -15,12 +15,8 @@ const DEFAULT_STORE = {
 };
 
 function constantTimeEqual(left, right) {
-  const leftBuffer = Buffer.from(String(left || ''), 'utf8');
-  const rightBuffer = Buffer.from(String(right || ''), 'utf8');
-
-  if (leftBuffer.length !== rightBuffer.length) {
-    return false;
-  }
+  const leftBuffer = crypto.createHash('sha256').update(String(left || ''), 'utf8').digest();
+  const rightBuffer = crypto.createHash('sha256').update(String(right || ''), 'utf8').digest();
 
   return crypto.timingSafeEqual(leftBuffer, rightBuffer);
 }

--- a/lib/grant-store.js
+++ b/lib/grant-store.js
@@ -88,13 +88,14 @@ function hashSecret(secret) {
 function normalizePermissions(rawPermissions) {
   const permissions = rawPermissions && typeof rawPermissions === 'object' ? rawPermissions : {};
   const write = permissions.write === true || permissions.edit === true;
-  const view = permissions.view !== false || write;
+  const publish = permissions.publish === true;
+  const view = permissions.view !== false || write || publish;
 
-  if (!view && !write) {
+  if (!view && !write && !publish) {
     throw new Error('Grant must allow at least one permission.');
   }
 
-  return { view, write, edit: write };
+  return { view, write, edit: write, publish };
 }
 
 function normalizePaths(rawPaths) {
@@ -245,7 +246,11 @@ function describeGrantScope(grant) {
 
 function buildIssueComment(action, grant, extra = {}) {
   const issueLink = buildIssueLink(grant.sourceIssueId) || grant.sourceIssueId;
-  const permissionLabel = grant.permissions.write ? 'view + write' : 'view';
+  const permissionLabel = [
+    grant.permissions.view && 'view',
+    grant.permissions.write && 'write',
+    grant.permissions.publish && 'publish',
+  ].filter(Boolean).join(' + ');
   const scopeLabel = describeGrantScope(grant);
   const lines = [];
 

--- a/lib/grant-store.js
+++ b/lib/grant-store.js
@@ -21,12 +21,8 @@ const ISSUER_ROLES = new Set([
 ]);
 
 function constantTimeEqual(left, right) {
-  const leftBuffer = Buffer.from(String(left || ''), 'utf8');
-  const rightBuffer = Buffer.from(String(right || ''), 'utf8');
-
-  if (leftBuffer.length !== rightBuffer.length) {
-    return false;
-  }
+  const leftBuffer = crypto.createHash('sha256').update(String(left || ''), 'utf8').digest();
+  const rightBuffer = crypto.createHash('sha256').update(String(right || ''), 'utf8').digest();
 
   return crypto.timingSafeEqual(leftBuffer, rightBuffer);
 }
@@ -46,6 +42,7 @@ function cloneStore(store) {
 function readStoreFromDisk(storePath) {
   try {
     const raw = fs.readFileSync(storePath, 'utf8');
+    fs.chmodSync(storePath, 0o600);
     const parsed = isYamlPath(storePath) ? yaml.load(raw) : JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') {
       return cloneStore(DEFAULT_STORE);
@@ -70,8 +67,18 @@ function writeSerializedFile(targetPath, serialized, prefix) {
     path.dirname(targetPath),
     `.${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
   );
-  fs.writeFileSync(tempPath, serialized, 'utf8');
-  fs.renameSync(tempPath, targetPath);
+  try {
+    fs.writeFileSync(tempPath, serialized, { encoding: 'utf8', mode: 0o600 });
+    fs.renameSync(tempPath, targetPath);
+    fs.chmodSync(targetPath, 0o600);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch (_cleanupError) {
+      // Best effort cleanup; preserve the original write error.
+    }
+    throw error;
+  }
 }
 
 function writeStoreToDisk(storePath, store) {
@@ -198,8 +205,9 @@ function computeGrantState(grant, now = Date.now()) {
 }
 
 function serializeGrant(grant, now = Date.now()) {
+  const { tokenHash: _tokenHash, ...projection } = grant;
   return {
-    ...grant,
+    ...projection,
     state: computeGrantState(grant, now),
   };
 }
@@ -214,7 +222,6 @@ function serializeGrantProjection(grant) {
     paths: Array.isArray(grant.paths) ? [...grant.paths] : [],
     permissions: { ...grant.permissions },
     expiresAt: grant.expiresAt,
-    tokenHash: grant.tokenHash,
   };
 }
 
@@ -248,7 +255,7 @@ function buildIssueComment(action, grant, extra = {}) {
   const issueLink = buildIssueLink(grant.sourceIssueId) || grant.sourceIssueId;
   const permissionLabel = [
     grant.permissions.view && 'view',
-    grant.permissions.write && 'write',
+    (grant.permissions.write || grant.permissions.edit) && 'write',
     grant.permissions.publish && 'publish',
   ].filter(Boolean).join(' + ');
   const scopeLabel = describeGrantScope(grant);

--- a/lib/grant-store.js
+++ b/lib/grant-store.js
@@ -87,14 +87,14 @@ function hashSecret(secret) {
 
 function normalizePermissions(rawPermissions) {
   const permissions = rawPermissions && typeof rawPermissions === 'object' ? rawPermissions : {};
-  const edit = permissions.edit === true;
-  const view = permissions.view !== false || edit;
+  const write = permissions.write === true || permissions.edit === true;
+  const view = permissions.view !== false || write;
 
-  if (!view && !edit) {
+  if (!view && !write) {
     throw new Error('Grant must allow at least one permission.');
   }
 
-  return { view, edit };
+  return { view, write, edit: write };
 }
 
 function normalizePaths(rawPaths) {
@@ -245,7 +245,7 @@ function describeGrantScope(grant) {
 
 function buildIssueComment(action, grant, extra = {}) {
   const issueLink = buildIssueLink(grant.sourceIssueId) || grant.sourceIssueId;
-  const permissionLabel = grant.permissions.edit ? 'view + edit' : 'view';
+  const permissionLabel = grant.permissions.write ? 'view + write' : 'view';
   const scopeLabel = describeGrantScope(grant);
   const lines = [];
 
@@ -389,7 +389,7 @@ function requiresApproval({ permissions, paths, subject, expiresAt, now }) {
   const broadSubject = subject.agents === 'all' || subject.userIds.length > 0;
   const wholeRepo = paths.length === 0;
 
-  return permissions.edit || wholeRepo || durationMs > sevenDaysMs || broadSubject;
+  return permissions.write || wholeRepo || durationMs > sevenDaysMs || broadSubject;
 }
 
 function createAuditEvent(grantId, type, actor, extra = {}) {
@@ -715,7 +715,7 @@ class GrantStore {
     }
 
     if (requiresApproval({ permissions, paths, subject, expiresAt, now: Date.now() }) && !approvalId) {
-      throw new Error('approvalId is required for edit access, whole-repo access, broad subjects, or expiry longer than 7 days.');
+      throw new Error('approvalId is required for write access, whole-repo access, broad subjects, or expiry longer than 7 days.');
     }
 
     let validatedAdapterAllowRoots = [];

--- a/lib/grant-store.js
+++ b/lib/grant-store.js
@@ -334,13 +334,39 @@ function scopesFromPaths(paths) {
 }
 
 function buildAccessContextForGrant(grant, source, queryToken) {
+  const subject = {
+    ...grant.subject,
+    agentIds: Array.isArray(grant.subject.agentIds) ? [...grant.subject.agentIds] : [],
+    userIds: Array.isArray(grant.subject.userIds) ? [...grant.subject.userIds] : [],
+  };
+  const unambiguousAgentId = subject.agents !== 'all'
+    && subject.agentIds.length === 1
+    && subject.userIds.length === 0
+    ? subject.agentIds[0]
+    : null;
+
   return {
     mode: 'scoped',
+    authType: 'grant',
     tokenName: `grant:${grant.id}`,
     grantId: grant.id,
+    subject,
+    principal: unambiguousAgentId ? {
+      kind: 'agent',
+      id: unambiguousAgentId,
+      credentialKind: 'grant',
+      credentialId: grant.id,
+      grantId: grant.id,
+    } : null,
+    issuer: {
+      agentId: grant.issuedByAgentId || null,
+      userId: grant.issuedByUserId || null,
+    },
+    sourceCompanyId: grant.sourceCompanyId,
+    targetCompanyId: grant.targetCompanyId,
     source,
     queryToken: source === 'query' ? queryToken : null,
-    permissions: grant.permissions,
+    permissions: { ...grant.permissions },
     allRepos: false,
     repos: {
       [grant.repoId]: scopesFromPaths(grant.paths),
@@ -626,7 +652,7 @@ class GrantStore {
 
     for (const grant of store.grants) {
       const state = computeGrantState(grant, now);
-      if (grant.tokenHash !== hash || state !== 'active') {
+      if (!constantTimeEqual(grant.tokenHash, hash) || state !== 'active') {
         continue;
       }
 
@@ -691,6 +717,9 @@ class GrantStore {
 
     const issuer = normalizeIssuer(input.issuer);
     const subject = normalizeSubject(input.subject, targetCompanyId);
+    if (subject.companyId !== targetCompanyId) {
+      throw new Error('Grant subject.companyId must match targetCompanyId.');
+    }
     const permissions = normalizePermissions(input.permissions);
     const paths = normalizePaths(input.paths);
     const reason = String(input.reason || '').trim();

--- a/lookie-link.yaml.example
+++ b/lookie-link.yaml.example
@@ -59,6 +59,11 @@ repositories:
 #         view: true
 #         write: true
 #         publish: false
+#   apiKeys:
+#     storePath: ~/.local/share/lookie-link/agent-api-keys.yaml
+#     adminTokens:
+#       local_operator:
+#         secretEnv: LOOKIE_LINK_AGENT_KEY_ADMIN_TOKEN
 #   grants:
 #     storePath: ~/.local/share/lookie-link/grants.yaml
 #     projectionPath: ~/.local/share/lookie-link/grants-projection.yaml

--- a/lookie-link.yaml.example
+++ b/lookie-link.yaml.example
@@ -48,16 +48,16 @@ repositories:
 #             - README.md
 #       permissions:
 #         view: true
-#         edit: false
-#     docs_editor:
-#       secretEnv: LOOKIE_TOKEN_DOCS_EDITOR
+#         write: false
+#     docs_writer:
+#       secretEnv: LOOKIE_TOKEN_DOCS_WRITER
 #       repos:
 #         docs:
 #           paths:
 #             - drafts/
 #       permissions:
 #         view: true
-#         edit: true
+#         write: true
 #   grants:
 #     storePath: ~/.local/share/lookie-link/grants.yaml
 #     projectionPath: ~/.local/share/lookie-link/grants-projection.yaml

--- a/lookie-link.yaml.example
+++ b/lookie-link.yaml.example
@@ -58,6 +58,7 @@ repositories:
 #       permissions:
 #         view: true
 #         write: true
+#         publish: false
 #   grants:
 #     storePath: ~/.local/share/lookie-link/grants.yaml
 #     projectionPath: ~/.local/share/lookie-link/grants-projection.yaml

--- a/server.js
+++ b/server.js
@@ -18,15 +18,18 @@ const {
 } = require('./lib/config');
 const {
   parseAccessConfig,
-  authenticateRequest,
   canAccessPath,
   appendAccessToken,
+  extractBearerToken,
   extractPresentedToken,
+  mutationUsesQueryToken,
+  resolveCredentialAccess,
 } = require('./lib/access-control');
 const {
   GrantStore,
   buildIssueComment,
 } = require('./lib/grant-store');
+const { ApiKeyStore } = require('./lib/api-key-store');
 const {
   safeResolve,
   toPosixPath,
@@ -282,6 +285,10 @@ function sendGrantJsonError(res, status, error) {
   res.status(status).json({ ok: false, error });
 }
 
+function sendApiKeyJsonError(res, status, error) {
+  res.status(status).json({ ok: false, error });
+}
+
 function createApp(options = {}) {
   const app = express();
   const mappings = options.mappings || loadRootMappings();
@@ -291,6 +298,9 @@ function createApp(options = {}) {
   const customThemeCss = options.customThemeCss || '';
   const rawAccessConfig = options.accessConfig === undefined ? getAccessConfig() : options.accessConfig;
   const accessConfig = parseAccessConfig(rawAccessConfig);
+  const apiKeyStore = options.apiKeyStore === undefined
+    ? ApiKeyStore.fromAccessConfig(rawAccessConfig.apiKeys)
+    : options.apiKeyStore;
   const grantStore = options.grantStore === undefined
     ? GrantStore.fromAccessConfig(rawAccessConfig.grants)
     : options.grantStore;
@@ -299,22 +309,7 @@ function createApp(options = {}) {
       return req.accessContext;
     }
 
-    const accessContext = authenticateRequest(req, accessConfig);
-    if (accessContext.mode === 'scoped' || !grantStore || !grantStore.isEnabled()) {
-      return accessContext;
-    }
-
-    const presentedToken = extractPresentedToken(req);
-    if (!presentedToken) {
-      return accessContext;
-    }
-
-    const grantAccess = grantStore.authenticateGrantToken(
-      presentedToken,
-      accessContext.source || null,
-      accessContext.queryToken || null
-    );
-    return grantAccess || accessContext;
+    return resolveCredentialAccess(req, accessConfig, apiKeyStore, grantStore);
   };
 
   const authenticateGrantAdmin = (req) => {
@@ -335,10 +330,42 @@ function createApp(options = {}) {
     return { ok: true, admin };
   };
 
+  const authenticateApiKeyAdmin = (req) => {
+    if (!apiKeyStore || !apiKeyStore.isEnabled()) {
+      return { ok: false, status: 404, error: 'Agent API keys are not configured.' };
+    }
+
+    const secret = extractBearerToken(req);
+    if (!secret) {
+      return { ok: false, status: 401, error: 'Agent API key admin authentication required.' };
+    }
+
+    const admin = apiKeyStore.authenticateAdminToken(secret);
+    if (!admin) {
+      return { ok: false, status: 403, error: 'Invalid agent API key admin token.' };
+    }
+
+    return { ok: true, admin };
+  };
+
+  const recordApiKeyAuditEvent = (type, accessContext, target, metadata) => {
+    if (!apiKeyStore || !apiKeyStore.isEnabled()) {
+      return null;
+    }
+    return apiKeyStore.recordAuditEvent(type, accessContext, target, metadata);
+  };
+
   app.disable('x-powered-by');
   app.set('trust proxy', true);
 
   app.use(express.json({ limit: '2mb' }));
+  app.use((req, res, next) => {
+    if (mutationUsesQueryToken(req)) {
+      res.status(400).json({ ok: false, error: 'Mutation credentials must use the Authorization header.' });
+      return;
+    }
+    next();
+  });
   app.use((req, _res, next) => {
     req.accessContext = resolveAccessContext(req);
     next();
@@ -347,6 +374,72 @@ function createApp(options = {}) {
     etag: true,
     maxAge: '1h',
   }));
+
+  app.get('/api/agent-keys', (req, res) => {
+    const auth = authenticateApiKeyAdmin(req);
+    if (!auth.ok) {
+      sendApiKeyJsonError(res, auth.status, auth.error);
+      return;
+    }
+
+    try {
+      const result = apiKeyStore.listKeys({
+        state: typeof req.query.state === 'string' ? req.query.state.trim() : undefined,
+        agentId: typeof req.query.agentId === 'string' ? req.query.agentId.trim() : undefined,
+        includeAudit: parseBooleanQuery(req.query.includeAudit),
+      });
+      res.status(200).json({ ok: true, ...result });
+    } catch (error) {
+      sendApiKeyJsonError(res, 400, error.message);
+    }
+  });
+
+  app.post('/api/agent-keys', (req, res) => {
+    const auth = authenticateApiKeyAdmin(req);
+    if (!auth.ok) {
+      sendApiKeyJsonError(res, auth.status, auth.error);
+      return;
+    }
+
+    try {
+      const result = apiKeyStore.createKey(req.body || {}, auth.admin);
+      res.status(201).json({ ok: true, ...result });
+    } catch (error) {
+      sendApiKeyJsonError(res, 400, error.message);
+    }
+  });
+
+  app.post('/api/agent-keys/:keyId/rotate', (req, res) => {
+    const auth = authenticateApiKeyAdmin(req);
+    if (!auth.ok) {
+      sendApiKeyJsonError(res, auth.status, auth.error);
+      return;
+    }
+
+    try {
+      const result = apiKeyStore.rotateKey(req.params.keyId, req.body || {}, auth.admin);
+      res.status(200).json({ ok: true, ...result });
+    } catch (error) {
+      const status = error.code === 'ENOTFOUND' ? 404 : 400;
+      sendApiKeyJsonError(res, status, error.code === 'ENOTFOUND' ? 'Agent API key not found.' : error.message);
+    }
+  });
+
+  app.post('/api/agent-keys/:keyId/revoke', (req, res) => {
+    const auth = authenticateApiKeyAdmin(req);
+    if (!auth.ok) {
+      sendApiKeyJsonError(res, auth.status, auth.error);
+      return;
+    }
+
+    try {
+      const result = apiKeyStore.revokeKey(req.params.keyId, req.body || {}, auth.admin);
+      res.status(200).json({ ok: true, ...result });
+    } catch (error) {
+      const status = error.code === 'ENOTFOUND' ? 404 : 400;
+      sendApiKeyJsonError(res, status, error.code === 'ENOTFOUND' ? 'Agent API key not found.' : error.message);
+    }
+  });
 
   app.get('/api/grants', (req, res) => {
     const auth = authenticateGrantAdmin(req);
@@ -816,7 +909,7 @@ function createApp(options = {}) {
       mtime: formatMTime(stat.mtime),
       size: formatFileSize(stat.size),
       viewHref: appendAccessToken(buildHref(repo, relativePath), accessContext),
-      saveHref: appendAccessToken(buildSaveHref(repo, relativePath), accessContext),
+      saveHref: buildSaveHref(repo, relativePath),
       previewHref: appendAccessToken(buildPreviewHref(repo, relativePath), accessContext),
       customThemeCss,
       queryToken: accessContext.queryToken,
@@ -949,6 +1042,11 @@ function createApp(options = {}) {
       res.status(500).json({ ok: false, error: 'Saved file but failed to fetch metadata.' });
       return;
     }
+
+    recordApiKeyAuditEvent('content.write', accessContext, { repo, relativePath }, {
+      outcome: 'accepted',
+      byteCount: Buffer.byteLength(content, 'utf8'),
+    });
 
     res.status(200).json({
       ok: true,

--- a/server.js
+++ b/server.js
@@ -938,7 +938,7 @@ function createApp(options = {}) {
       size: formatFileSize(stat.size),
       viewHref: appendAccessToken(buildHref(repo, relativePath), accessContext),
       saveHref: buildSaveHref(repo, relativePath),
-      previewHref: appendAccessToken(buildPreviewHref(repo, relativePath), accessContext),
+      previewHref: buildPreviewHref(repo, relativePath),
       customThemeCss,
       queryToken: accessContext.queryToken,
     });

--- a/test/access-control.test.js
+++ b/test/access-control.test.js
@@ -284,12 +284,27 @@ test('edit-scoped token can save while restricted humans and invalid tokens are 
     const editPage = await server.request('/edit/alpha/docs/guide.md?token=editor-token');
     assert.equal(editPage.status, 200);
     const editHtml = await editPage.text();
-    assert.match(editHtml, /"saveHref":"\/api\/save\/alpha\/docs\/guide\.md\?token=editor-token"/);
+    assert.match(editHtml, /"saveHref":"\/api\/save\/alpha\/docs\/guide\.md"/);
+    assert.doesNotMatch(editHtml, /api\/save[^"\\]*token=/);
 
     const beforeStat = await fs.stat(targetFile);
-    const saveResponse = await server.request('/api/save/alpha/docs/guide.md?token=editor-token', {
+    const querySave = await server.request('/api/save/alpha/docs/guide.md?token=editor-token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: '# Updated\n',
+        expectedMtimeMs: Math.trunc(beforeStat.mtimeMs),
+      }),
+    });
+    assert.equal(querySave.status, 400);
+    assert.equal(await fs.readFile(targetFile, 'utf8'), '# Guide\n![Diagram](diagram.png)\n');
+
+    const saveResponse = await server.request('/api/save/alpha/docs/guide.md', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer editor-token',
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({
         content: '# Updated\n',
         expectedMtimeMs: Math.trunc(beforeStat.mtimeMs),

--- a/test/access-control.test.js
+++ b/test/access-control.test.js
@@ -131,9 +131,10 @@ test('query token scopes repo listings and preserves tokenized navigation', asyn
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content: '# Preview\n' }),
     });
-    assert.equal(previewResponse.status, 200);
+    assert.equal(previewResponse.status, 400);
     const previewPayload = await previewResponse.json();
-    assert.equal(previewPayload.ok, true);
+    assert.equal(previewPayload.ok, false);
+    assert.equal(JSON.stringify(previewPayload).includes('viewer-token'), false);
   } finally {
     await server.close();
     await fs.rm(fixture.root, { recursive: true, force: true });
@@ -257,6 +258,7 @@ test('edit-scoped token can save while restricted humans and invalid tokens are 
   const server = await startTestServer({
     mappings: fixture.mappings,
     editingEnabled: true,
+    annotationsEnabled: true,
     accessConfig: {
       humanDefault: 'restricted',
       tokens: {
@@ -285,19 +287,65 @@ test('edit-scoped token can save while restricted humans and invalid tokens are 
     assert.equal(editPage.status, 200);
     const editHtml = await editPage.text();
     assert.match(editHtml, /"saveHref":"\/api\/save\/alpha\/docs\/guide\.md"/);
+    assert.match(editHtml, /"previewHref":"\/api\/preview\/alpha\/docs\/guide\.md"/);
     assert.doesNotMatch(editHtml, /api\/save[^"\\]*token=/);
+    assert.doesNotMatch(editHtml, /api\/preview[^"\\]*token=/);
 
     const beforeStat = await fs.stat(targetFile);
-    const querySave = await server.request('/api/save/alpha/docs/guide.md?token=editor-token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        content: '# Updated\n',
+    const annotationSidecar = path.join(
+      fixture.mappings.alpha,
+      '.lookie-link',
+      'annotations',
+      'alpha',
+      'docs',
+      'guide.md.json'
+    );
+    const rejectedMutations = [
+      ['/api/save/alpha/docs/guide.md?token=editor-token', {
+        content: '# Lowercase query-token write\n',
         expectedMtimeMs: Math.trunc(beforeStat.mtimeMs),
-      }),
-    });
-    assert.equal(querySave.status, 400);
-    assert.equal(await fs.readFile(targetFile, 'utf8'), '# Guide\n![Diagram](diagram.png)\n');
+      }],
+      ['/API/SAVE/alpha/docs/guide.md?token=editor-token', {
+        content: '# Uppercase query-token write\n',
+        expectedMtimeMs: Math.trunc(beforeStat.mtimeMs),
+      }],
+      ['/api/annotations/alpha/docs/guide.md?token=editor-token', {
+        anchor: '#guide',
+        anchorKind: 'heading',
+        author: 'query-token-writer',
+        body: 'Lowercase annotation mutation',
+      }],
+      ['/API/ANNOTATIONS/alpha/docs/guide.md?token=editor-token', {
+        anchor: '#guide',
+        anchorKind: 'heading',
+        author: 'query-token-writer',
+        body: 'Mixed-case annotation mutation',
+      }],
+    ];
+
+    for (const [requestPath, body] of rejectedMutations) {
+      const response = await server.request(requestPath, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      assert.equal(response.status, 400, requestPath);
+      assert.equal(await fs.readFile(targetFile, 'utf8'), '# Guide\n![Diagram](diagram.png)\n');
+      await assert.rejects(fs.stat(annotationSidecar), (error) => error && error.code === 'ENOENT');
+    }
+
+    for (const requestPath of [
+      '/api/preview/alpha/docs/guide.md?token=editor-token',
+      '/API/PREVIEW/alpha/docs/guide.md?token=editor-token',
+    ]) {
+      const response = await server.request(requestPath, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: '# Query token must not be echoed: editor-token\n' }),
+      });
+      assert.equal(response.status, 400, requestPath);
+      assert.equal((await response.text()).includes('editor-token'), false);
+    }
 
     const saveResponse = await server.request('/api/save/alpha/docs/guide.md', {
       method: 'POST',
@@ -603,6 +651,10 @@ test('managed grant API creates issue-linked grants and enforces grant tokens', 
     const projectionRaw = await fs.readFile(fixture.grantPaths.projection, 'utf8');
     assert.match(projectionRaw, /id:/);
     assert.doesNotMatch(projectionRaw, /Cross-company review requested in issue/);
+    assert.doesNotMatch(projectionRaw, /tokenHash/);
+    assert.equal((await fs.stat(fixture.grantPaths.store)).mode & 0o777, 0o600);
+    assert.equal((await fs.stat(fixture.grantPaths.projection)).mode & 0o777, 0o600);
+    assert.equal(Object.hasOwn(createPayload.grant, 'tokenHash'), false);
 
     const listResponse = await server.request('/api/grants?state=active&includeAudit=1', {
       headers: {
@@ -612,6 +664,7 @@ test('managed grant API creates issue-linked grants and enforces grant tokens', 
     assert.equal(listResponse.status, 200);
     const listPayload = await listResponse.json();
     assert.equal(listPayload.grants.length, 1);
+    assert.equal(Object.hasOwn(listPayload.grants[0], 'tokenHash'), false);
     assert.ok(Array.isArray(listPayload.auditEvents));
 
     const renewResponse = await server.request(`/api/grants/${createPayload.grant.id}/renew`, {

--- a/test/api-key-store.test.js
+++ b/test/api-key-store.test.js
@@ -1,0 +1,272 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ApiKeyStore } = require('../lib/api-key-store');
+const {
+  mutationUsesQueryToken,
+  parseAccessConfig,
+  resolveCredentialAccess,
+} = require('../lib/access-control');
+const { createApp } = require('../server');
+
+function bearerRequest(secret, query = {}) {
+  return {
+    method: 'GET',
+    path: '/view/docs/readme.md',
+    headers: { authorization: `Bearer ${secret}` },
+    query,
+    get(name) {
+      return this.headers[String(name).toLowerCase()] || null;
+    },
+  };
+}
+
+function makeStore(storePath) {
+  return new ApiKeyStore({
+    storePath,
+    adminTokens: [{ name: 'local_operator', secret: 'admin-placeholder-secret' }],
+  });
+}
+
+function keyInput() {
+  return {
+    label: 'Example automation',
+    subject: {
+      companyId: 'example-company',
+      agentId: 'agent-example',
+      label: 'Display label is not audit identity',
+    },
+    permissions: { view: true, write: true, publish: false },
+    repos: { docs: { paths: ['drafts/'] } },
+    issuer: {
+      actorType: 'operator',
+      actorId: 'operator',
+      actorLabel: 'Display label is redacted from audit',
+    },
+  };
+}
+
+function captureResponse() {
+  const captured = { status: null, body: null };
+  return {
+    captured,
+    response: {
+      status(status) {
+        captured.status = status;
+        return this;
+      },
+      json(body) {
+        captured.body = body;
+        return this;
+      },
+    },
+  };
+}
+
+async function invokeRoute(app, routePath, req) {
+  const routeLayer = app._router.stack.find((layer) => layer.route && layer.route.path === routePath);
+  assert.ok(routeLayer, `expected route ${routePath}`);
+  const { captured, response } = captureResponse();
+  await routeLayer.route.stack[0].handle(req, response);
+  return captured;
+}
+
+test('managed API keys are hashed, mode 0600, one-time, rotatable, revocable, and audit-redacted', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-api-keys-'));
+  const storePath = path.join(root, 'agent-api-keys.json');
+  const store = makeStore(storePath);
+  const admin = store.authenticateAdminToken('admin-placeholder-secret');
+
+  try {
+    const created = store.createKey(keyInput(), admin);
+    assert.ok(created.token);
+    assert.equal(created.key.subject.agentId, 'agent-example');
+    assert.equal(Object.hasOwn(created.key, 'secretHash'), false);
+    assert.equal(Object.hasOwn(created.key, 'token'), false);
+
+    const initialRaw = await fs.readFile(storePath, 'utf8');
+    const initialDisk = JSON.parse(initialRaw);
+    assert.equal(initialRaw.includes(created.token), false);
+    assert.match(initialDisk.keys[0].secretHash, /^[a-f0-9]{64}$/);
+    assert.equal((await fs.stat(storePath)).mode & 0o777, 0o600);
+
+    const listed = store.listKeys({ includeAudit: true });
+    assert.equal(Object.hasOwn(listed.keys[0], 'secretHash'), false);
+    assert.equal(Object.hasOwn(listed.keys[0], 'token'), false);
+    const access = store.authenticateKey(created.token, 'header', null);
+    assert.deepEqual(access.principal, {
+      kind: 'agent',
+      id: 'agent-example',
+      credentialKind: 'api_key',
+      credentialId: created.key.id,
+    });
+
+    const rotated = store.rotateKey(created.key.id, { reason: created.token }, admin);
+    assert.ok(rotated.token);
+    assert.notEqual(rotated.token, created.token);
+    assert.equal(store.authenticateKey(created.token, 'header', null), null);
+    assert.equal(store.authenticateKey(rotated.token, 'header', null).keyId, created.key.id);
+
+    store.recordAuditEvent('content.write', store.authenticateKey(rotated.token, 'header', null), {
+      repo: 'docs',
+      relativePath: 'drafts/example.md',
+    }, {
+      outcome: 'accepted',
+      byteCount: 12,
+      secret: rotated.token,
+    });
+    const revoked = store.revokeKey(created.key.id, { reason: rotated.token }, admin);
+    assert.equal(revoked.key.state, 'revoked');
+    assert.equal(store.authenticateKey(rotated.token, 'header', null), null);
+
+    const finalDisk = JSON.parse(await fs.readFile(storePath, 'utf8'));
+    const auditJson = JSON.stringify(finalDisk.auditEvents);
+    assert.equal(auditJson.includes(created.token), false);
+    assert.equal(auditJson.includes(rotated.token), false);
+    assert.equal(auditJson.includes('Display label is redacted from audit'), false);
+    assert.equal(auditJson.includes('Display label is not audit identity'), false);
+    assert.equal((await fs.stat(storePath)).mode & 0o777, 0o600);
+
+    for (const keyId of [created.key.id, 'random-key-id']) {
+      assert.throws(
+        () => store.rotateKey(keyId, {}, admin),
+        (error) => error.code === 'ENOTFOUND' && error.message === 'Agent API key not found.'
+      );
+      assert.throws(
+        () => store.revokeKey(keyId, { reason: 'repeat' }, admin),
+        (error) => error.code === 'ENOTFOUND' && error.message === 'Agent API key not found.'
+      );
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('API-key comparison explicitly uses timingSafeEqual', async () => {
+  const source = await fs.readFile(path.join(__dirname, '..', 'lib', 'api-key-store.js'), 'utf8');
+  assert.match(source, /crypto\.timingSafeEqual\(/);
+  assert.match(source, /constantTimeEqual\(apiKey\.secretHash, hash\)/);
+  assert.doesNotMatch(source, /apiKey\.secretHash\s*!==\s*hash/);
+});
+
+test('credentials resolve static token then API key then grant with header precedence', () => {
+  const calls = [];
+  const apiKeyStore = {
+    isEnabled: () => true,
+    authenticateKey(secret, source, queryToken) {
+      calls.push(['api_key', secret, source, queryToken]);
+      return secret === 'api-placeholder' ? { mode: 'scoped', authType: 'api_key' } : null;
+    },
+  };
+  const grantStore = {
+    isEnabled: () => true,
+    authenticateGrantToken(secret, source, queryToken) {
+      calls.push(['grant', secret, source, queryToken]);
+      return secret === 'grant-placeholder' ? { mode: 'scoped', authType: 'grant' } : null;
+    },
+  };
+  const staticConfig = parseAccessConfig({
+    humanDefault: 'restricted',
+    tokens: {
+      static: { secret: 'static-placeholder', repos: 'all', permissions: { view: true } },
+    },
+  });
+
+  const staticAccess = resolveCredentialAccess(
+    bearerRequest('static-placeholder', { token: 'api-placeholder' }),
+    staticConfig,
+    apiKeyStore,
+    grantStore
+  );
+  assert.equal(staticAccess.authType, 'static_token');
+  assert.deepEqual(calls, []);
+
+  const deniedStaticConfig = parseAccessConfig({ humanDefault: 'restricted' });
+  const apiAccess = resolveCredentialAccess(
+    bearerRequest('api-placeholder', { token: 'grant-placeholder' }),
+    deniedStaticConfig,
+    apiKeyStore,
+    grantStore
+  );
+  assert.equal(apiAccess.authType, 'api_key');
+  assert.deepEqual(calls, [['api_key', 'api-placeholder', 'header', null]]);
+
+  calls.length = 0;
+  const grantAccess = resolveCredentialAccess(
+    bearerRequest('grant-placeholder'),
+    deniedStaticConfig,
+    apiKeyStore,
+    grantStore
+  );
+  assert.equal(grantAccess.authType, 'grant');
+  assert.deepEqual(calls, [
+    ['api_key', 'grant-placeholder', 'header', null],
+    ['grant', 'grant-placeholder', 'header', null],
+  ]);
+});
+
+test('mutation query tokens are rejected even when a bearer header is present', () => {
+  assert.equal(mutationUsesQueryToken({
+    method: 'POST',
+    path: '/api/save/docs/file.md',
+    headers: { authorization: 'Bearer header-placeholder' },
+    query: { token: 'query-placeholder' },
+  }), true);
+  assert.equal(mutationUsesQueryToken({
+    method: 'GET',
+    path: '/view/docs/file.md',
+    query: { token: 'query-placeholder' },
+  }), false);
+  assert.equal(mutationUsesQueryToken({
+    method: 'POST',
+    path: '/api/preview/docs/file.md',
+    query: { token: 'query-placeholder' },
+  }), false);
+});
+
+test('key-ID denials are uniform before and after authorized lookup', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-api-key-routes-'));
+  const store = makeStore(path.join(root, 'keys.json'));
+  const admin = store.authenticateAdminToken('admin-placeholder-secret');
+  const created = store.createKey(keyInput(), admin);
+  store.revokeKey(created.key.id, { reason: 'completed' }, admin);
+  const app = createApp({ mappings: {}, accessConfig: { humanDefault: 'restricted' }, apiKeyStore: store });
+
+  try {
+    const invalidKnown = await invokeRoute(app, '/api/agent-keys/:keyId/rotate', {
+      ...bearerRequest('invalid-admin'),
+      params: { keyId: created.key.id },
+      body: {},
+    });
+    const invalidRandom = await invokeRoute(app, '/api/agent-keys/:keyId/rotate', {
+      ...bearerRequest('invalid-admin'),
+      params: { keyId: 'random-key-id' },
+      body: {},
+    });
+    assert.deepEqual(invalidKnown, invalidRandom);
+    assert.equal(invalidKnown.status, 403);
+
+    const missingRevoked = await invokeRoute(app, '/api/agent-keys/:keyId/rotate', {
+      ...bearerRequest('admin-placeholder-secret'),
+      params: { keyId: created.key.id },
+      body: {},
+    });
+    const missingRandom = await invokeRoute(app, '/api/agent-keys/:keyId/rotate', {
+      ...bearerRequest('admin-placeholder-secret'),
+      params: { keyId: 'random-key-id' },
+      body: {},
+    });
+    assert.deepEqual(missingRevoked, missingRandom);
+    assert.deepEqual(missingRevoked, {
+      status: 404,
+      body: { ok: false, error: 'Agent API key not found.' },
+    });
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/api-key-store.test.js
+++ b/test/api-key-store.test.js
@@ -148,10 +148,16 @@ test('managed API keys are hashed, mode 0600, one-time, rotatable, revocable, an
 });
 
 test('API-key comparison explicitly uses timingSafeEqual', async () => {
-  const source = await fs.readFile(path.join(__dirname, '..', 'lib', 'api-key-store.js'), 'utf8');
-  assert.match(source, /crypto\.timingSafeEqual\(/);
-  assert.match(source, /constantTimeEqual\(apiKey\.secretHash, hash\)/);
-  assert.doesNotMatch(source, /apiKey\.secretHash\s*!==\s*hash/);
+  for (const relativePath of ['lib/access-control.js', 'lib/api-key-store.js', 'lib/grant-store.js']) {
+    const source = await fs.readFile(path.join(__dirname, '..', relativePath), 'utf8');
+    assert.match(source, /crypto\.createHash\('sha256'\).*\.digest\(\)/s);
+    assert.match(source, /crypto\.timingSafeEqual\(/);
+    assert.doesNotMatch(source, /if \(leftBuffer\.length !== rightBuffer\.length\)/);
+  }
+
+  const apiKeySource = await fs.readFile(path.join(__dirname, '..', 'lib', 'api-key-store.js'), 'utf8');
+  assert.match(apiKeySource, /constantTimeEqual\(apiKey\.secretHash, hash\)/);
+  assert.doesNotMatch(apiKeySource, /apiKey\.secretHash\s*!==\s*hash/);
 });
 
 test('credentials resolve static token then API key then grant with header precedence', () => {
@@ -226,7 +232,22 @@ test('mutation query tokens are rejected even when a bearer header is present', 
     method: 'POST',
     path: '/api/preview/docs/file.md',
     query: { token: 'query-placeholder' },
-  }), false);
+  }), true);
+  assert.equal(mutationUsesQueryToken({
+    method: 'PATCH',
+    path: '/API/ANNOTATIONS/docs/file.md',
+    query: { token: 'query-placeholder' },
+  }), true);
+  assert.equal(mutationUsesQueryToken({
+    method: 'DELETE',
+    path: '/future/mutation',
+    query: { token: 'query-placeholder' },
+  }), true);
+  assert.equal(mutationUsesQueryToken({
+    method: 'PUT',
+    path: '/future/mutation',
+    query: { token: '' },
+  }), true);
 });
 
 test('key-ID denials are uniform before and after authorized lookup', async () => {

--- a/test/auth-foundations.test.js
+++ b/test/auth-foundations.test.js
@@ -12,6 +12,7 @@ const {
   parseAccessConfig,
 } = require('../lib/access-control');
 const { GrantStore } = require('../lib/grant-store');
+const { createApp } = require('../server');
 
 function requestWithBearer(secret) {
   return {
@@ -34,7 +35,7 @@ test('static tokens normalize legacy edit and canonical write permissions', () =
     });
     const access = authenticateRequest(requestWithBearer('static-writer-placeholder'), config);
 
-    assert.deepEqual(access.permissions, { view: true, write: true, edit: true });
+    assert.deepEqual(access.permissions, { view: true, write: true, edit: true, publish: false });
     assert.equal(canAccessPath(access, 'write', 'docs', 'drafts/note.md'), true);
     assert.equal(canAccessPath(access, 'edit', 'docs', 'drafts/note.md'), true);
   }
@@ -85,9 +86,71 @@ test('managed grants normalize legacy edit to canonical write', async () => {
     });
     const access = store.authenticateGrantToken(created.token, 'header', null);
 
-    assert.deepEqual(created.grant.permissions, { view: true, write: true, edit: true });
+    assert.deepEqual(created.grant.permissions, { view: true, write: true, edit: true, publish: false });
     assert.equal(canAccessPath(access, 'write', 'docs', 'drafts/note.md'), true);
     assert.equal(canAccessPath(access, 'edit', 'docs', 'drafts/note.md'), true);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('publish is authorization vocabulary only and implies no write or endpoint', async () => {
+  const config = parseAccessConfig({
+    humanDefault: 'restricted',
+    tokens: {
+      publisher: {
+        secret: 'publisher-placeholder',
+        permissions: { view: false, publish: true },
+        repos: { docs: 'all' },
+      },
+    },
+  });
+  const access = authenticateRequest(requestWithBearer('publisher-placeholder'), config);
+
+  assert.deepEqual(access.permissions, { view: true, write: false, edit: false, publish: true });
+  assert.equal(canAccessPath(access, 'publish', 'docs', 'release.md'), true);
+  assert.equal(canAccessPath(access, 'write', 'docs', 'release.md'), false);
+
+  const app = createApp({ mappings: {}, accessConfig: config });
+  const routePaths = app._router.stack
+    .map((layer) => layer.route && layer.route.path)
+    .filter(Boolean);
+  assert.equal(routePaths.some((routePath) => String(routePath).includes('publish')), false);
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-auth-publish-'));
+  const repoRoot = path.join(root, 'docs');
+  await fs.mkdir(repoRoot);
+  const grantStore = new GrantStore({
+    storePath: path.join(root, 'grants.json'),
+    projectionPath: null,
+    repoOwners: { docs: 'example-company' },
+    adminTokens: [],
+    repoRoots: { docs: repoRoot },
+  });
+
+  try {
+    const created = grantStore.createGrant({
+      repoId: 'docs',
+      sourceCompanyId: 'example-company',
+      targetCompanyId: 'example-company',
+      subject: { companyId: 'example-company', agentIds: ['agent-publisher'] },
+      permissions: { view: false, publish: true },
+      paths: ['releases/'],
+      sourceIssueId: 'EXAMPLE-2',
+      approvalId: 'APPROVAL-2',
+      reason: 'Authorization vocabulary test.',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      issuer: {
+        role: 'manager_agent',
+        companyId: 'example-company',
+        agentId: 'agent-manager',
+      },
+    });
+    const grantAccess = grantStore.authenticateGrantToken(created.token, 'header', null);
+
+    assert.deepEqual(created.grant.permissions, { view: true, write: false, edit: false, publish: true });
+    assert.equal(canAccessPath(grantAccess, 'publish', 'docs', 'releases/v1.md'), true);
+    assert.equal(canAccessPath(grantAccess, 'write', 'docs', 'releases/v1.md'), false);
   } finally {
     await fs.rm(root, { recursive: true, force: true });
   }

--- a/test/auth-foundations.test.js
+++ b/test/auth-foundations.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  authenticateRequest,
+  canAccessPath,
+  parseAccessConfig,
+} = require('../lib/access-control');
+const { GrantStore } = require('../lib/grant-store');
+
+function requestWithBearer(secret) {
+  return {
+    headers: { authorization: `Bearer ${secret}` },
+    query: {},
+  };
+}
+
+test('static tokens normalize legacy edit and canonical write permissions', () => {
+  for (const permissions of [{ edit: true }, { write: true }]) {
+    const config = parseAccessConfig({
+      humanDefault: 'restricted',
+      tokens: {
+        writer: {
+          secret: 'static-writer-placeholder',
+          permissions,
+          repos: { docs: { paths: ['drafts/'] } },
+        },
+      },
+    });
+    const access = authenticateRequest(requestWithBearer('static-writer-placeholder'), config);
+
+    assert.deepEqual(access.permissions, { view: true, write: true, edit: true });
+    assert.equal(canAccessPath(access, 'write', 'docs', 'drafts/note.md'), true);
+    assert.equal(canAccessPath(access, 'edit', 'docs', 'drafts/note.md'), true);
+  }
+});
+
+test('canAccessPath remains compatible with pre-normalized edit-only contexts', () => {
+  const legacyContext = {
+    mode: 'scoped',
+    permissions: { view: true, edit: true },
+    allRepos: true,
+    repos: {},
+  };
+
+  assert.equal(canAccessPath(legacyContext, 'write', 'docs', 'note.md'), true);
+  assert.equal(canAccessPath(legacyContext, 'edit', 'docs', 'note.md'), true);
+});
+
+test('managed grants normalize legacy edit to canonical write', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-auth-grant-'));
+  const storePath = path.join(root, 'grants.json');
+  const repoRoot = path.join(root, 'docs');
+  await fs.mkdir(repoRoot);
+  const store = new GrantStore({
+    storePath,
+    projectionPath: null,
+    repoOwners: { docs: 'example-company' },
+    adminTokens: [],
+    repoRoots: { docs: repoRoot },
+  });
+
+  try {
+    const created = store.createGrant({
+      repoId: 'docs',
+      sourceCompanyId: 'example-company',
+      targetCompanyId: 'example-company',
+      subject: { companyId: 'example-company', agentIds: ['agent-example'] },
+      permissions: { edit: true },
+      paths: ['drafts/'],
+      sourceIssueId: 'EXAMPLE-1',
+      approvalId: 'APPROVAL-1',
+      reason: 'Compatibility test.',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      issuer: {
+        role: 'manager_agent',
+        companyId: 'example-company',
+        agentId: 'agent-manager',
+      },
+    });
+    const access = store.authenticateGrantToken(created.token, 'header', null);
+
+    assert.deepEqual(created.grant.permissions, { view: true, write: true, edit: true });
+    assert.equal(canAccessPath(access, 'write', 'docs', 'drafts/note.md'), true);
+    assert.equal(canAccessPath(access, 'edit', 'docs', 'drafts/note.md'), true);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/grant-policy.test.js
+++ b/test/grant-policy.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { GrantStore } = require('../lib/grant-store');
+
+function grantInput(repoRoot, overrides = {}) {
+  return {
+    repoId: 'docs',
+    sourceCompanyId: 'source-company',
+    targetCompanyId: 'target-company',
+    subject: { companyId: 'target-company', agentIds: ['agent-example'] },
+    permissions: { view: true, write: false, publish: false },
+    paths: ['shared/'],
+    sourceIssueId: 'EXAMPLE-3',
+    approvalId: 'APPROVAL-3',
+    reason: 'Cross-company review.',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    issuer: {
+      role: 'manager_agent',
+      companyId: 'source-company',
+      agentId: 'agent-manager',
+    },
+    adapterAllowRoots: [repoRoot],
+    ...overrides,
+  };
+}
+
+test('grant access carries tested non-secret issuer and subject lineage', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-grant-policy-'));
+  const repoRoot = path.join(root, 'docs');
+  await fs.mkdir(path.join(repoRoot, 'shared'), { recursive: true });
+  const store = new GrantStore({
+    storePath: path.join(root, 'grants.json'),
+    projectionPath: null,
+    repoOwners: { docs: 'source-company' },
+    adminTokens: [],
+    repoRoots: { docs: repoRoot },
+  });
+
+  try {
+    const created = store.createGrant(grantInput(repoRoot));
+    const access = store.authenticateGrantToken(created.token, 'header', null);
+
+    assert.equal(access.authType, 'grant');
+    assert.equal(access.grantId, created.grant.id);
+    assert.deepEqual(access.subject, {
+      companyId: 'target-company',
+      agentIds: ['agent-example'],
+      userIds: [],
+      agents: null,
+    });
+    assert.deepEqual(access.principal, {
+      kind: 'agent',
+      id: 'agent-example',
+      credentialKind: 'grant',
+      credentialId: created.grant.id,
+      grantId: created.grant.id,
+    });
+    assert.deepEqual(access.issuer, { agentId: 'agent-manager', userId: null });
+    assert.equal(access.sourceCompanyId, 'source-company');
+    assert.equal(access.targetCompanyId, 'target-company');
+    assert.equal(Object.hasOwn(access, 'grant'), false);
+    assert.equal(JSON.stringify(access).includes('tokenHash'), false);
+    assert.equal(JSON.stringify(access).includes(repoRoot), false);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('grant subject company and cross-company allow roots are enforced', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-grant-roots-'));
+  const repoRoot = path.join(root, 'docs');
+  const outsideRoot = path.join(root, 'outside');
+  await fs.mkdir(path.join(repoRoot, 'shared'), { recursive: true });
+  await fs.mkdir(outsideRoot);
+  const store = new GrantStore({
+    storePath: path.join(root, 'grants.json'),
+    projectionPath: null,
+    repoOwners: { docs: 'source-company' },
+    adminTokens: [],
+    repoRoots: { docs: repoRoot },
+  });
+
+  try {
+    assert.throws(
+      () => store.createGrant(grantInput(repoRoot, {
+        subject: { companyId: 'unrelated-company', agentIds: ['agent-example'] },
+      })),
+      /subject\.companyId must match targetCompanyId/
+    );
+    assert.throws(
+      () => store.createGrant(grantInput(repoRoot, { adapterAllowRoots: undefined })),
+      /adapterAllowRoots is required/
+    );
+    assert.throws(
+      () => store.createGrant(grantInput(repoRoot, { adapterAllowRoots: [outsideRoot] })),
+      /outside adapter allow roots/
+    );
+    assert.doesNotThrow(() => store.createGrant(grantInput(repoRoot)));
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('grant hash lookup uses constant-time comparison', async () => {
+  const source = await fs.readFile(path.join(__dirname, '..', 'lib', 'grant-store.js'), 'utf8');
+  assert.match(source, /constantTimeEqual\(grant\.tokenHash, hash\)/);
+  assert.doesNotMatch(source, /grant\.tokenHash\s*!==\s*hash/);
+});

--- a/test/grant-policy.test.js
+++ b/test/grant-policy.test.js
@@ -6,7 +6,7 @@ const fs = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 
-const { GrantStore } = require('../lib/grant-store');
+const { GrantStore, buildIssueComment } = require('../lib/grant-store');
 
 function grantInput(repoRoot, overrides = {}) {
   return {
@@ -46,6 +46,7 @@ test('grant access carries tested non-secret issuer and subject lineage', async 
     const created = store.createGrant(grantInput(repoRoot));
     const access = store.authenticateGrantToken(created.token, 'header', null);
 
+    assert.equal(Object.hasOwn(created.grant, 'tokenHash'), false);
     assert.equal(access.authType, 'grant');
     assert.equal(access.grantId, created.grant.id);
     assert.deepEqual(access.subject, {
@@ -111,4 +112,54 @@ test('grant hash lookup uses constant-time comparison', async () => {
   const source = await fs.readFile(path.join(__dirname, '..', 'lib', 'grant-store.js'), 'utf8');
   assert.match(source, /constantTimeEqual\(grant\.tokenHash, hash\)/);
   assert.doesNotMatch(source, /grant\.tokenHash\s*!==\s*hash/);
+});
+
+test('grant storage and projections are private and public projections omit token hashes', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-grant-private-'));
+  const repoRoot = path.join(root, 'docs');
+  const storePath = path.join(root, 'grants.json');
+  const projectionPath = path.join(root, 'grants-projection.json');
+  await fs.mkdir(path.join(repoRoot, 'shared'), { recursive: true });
+  const store = new GrantStore({
+    storePath,
+    projectionPath,
+    repoOwners: { docs: 'source-company' },
+    adminTokens: [],
+    repoRoots: { docs: repoRoot },
+  });
+
+  try {
+    const created = store.createGrant(grantInput(repoRoot));
+    const persisted = JSON.parse(await fs.readFile(storePath, 'utf8'));
+    const projected = JSON.parse(await fs.readFile(projectionPath, 'utf8'));
+    const listed = store.listGrants();
+
+    assert.match(persisted.grants[0].tokenHash, /^[a-f0-9]{64}$/);
+    assert.equal(Object.hasOwn(created.grant, 'tokenHash'), false);
+    assert.equal(Object.hasOwn(projected.grants[0], 'tokenHash'), false);
+    assert.equal(Object.hasOwn(listed.grants[0], 'tokenHash'), false);
+    assert.equal((await fs.stat(storePath)).mode & 0o777, 0o600);
+    assert.equal((await fs.stat(projectionPath)).mode & 0o777, 0o600);
+
+    await fs.chmod(storePath, 0o644);
+    store.listGrants();
+    assert.equal((await fs.stat(storePath)).mode & 0o777, 0o600);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('legacy edit grants are labeled as write authority in issue comments', () => {
+  const comment = buildIssueComment('revoked', {
+    id: 'legacy-grant',
+    sourceIssueId: 'EXAMPLE-4',
+    repoId: 'docs',
+    paths: ['shared/'],
+    permissions: { view: true, edit: true },
+    targetCompanyId: 'example-company',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    revocationReason: 'Legacy grant audit test.',
+  });
+
+  assert.match(comment.markdown, /- Permissions: view \+ write/);
 });


### PR DESCRIPTION
Recreation of #145 (closed by GitHub when #140's base branch was deleted — original body incl. threat-model table there). Part of #91 Step 6. 24/24 tests + validators. **Hold for the in-flight independent security review before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)