### PR TITLE
feat: HTML bundle validation via ?validate=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Lookie-Link solves this by giving every file a URL. The agent modifies a documen
 ## Features
 
 - **File browser + renderer** — directory listings, rendered markdown/code/YAML views
-- **HTML rendering** — `.html` and `.htm` render as sanitized documents with a Raw toggle back to source view
+- **HTML rendering** — `.html` and `.htm` render as sanitized documents with a Raw toggle back to source view; `?validate=1` reports local asset and document-reference health as JSON
 - **PDF rendering** — `.pdf` files open in an embedded viewer page with browser-open and download actions
 - **Opt-in editable mode** — edit any non-binary file, then save back to disk
 - **Managed Paperclip grants** — issue time-limited repo/path tokens with audit history

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
 | `GET /` | Repository index |
 | `GET /healthz` | Health check (returns `{"status":"ok","editingEnabled":bool}`) |
 | `GET /api/repos` | Discover served repos as JSON (filtered by grant scope when a token is presented) |
-| `GET /view/<repo>/<path>` | Rendered file or directory listing |
+| `GET /view/<repo>/<path>` | Rendered file or directory listing. For `.html` and `.htm`, append `?validate=1` to inspect local asset and document references as JSON. |
 | `GET /asset/<repo>/<path>` | Raw asset serving. Supports `Range` requests so `<audio>` can seek, backs the embedded PDF viewer page, and is the agent-facing read path for text/source files (see `lookie-read` CLI in the repo `bin/`). MIME types: images (`.png`/`.jpg`/`.gif`/`.webp`/`.svg`/`.jpeg`), audio (`.m4a`/`.mp3`/`.wav`/`.ogg`/`.oga`/`.opus`/`.flac`/`.aac`), PDF (`.pdf`), markdown (`.md`/`.markdown`/`.mdown` → `text/markdown`), YAML (`.yaml`/`.yml` → `text/yaml`), JSON (`.json`), XML (`.xml`), and the editable text/source set (shell, Python, JS/TS, Go, Rust, C/C++, etc.) returned as `text/plain; charset=utf-8`. Anything else returns `415 Unsupported asset type`. |
 | `GET /edit/<repo>/<path>` | Edit page (only when editing enabled) |
 | `POST /api/save/<repo>/<path>` | Save updated file content (JSON body) |
@@ -38,6 +38,21 @@ Route enforcement in phase 1:
 - `/api/annotations/*` requires `view` and returns `404` when annotations are disabled
 
 Invalid tokens return `403`. Missing tokens return `401` when unauthenticated human access is restricted.
+
+## HTML Bundle Validation
+
+`GET /view/<repo>/<path>.html?validate=1`
+
+Returns the HTML source metadata, repo-relative view/asset URLs, local references
+from stylesheet, script, image, and source elements, and local HTML/directory
+navigation targets. Each reference includes its resolved repo-relative path,
+content type, existence, byte count, and rewritten view URL where applicable.
+The `summary` object provides missing and unsupported counts for automated checks.
+
+Validation uses the caller's normal `view` scope for every referenced target.
+An unreadable target is reported with the same `exists: false`, null metadata,
+and `not_found` error as an absent target. Responses never include filesystem
+paths from the host.
 
 ## Repo Discovery Endpoint
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -124,6 +124,7 @@ Behavior:
 - `<script>` tags and inline event handlers are stripped by DOMPurify
 - Local `<img src="./file.png">` references are rewritten through `/asset/<repo>/<path>` so images still load from the repo
 - Heading anchors and TOC generation apply to rendered HTML headings the same way they do for markdown
+- Agents can inspect a local HTML bundle without launching a browser by requesting `/view/<repo>/<path>.html?validate=1`. The JSON response checks stylesheet, script, image/source, and local HTML navigation references, reports missing/unsupported counts, and contains repo-relative URLs only. Reference checks enforce the caller's view scope; unreadable and absent targets use the same not-found result.
 
 ## Annotations
 

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const path = require('node:path');
 const fs = require('node:fs/promises');
+const { JSDOM } = require('jsdom');
 
 const {
   loadRootMappings,
@@ -276,6 +277,213 @@ function parseBooleanQuery(value) {
   }
 
   return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function buildAssetBaseHref(repo, relativePath, accessContext) {
+  const normalized = toPosixPath(relativePath);
+  const currentDir = path.posix.dirname(normalized) === '.' ? '' : path.posix.dirname(normalized);
+  const repoPart = encodeURIComponent(repo);
+  const dirPart = currentDir ? `${currentDir.split('/').map(encodeURIComponent).join('/')}/` : '';
+  return appendAccessToken(`/asset/${repoPart}/${dirPart}`, accessContext);
+}
+
+function isExternalOrSpecialHref(value) {
+  return /^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(String(value || '').trim());
+}
+
+function splitSrcset(value) {
+  return String(value || '')
+    .split(',')
+    .map((entry) => entry.trim().split(/\s+/)[0])
+    .filter(Boolean);
+}
+
+function normalizeLocalReference(relativePath, rawValue) {
+  const value = String(rawValue || '').trim();
+  if (!value || isExternalOrSpecialHref(value)) {
+    return null;
+  }
+
+  const match = value.match(/^([^?#]*)(\?[^#]*)?(#.*)?$/);
+  if (!match) {
+    return null;
+  }
+
+  const rawPath = match[1] || '';
+  const query = match[2] || '';
+  const hash = match[3] || '';
+  const currentDir = path.posix.dirname(toPosixPath(relativePath)) === '.'
+    ? ''
+    : path.posix.dirname(toPosixPath(relativePath));
+  let pathname;
+  try {
+    pathname = decodeURIComponent(rawPath);
+  } catch (_error) {
+    return null;
+  }
+  if (!pathname || pathname === '/') {
+    return null;
+  }
+
+  const referencePath = pathname.replace(/^\/+/, '');
+  const resolvedPath = value.startsWith('/')
+    ? referencePath
+    : path.posix.join(currentDir, referencePath);
+  const normalized = toPosixPath(path.posix.normalize(resolvedPath));
+  if (!normalized || normalized === '.' || normalized.startsWith('../') || normalized === '..') {
+    return null;
+  }
+
+  return {
+    original: value,
+    path: normalized,
+    query,
+    hash,
+    directoryHint: /\/(?:[?#].*)?$/.test(value),
+  };
+}
+
+function buildReferenceDescription({ repo, normalized, tag, attr, kind, accessContext }) {
+  const extension = effectiveViewExtension(normalized.path);
+  const contentType = ASSET_MIME_TYPES[extension] || null;
+  const viewUrl = appendAccessToken(buildHref(repo, normalized.path), accessContext);
+  const assetUrl = appendAccessToken(buildAssetHref(repo, normalized.path), accessContext);
+  const entry = {
+    tag,
+    attr,
+    kind,
+    href: normalized.original,
+    resolvedPath: normalized.path,
+    query: normalized.query,
+    hash: normalized.hash,
+    assetUrl,
+    viewUrl,
+    contentType,
+    exists: false,
+    bytes: null,
+    isDirectory: false,
+    supportedAsset: Boolean(contentType),
+  };
+
+  if (kind === 'document') {
+    entry.rewrittenViewUrl = viewUrl + normalized.query + normalized.hash;
+    entry.rewriteTarget = '_top';
+  }
+
+  return entry;
+}
+
+async function describeLocalReference({ repo, rootPath, sourceRelativePath, tag, attr, value, kind, accessContext }) {
+  const normalized = normalizeLocalReference(sourceRelativePath, value);
+  if (!normalized) {
+    return null;
+  }
+
+  const entry = buildReferenceDescription({ repo, normalized, tag, attr, kind, accessContext });
+  let stat;
+  try {
+    const absolutePath = await safeResolve(rootPath, normalized.path);
+    stat = await fs.stat(absolutePath);
+  } catch (_error) {
+    entry.error = 'not_found';
+    return entry;
+  }
+
+  const pathType = stat.isDirectory() ? 'directory' : 'file';
+  if (!canAccessPath(accessContext, 'view', repo, normalized.path, pathType)) {
+    entry.error = 'not_found';
+    return entry;
+  }
+
+  entry.exists = true;
+  entry.isDirectory = stat.isDirectory();
+  entry.bytes = stat.isFile() ? stat.size : null;
+  if (entry.isDirectory) {
+    entry.contentType = 'text/html; charset=utf-8';
+    entry.supportedAsset = false;
+  }
+  return entry;
+}
+
+async function buildHtmlRenderValidation({ repo, rootPath, relativePath, stat, source, rawHtmlEnabled, accessContext }) {
+  const dom = new JSDOM(source);
+  const { document } = dom.window;
+  const assetRefs = [];
+  const documentRefs = [];
+
+  function pushAsset(selector, attr) {
+    document.querySelectorAll(selector).forEach((node) => {
+      const raw = node.getAttribute(attr);
+      if (!raw) {
+        return;
+      }
+      const values = attr === 'srcset' ? splitSrcset(raw) : [raw];
+      values.forEach((value) => {
+        assetRefs.push({ tag: node.tagName.toLowerCase(), attr, value, kind: 'asset' });
+      });
+    });
+  }
+
+  pushAsset('link[href]', 'href');
+  pushAsset('script[src]', 'src');
+  pushAsset('img[src]', 'src');
+  pushAsset('img[srcset]', 'srcset');
+  pushAsset('source[src]', 'src');
+  pushAsset('source[srcset]', 'srcset');
+
+  document.querySelectorAll('a[href]').forEach((node) => {
+    const href = node.getAttribute('href');
+    const normalized = normalizeLocalReference(relativePath, href);
+    if (!normalized) {
+      return;
+    }
+    if (HTML_EXTENSIONS.has(effectiveViewExtension(normalized.path)) || normalized.directoryHint) {
+      documentRefs.push({ tag: 'a', attr: 'href', value: href, kind: 'document' });
+    }
+  });
+
+  const localAssets = (await Promise.all(assetRefs.map((ref) => describeLocalReference({
+    repo,
+    rootPath,
+    sourceRelativePath: relativePath,
+    accessContext,
+    ...ref,
+  })))).filter(Boolean);
+  const navigationLinks = (await Promise.all(documentRefs.map((ref) => describeLocalReference({
+    repo,
+    rootPath,
+    sourceRelativePath: relativePath,
+    accessContext,
+    ...ref,
+  })))).filter(Boolean);
+
+  return {
+    ok: true,
+    kind: 'html-render-validation',
+    repo,
+    relativePath,
+    renderMode: rawHtmlEnabled ? 'raw-html-iframe' : 'sanitized-html',
+    source: {
+      bytes: stat.size,
+      mtimeMs: stat.mtimeMs,
+      contentType: RAW_HTML_MIME_TYPE,
+    },
+    urls: {
+      view: appendAccessToken(buildHref(repo, relativePath), accessContext),
+      raw: rawHtmlEnabled ? appendAccessToken(buildRawHref(repo, relativePath), accessContext) : null,
+      asset: appendAccessToken(buildAssetHref(repo, relativePath), accessContext),
+      assetBase: buildAssetBaseHref(repo, relativePath, accessContext),
+    },
+    localAssets,
+    navigationLinks,
+    summary: {
+      localAssetCount: localAssets.length,
+      missingLocalAssetCount: localAssets.filter((entry) => !entry.exists).length,
+      unsupportedLocalAssetCount: localAssets.filter((entry) => !entry.supportedAsset).length,
+      navigationLinkCount: navigationLinks.length,
+      missingNavigationTargetCount: navigationLinks.filter((entry) => !entry.exists).length,
+    },
+  };
 }
 
 function sendGrantJsonError(res, status, error) {
@@ -581,6 +789,40 @@ function createApp(options = {}) {
     }
 
     const extension = effectiveViewExtension(relativePath);
+    if (parseBooleanQuery(req.query && req.query.validate) && HTML_EXTENSIONS.has(extension)) {
+      let sourceBuffer;
+      try {
+        sourceBuffer = await fs.readFile(resolved);
+      } catch (error) {
+        console.error('Failed to read HTML file for validation', { resolved, error });
+        res.status(500).json({ ok: false, error: 'Failed to read file.' });
+        return;
+      }
+
+      if (isBinaryBuffer(sourceBuffer)) {
+        res.status(415).json({ ok: false, error: 'Binary files are not supported.' });
+        return;
+      }
+
+      try {
+        const validation = await buildHtmlRenderValidation({
+          repo,
+          rootPath,
+          relativePath,
+          stat,
+          source: sourceBuffer.toString('utf8'),
+          rawHtmlEnabled,
+          accessContext,
+        });
+        res.status(200).json(validation);
+        return;
+      } catch (error) {
+        console.error('Failed to validate HTML render', { resolved, error });
+        res.status(500).json({ ok: false, error: 'Failed to validate HTML render.' });
+        return;
+      }
+    }
+
     if (IMAGE_EXTENSIONS.has(extension)) {
       const parentRel = parentPath(relativePath);
       const html = renderImagePage({

--- a/test/html-validation.test.js
+++ b/test/html-validation.test.js
@@ -1,0 +1,241 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createApp } = require('../server');
+
+async function makeRepo(t, files) {
+  const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-validation-'));
+  t.after(() => fs.rm(repoRoot, { recursive: true, force: true }));
+
+  await Promise.all(Object.entries(files).map(async ([relativePath, contents]) => {
+    const absolutePath = path.join(repoRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, contents);
+  }));
+  return repoRoot;
+}
+
+function viewHandler(app) {
+  const layer = app._router.stack.find((candidate) => candidate.route && candidate.route.path === '/view/*');
+  assert.ok(layer, 'GET /view/* route should be registered');
+  return layer.route.stack[0].handle;
+}
+
+async function requestValidation(app, requestPath, query = {}) {
+  const response = {
+    statusCode: 200,
+    contentType: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    type(value) {
+      this.contentType = value;
+      return this;
+    },
+    json(value) {
+      this.contentType = 'application/json';
+      this.body = value;
+      return this;
+    },
+    send(value) {
+      this.body = value;
+      return this;
+    },
+  };
+  const req = {
+    params: { 0: requestPath },
+    query: { validate: '1', ...query },
+    headers: {},
+    get(name) {
+      return this.headers[String(name).toLowerCase()];
+    },
+  };
+
+  await viewHandler(app)(req, response);
+  return response;
+}
+
+test('valid HTML bundle reports local assets and document targets', async (t) => {
+  const source = `<!doctype html>
+<html><head><link rel="stylesheet" href="./styles.css"><script src="./app.js"></script></head>
+<body><img src="./image.png"><a href="./next.html?mode=review#details">Next</a></body></html>`;
+  const repoRoot = await makeRepo(t, {
+    'bundle/index.html': source,
+    'bundle/styles.css': 'body { color: black; }',
+    'bundle/app.js': 'document.body.dataset.ready = "true";',
+    'bundle/image.png': Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    'bundle/next.html': '<h1 id="details">Next</h1>',
+  });
+  const app = createApp({ mappings: { docs: repoRoot }, rawHtmlEnabled: false });
+
+  const response = await requestValidation(app, 'docs/bundle/index.html');
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.contentType, 'application/json');
+  assert.equal(response.body.ok, true);
+  assert.equal(response.body.renderMode, 'sanitized-html');
+  assert.deepEqual(response.body.summary, {
+    localAssetCount: 3,
+    missingLocalAssetCount: 0,
+    unsupportedLocalAssetCount: 0,
+    navigationLinkCount: 1,
+    missingNavigationTargetCount: 0,
+  });
+  assert.deepEqual(response.body.localAssets.map((entry) => entry.resolvedPath), [
+    'bundle/styles.css',
+    'bundle/app.js',
+    'bundle/image.png',
+  ]);
+  assert.ok(response.body.localAssets.every((entry) => entry.exists));
+  assert.deepEqual(response.body.navigationLinks[0], {
+    tag: 'a',
+    attr: 'href',
+    kind: 'document',
+    href: './next.html?mode=review#details',
+    resolvedPath: 'bundle/next.html',
+    query: '?mode=review',
+    hash: '#details',
+    assetUrl: '/asset/docs/bundle/next.html',
+    viewUrl: '/view/docs/bundle/next.html',
+    contentType: 'text/plain; charset=utf-8',
+    exists: true,
+    bytes: Buffer.byteLength('<h1 id="details">Next</h1>'),
+    isDirectory: false,
+    supportedAsset: true,
+    rewrittenViewUrl: '/view/docs/bundle/next.html?mode=review#details',
+    rewriteTarget: '_top',
+  });
+});
+
+test('missing local asset uses a stable not-found result', async (t) => {
+  const repoRoot = await makeRepo(t, {
+    'bundle/index.html': '<img src="./missing.png">',
+  });
+  const app = createApp({ mappings: { docs: repoRoot } });
+
+  const response = await requestValidation(app, 'docs/bundle/index.html');
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.summary.missingLocalAssetCount, 1);
+  assert.deepEqual(response.body.localAssets[0], {
+    tag: 'img',
+    attr: 'src',
+    kind: 'asset',
+    href: './missing.png',
+    resolvedPath: 'bundle/missing.png',
+    query: '',
+    hash: '',
+    assetUrl: '/asset/docs/bundle/missing.png',
+    viewUrl: '/view/docs/bundle/missing.png',
+    contentType: 'image/png',
+    exists: false,
+    bytes: null,
+    isDirectory: false,
+    supportedAsset: true,
+    error: 'not_found',
+  });
+});
+
+test('out-of-scope references are indistinguishable from missing references', async (t) => {
+  const repoRoot = await makeRepo(t, {
+    'bundle/index.html': '<img src="../private/secret.png"><img src="../public/missing.png">',
+    'private/secret.png': Buffer.from('private fixture'),
+  });
+  const app = createApp({
+    mappings: { docs: repoRoot },
+    accessConfig: {
+      humanDefault: 'restricted',
+      tokens: {
+        validator: {
+          secret: 'scoped-fixture-token',
+          permissions: { view: true },
+          repos: { docs: ['bundle/index.html', 'public/missing.png'] },
+        },
+      },
+    },
+  });
+
+  const response = await requestValidation(app, 'docs/bundle/index.html', { token: 'scoped-fixture-token' });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.summary.missingLocalAssetCount, 2);
+  const results = response.body.localAssets.map((entry) => ({
+    exists: entry.exists,
+    bytes: entry.bytes,
+    isDirectory: entry.isDirectory,
+    supportedAsset: entry.supportedAsset,
+    contentType: entry.contentType,
+    error: entry.error,
+  }));
+  assert.deepEqual(results[0], results[1]);
+  assert.deepEqual(results[0], {
+    exists: false,
+    bytes: null,
+    isDirectory: false,
+    supportedAsset: true,
+    contentType: 'image/png',
+    error: 'not_found',
+  });
+});
+
+test('validation response keeps the deployed schema', async (t) => {
+  const repoRoot = await makeRepo(t, {
+    'index.html': '<!doctype html><title>Schema</title>',
+  });
+  const app = createApp({ mappings: { docs: repoRoot }, rawHtmlEnabled: false });
+
+  const response = await requestValidation(app, 'docs/index.html');
+
+  assert.deepEqual(Object.keys(response.body), [
+    'ok',
+    'kind',
+    'repo',
+    'relativePath',
+    'renderMode',
+    'source',
+    'urls',
+    'localAssets',
+    'navigationLinks',
+    'summary',
+  ]);
+  assert.equal(response.body.kind, 'html-render-validation');
+  assert.equal(response.body.repo, 'docs');
+  assert.equal(response.body.relativePath, 'index.html');
+  assert.deepEqual(Object.keys(response.body.source), ['bytes', 'mtimeMs', 'contentType']);
+  assert.equal(response.body.source.contentType, 'text/html; charset=utf-8');
+  assert.equal(typeof response.body.source.bytes, 'number');
+  assert.equal(typeof response.body.source.mtimeMs, 'number');
+  assert.deepEqual(response.body.urls, {
+    view: '/view/docs/index.html',
+    raw: null,
+    asset: '/asset/docs/index.html',
+    assetBase: '/asset/docs/',
+  });
+  assert.ok(Array.isArray(response.body.localAssets));
+  assert.ok(Array.isArray(response.body.navigationLinks));
+});
+
+test('validation response never exposes absolute host paths', async (t) => {
+  const repoRoot = await makeRepo(t, {
+    'nested/index.html': '<img src="./image.png"><a href="./next.html">Next</a>',
+    'nested/image.png': Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    'nested/next.html': '<p>Next</p>',
+  });
+  const app = createApp({ mappings: { docs: repoRoot } });
+
+  const response = await requestValidation(app, 'docs/nested/index.html');
+  const serialized = JSON.stringify(response.body);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(serialized.includes(repoRoot), false);
+  assert.equal(serialized.includes(path.dirname(repoRoot)), false);
+  assert.ok(response.body.localAssets.every((entry) => !path.isAbsolute(entry.resolvedPath)));
+  assert.ok(response.body.navigationLinks.every((entry) => !path.isAbsolute(entry.resolvedPath)));
+});


### PR DESCRIPTION
Part of #91 (reconciliation Step 5.3). Ports the deployed tree's `GET /view/...html?validate=1` bundle-inspection contract: asset/document reference checks with view-scoped access, uniform not-found semantics for out-of-scope references, repo-relative references only (no absolute host paths in responses — negative-tested). Merged with current main (clean auto-merge). Verification: 32/32 tests on the merged branch; added-line scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)