### PR TITLE
feat: repair raw-HTML contract — byte-preserving /raw + new /embed injection route

### DIFF
--- a/lib/embed-html.js
+++ b/lib/embed-html.js
@@ -6,6 +6,8 @@ const path = require('node:path');
 const { TextDecoder } = require('node:util');
 const { JSDOM } = require('jsdom');
 
+const { decorateRenderedHtmlForAnnotations } = require('./renderer');
+
 const HTML_EXTENSIONS = new Set(['.html', '.htm']);
 const URL_ATTRIBUTES = [
   ['img', 'src'],
@@ -237,7 +239,7 @@ function rewriteDocumentUrls(document, options) {
   }
 }
 
-function ensureHeadingIds(document) {
+function markAnnotationTargets(document) {
   const used = new Set(Array.from(document.querySelectorAll('[id]')).map((node) => node.id).filter(Boolean));
   for (const heading of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
     if (!heading.id) {
@@ -248,15 +250,7 @@ function ensureHeadingIds(document) {
       heading.id = candidate;
       used.add(candidate);
     }
-    if (!heading.querySelector('.anchor-link')) {
-      const anchor = document.createElement('a');
-      anchor.className = 'anchor-link';
-      anchor.href = `#${heading.id}`;
-      anchor.dataset.anchorId = heading.id;
-      anchor.setAttribute('aria-label', 'Copy section link');
-      anchor.textContent = '🔗';
-      heading.appendChild(anchor);
-    }
+    heading.setAttribute('data-lookie-annotation-anchor', heading.id);
   }
 }
 
@@ -284,7 +278,26 @@ function addThemeInjection(document, options) {
 
 function addAnnotations(document, options) {
   if (!options.annotationsEnabled) return;
-  ensureHeadingIds(document);
+  markAnnotationTargets(document);
+  document.body.innerHTML = decorateRenderedHtmlForAnnotations(document.body.innerHTML);
+  document.body.setAttribute('data-rendered-view', '');
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'toolbar-btn toolbar-btn-annotation-count';
+  toggle.setAttribute('data-annotations-toggle', '');
+  toggle.setAttribute('aria-label', 'Show or hide resolved annotations');
+  toggle.setAttribute('aria-pressed', 'false');
+  toggle.hidden = true;
+  toggle.textContent = '💬 0';
+  document.body.prepend(toggle);
+
+  const stale = document.createElement('aside');
+  stale.className = 'lookie-annotations-stale';
+  stale.setAttribute('data-annotations-stale', '');
+  stale.hidden = true;
+  document.body.appendChild(stale);
+
   const bootstrap = document.createElement('script');
   bootstrap.id = 'lookie-link-annotations-bootstrap';
   bootstrap.type = 'application/json';
@@ -292,6 +305,7 @@ function addAnnotations(document, options) {
     repo: options.repo,
     relativePath: options.relativePath,
     queryToken: options.queryToken || null,
+    supportsLineRangeAnnotations: false,
   }).replace(/</g, '\\u003c');
   document.body.appendChild(bootstrap);
 

--- a/lib/embed-html.js
+++ b/lib/embed-html.js
@@ -1,0 +1,355 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { TextDecoder } = require('node:util');
+const { JSDOM } = require('jsdom');
+
+const HTML_EXTENSIONS = new Set(['.html', '.htm']);
+const URL_ATTRIBUTES = [
+  ['img', 'src'],
+  ['script', 'src'],
+  ['link', 'href'],
+  ['audio', 'src'],
+  ['video', 'src'],
+  ['source', 'src'],
+  ['track', 'src'],
+  ['iframe', 'src'],
+  ['object', 'data'],
+];
+
+function encodeRoutePath(route, repo, relativePath) {
+  const repoPart = encodeURIComponent(repo);
+  const pathPart = relativePath
+    ? `/${relativePath.split('/').map(encodeURIComponent).join('/')}`
+    : '';
+  return `/${route}/${repoPart}${pathPart}`;
+}
+
+function appendQueryToken(url, queryToken) {
+  if (!queryToken || url.startsWith('#')) {
+    return url;
+  }
+  const hashIndex = url.indexOf('#');
+  const beforeHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : url.slice(hashIndex);
+  const separator = beforeHash.includes('?') ? '&' : '?';
+  return `${beforeHash}${separator}token=${encodeURIComponent(queryToken)}${hash}`;
+}
+
+function splitReference(value) {
+  const raw = String(value || '').trim();
+  if (!raw || /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(raw)) {
+    return null;
+  }
+  const match = raw.match(/^([^?#]*)(\?[^#]*)?(#.*)?$/);
+  if (!match) {
+    return null;
+  }
+  let pathname;
+  try {
+    pathname = decodeURIComponent(match[1] || '');
+  } catch (_error) {
+    return null;
+  }
+  return { raw, pathname, query: match[2] || '', hash: match[3] || '' };
+}
+
+function isWithinRoot(targetPath, rootPath) {
+  return targetPath === rootPath || targetPath.startsWith(`${rootPath}${path.sep}`);
+}
+
+function repoEntries(options) {
+  return Object.entries(options.mappings || {})
+    .filter(([repo, rootPath]) => repo && typeof rootPath === 'string' && rootPath)
+    .map(([repo, rootPath]) => ({ repo, rootPath: path.resolve(rootPath) }))
+    .sort((left, right) => right.rootPath.length - left.rootPath.length);
+}
+
+function canResolve(options, repo, relativePath, isDirectory = false) {
+  return typeof options.canAccess !== 'function' || options.canAccess(repo, relativePath, isDirectory);
+}
+
+function resolveReference(value, options) {
+  const parsed = splitReference(value);
+  if (!parsed) {
+    return null;
+  }
+  if (!parsed.pathname) {
+    return parsed.hash
+      ? `${encodeRoutePath('view', options.repo, options.relativePath)}${parsed.hash}`
+      : null;
+  }
+
+  const entries = repoEntries(options);
+  const currentRoot = path.resolve(options.rootPath);
+  const sourceDir = path.dirname(path.join(currentRoot, options.relativePath));
+  let absoluteTarget;
+
+  if (parsed.pathname.startsWith('~/') || parsed.pathname.startsWith('$HOME/')) {
+    const portablePath = parsed.pathname.replace(/^(?:~\/|\$HOME\/)/, '');
+    const [repoName, ...parts] = portablePath.split('/');
+    const explicitRepo = entries.find((entry) => entry.repo === repoName);
+    if (explicitRepo) {
+      absoluteTarget = path.resolve(explicitRepo.rootPath, parts.join('/'));
+    } else {
+      absoluteTarget = path.resolve(os.homedir(), portablePath);
+    }
+  } else if (path.isAbsolute(parsed.pathname)) {
+    absoluteTarget = path.resolve(parsed.pathname);
+  } else {
+    absoluteTarget = path.resolve(sourceDir, parsed.pathname);
+  }
+
+  let targetRepo = entries.find((entry) => isWithinRoot(absoluteTarget, entry.rootPath));
+  if (!targetRepo && parsed.pathname.startsWith('/') && !/^\/(?:home|Users)\//.test(parsed.pathname)) {
+    targetRepo = entries.find((entry) => entry.repo === options.repo);
+    absoluteTarget = path.resolve(currentRoot, parsed.pathname.replace(/^\/+/, ''));
+  }
+  if (!targetRepo || !isWithinRoot(absoluteTarget, targetRepo.rootPath)) {
+    return /^\/(?:home|Users)\//.test(parsed.pathname) || /^(?:~|\$HOME)(?:\/|$)/.test(parsed.pathname)
+      ? '#unresolved-portable-link'
+      : null;
+  }
+
+  const relativePath = path.relative(targetRepo.rootPath, absoluteTarget).split(path.sep).join('/');
+  const normalizedPath = relativePath === '.' ? '' : relativePath;
+  const isDirectory = parsed.pathname.endsWith('/');
+  if (!canResolve(options, targetRepo.repo, normalizedPath, isDirectory)) {
+    return '#unavailable-link';
+  }
+
+  return {
+    repo: targetRepo.repo,
+    relativePath: normalizedPath,
+    query: parsed.query,
+    hash: parsed.hash,
+    isDirectory,
+  };
+}
+
+function slugKey(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/\.[^.\/]+$/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function wikiKeys(relativePath, isDirectory) {
+  const base = path.posix.basename(String(relativePath || '').replace(/\/$/, ''));
+  const extension = isDirectory ? '' : path.posix.extname(base);
+  const stem = extension ? base.slice(0, -extension.length) : base;
+  return [...new Set([base.toLowerCase(), stem.toLowerCase(), slugKey(base), slugKey(stem)].filter(Boolean))];
+}
+
+function buildWikiIndex(options, limit = 5000) {
+  const index = new Map();
+  let count = 0;
+  function add(entry) {
+    for (const key of wikiKeys(entry.relativePath, entry.isDirectory)) {
+      if (!index.has(key)) index.set(key, []);
+      index.get(key).push(entry);
+    }
+  }
+  function walk(repo, rootPath, absoluteDir, relativeDir) {
+    if (count >= limit) return;
+    let dirents;
+    try {
+      dirents = fs.readdirSync(absoluteDir, { withFileTypes: true });
+    } catch (_error) {
+      return;
+    }
+    for (const dirent of dirents) {
+      if (count >= limit) break;
+      if (dirent.name.startsWith('.')) continue;
+      count += 1;
+      const relativePath = relativeDir ? `${relativeDir}/${dirent.name}` : dirent.name;
+      if (dirent.isDirectory()) {
+        if (canResolve(options, repo, relativePath, true)) add({ repo, relativePath, isDirectory: true });
+        walk(repo, rootPath, path.join(absoluteDir, dirent.name), relativePath);
+      } else if (dirent.isFile() && canResolve(options, repo, relativePath, false)) {
+        add({ repo, relativePath, isDirectory: false });
+      }
+    }
+  }
+  for (const entry of repoEntries(options)) {
+    walk(entry.repo, entry.rootPath, entry.rootPath, '');
+  }
+  return index;
+}
+
+function resolveWikiReference(value, options, wikiIndex) {
+  const match = String(value || '').trim().match(/^\[\[([^\[\]]+)\]\]$/);
+  if (!match) return null;
+  const targetPart = match[1].split('|', 1)[0];
+  const hashIndex = targetPart.indexOf('#');
+  const name = (hashIndex === -1 ? targetPart : targetPart.slice(0, hashIndex)).trim();
+  const hash = hashIndex === -1 ? '' : targetPart.slice(hashIndex);
+  const candidates = wikiIndex.get(slugKey(name)) || [];
+  const sameRepo = candidates.filter((entry) => entry.repo === options.repo);
+  const scoped = sameRepo.length ? sameRepo : candidates;
+  if (scoped.length !== 1) return '#unresolved-wiki-link';
+  return `${encodeRoutePath('view', scoped[0].repo, scoped[0].relativePath)}${hash}`;
+}
+
+function resolvedRoute(reference, route, queryToken) {
+  if (typeof reference === 'string') return appendQueryToken(reference, queryToken);
+  const href = `${encodeRoutePath(route, reference.repo, reference.relativePath)}${reference.query}${reference.hash}`;
+  return appendQueryToken(href, queryToken);
+}
+
+function rewriteDocumentUrls(document, options) {
+  const wikiIndex = buildWikiIndex(options);
+  for (const link of document.querySelectorAll('a[href]')) {
+    const original = link.getAttribute('href');
+    const wikiHref = resolveWikiReference(original, options, wikiIndex);
+    const reference = wikiHref || resolveReference(original, options);
+    if (!reference) continue;
+    const href = wikiHref
+      ? appendQueryToken(wikiHref, options.queryToken)
+      : resolvedRoute(reference, 'view', options.queryToken);
+    link.setAttribute('href', href);
+    if (!href.startsWith('#')) link.setAttribute('target', '_top');
+  }
+
+  for (const [selector, attribute] of URL_ATTRIBUTES) {
+    for (const element of document.querySelectorAll(`${selector}[${attribute}]`)) {
+      if (selector === 'link' && !/stylesheet|icon/i.test(element.getAttribute('rel') || '')) continue;
+      const reference = resolveReference(element.getAttribute(attribute), options);
+      if (!reference || typeof reference === 'string') continue;
+      element.setAttribute(attribute, resolvedRoute(reference, 'asset', options.queryToken));
+    }
+  }
+
+  for (const element of document.querySelectorAll('[srcset]')) {
+    const rewritten = element.getAttribute('srcset').split(',').map((candidate) => {
+      const parts = candidate.trim().split(/\s+/);
+      const reference = resolveReference(parts[0], options);
+      if (reference && typeof reference !== 'string') parts[0] = resolvedRoute(reference, 'asset', options.queryToken);
+      return parts.join(' ');
+    }).join(', ');
+    element.setAttribute('srcset', rewritten);
+  }
+}
+
+function ensureHeadingIds(document) {
+  const used = new Set(Array.from(document.querySelectorAll('[id]')).map((node) => node.id).filter(Boolean));
+  for (const heading of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
+    if (!heading.id) {
+      const base = slugKey(heading.textContent) || 'section';
+      let candidate = base;
+      let suffix = 2;
+      while (used.has(candidate)) candidate = `${base}-${suffix++}`;
+      heading.id = candidate;
+      used.add(candidate);
+    }
+    if (!heading.querySelector('.anchor-link')) {
+      const anchor = document.createElement('a');
+      anchor.className = 'anchor-link';
+      anchor.href = `#${heading.id}`;
+      anchor.dataset.anchorId = heading.id;
+      anchor.setAttribute('aria-label', 'Copy section link');
+      anchor.textContent = '🔗';
+      heading.appendChild(anchor);
+    }
+  }
+}
+
+function addThemeInjection(document, options) {
+  const mode = options.themeMode === 'light' ? 'light' : 'dark';
+  const scheme = /^[a-z0-9-]+$/.test(options.themeScheme || '') ? options.themeScheme : 'slate';
+  document.documentElement.setAttribute('data-lookie-link-theme', mode);
+  document.documentElement.setAttribute('data-lookie-link-scheme', scheme);
+
+  const base = document.createElement('base');
+  const currentDir = path.posix.dirname(options.relativePath);
+  base.href = `${encodeRoutePath('asset', options.repo, currentDir === '.' ? '' : currentDir)}/`;
+  document.head.prepend(base);
+
+  const style = document.createElement('style');
+  style.id = 'lookie-link-embed-theme';
+  style.textContent = `:root { color-scheme: ${mode}; --lookie-bg: #111827; --lookie-bg-elev: #1f2937; --lookie-bg-code: #0f172a; --lookie-text: #e5e7eb; --lookie-text-soft: #9ca3af; --lookie-accent: #22c55e; --lookie-border: #374151; --lookie-link: #38bdf8; }\n${options.customThemeCss || ''}`;
+  document.head.appendChild(style);
+
+  const script = document.createElement('script');
+  script.id = 'lookie-link-embed-runtime';
+  script.textContent = `(function () {\n  window.addEventListener('message', function (event) {\n    if (event.origin !== window.location.origin || !event.data) return;\n    if (event.data.type === 'lookie-link:set-theme') {\n      document.documentElement.setAttribute('data-lookie-link-theme', event.data.mode === 'light' ? 'light' : 'dark');\n      if (/^[a-z0-9-]+$/.test(event.data.scheme || '')) document.documentElement.setAttribute('data-lookie-link-scheme', event.data.scheme);\n    }\n    if (event.data.type === 'lookie-link:set-annotation-mode') {\n      document.documentElement.classList.toggle('lookie-annotations-active', Boolean(event.data.enabled));\n    }\n  });\n}());`;
+  document.head.appendChild(script);
+}
+
+function addAnnotations(document, options) {
+  if (!options.annotationsEnabled) return;
+  ensureHeadingIds(document);
+  const bootstrap = document.createElement('script');
+  bootstrap.id = 'lookie-link-annotations-bootstrap';
+  bootstrap.type = 'application/json';
+  bootstrap.textContent = JSON.stringify({
+    repo: options.repo,
+    relativePath: options.relativePath,
+    queryToken: options.queryToken || null,
+  }).replace(/</g, '\\u003c');
+  document.body.appendChild(bootstrap);
+
+  const initializer = document.createElement('script');
+  initializer.textContent = `(function () {\n  var node = document.getElementById('lookie-link-annotations-bootstrap');\n  try { window.__lookieLinkAnnotations = JSON.parse(node.textContent || '{}'); } catch (_error) { window.__lookieLinkAnnotations = null; }\n}());`;
+  document.body.appendChild(initializer);
+  const client = document.createElement('script');
+  client.src = '/public/annotations.js';
+  client.defer = true;
+  document.body.appendChild(client);
+}
+
+function redactPrivatePaths(html, options) {
+  let output = html;
+  for (const entry of repoEntries(options)) {
+    output = output.split(entry.rootPath).join(encodeRoutePath('view', entry.repo, ''));
+  }
+  const homePath = path.resolve(os.homedir());
+  output = output.split(homePath).join('[host-home]');
+  for (const secret of options.sensitiveValues || []) {
+    if (secret) output = output.split(String(secret)).join('[credential-redacted]');
+  }
+  return output.replace(/\/(?:home|Users)\/[^/\s"'<>]+(?:\/[^\s"'<>]*)?/g, '[host-path]');
+}
+
+function transformEmbedHtml(source, options) {
+  const authoredFullDocument = /<(?:!doctype|html|head|body)\b/i.test(source);
+  const dom = new JSDOM(authoredFullDocument ? source : `<body>${source}</body>`);
+  const { document } = dom.window;
+  rewriteDocumentUrls(document, options);
+  addThemeInjection(document, options);
+  addAnnotations(document, options);
+  const serialized = dom.serialize();
+  const withDoctype = /^<!doctype/i.test(serialized) ? serialized : `<!doctype html>\n${serialized}`;
+  return redactPrivatePaths(withDoctype, options);
+}
+
+function looksBinary(buffer) {
+  const sampleSize = Math.min(buffer.length, 2048);
+  for (let index = 0; index < sampleSize; index += 1) {
+    if (buffer[index] === 0) return true;
+  }
+  return false;
+}
+
+function decodeEmbedHtmlBuffer(buffer) {
+  if (looksBinary(buffer)) {
+    const error = new Error('Embedded HTML must be text, not binary data.');
+    error.code = 'EINVALIDHTML';
+    throw error;
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+  } catch (_error) {
+    const error = new Error('Embedded HTML must be valid UTF-8.');
+    error.code = 'EINVALIDHTML';
+    throw error;
+  }
+}
+
+module.exports = {
+  decodeEmbedHtmlBuffer,
+  transformEmbedHtml,
+};

--- a/lib/embed-html.js
+++ b/lib/embed-html.js
@@ -196,7 +196,10 @@ function resolveWikiReference(value, options, wikiIndex) {
 
 function resolvedRoute(reference, route, queryToken) {
   if (typeof reference === 'string') return appendQueryToken(reference, queryToken);
-  const href = `${encodeRoutePath(route, reference.repo, reference.relativePath)}${reference.query}${reference.hash}`;
+  const authoredQuery = new URLSearchParams(reference.query.replace(/^\?/, ''));
+  authoredQuery.delete('token');
+  const safeQuery = authoredQuery.toString();
+  const href = `${encodeRoutePath(route, reference.repo, reference.relativePath)}${safeQuery ? `?${safeQuery}` : ''}${reference.hash}`;
   return appendQueryToken(href, queryToken);
 }
 
@@ -314,10 +317,33 @@ function redactPrivatePaths(html, options) {
   return output.replace(/\/(?:home|Users)\/[^/\s"'<>]+(?:\/[^\s"'<>]*)?/g, '[host-path]');
 }
 
+function redactSensitiveDom(document, sensitiveValues) {
+  const secrets = (sensitiveValues || []).map(String).filter(Boolean);
+  if (!secrets.length) return;
+  for (const element of document.querySelectorAll('*')) {
+    for (const attribute of element.attributes) {
+      let value = attribute.value;
+      for (const secret of secrets) value = value.split(secret).join('[credential-redacted]');
+      if (value !== attribute.value) element.setAttribute(attribute.name, value);
+    }
+    for (const node of element.childNodes) {
+      if (node.nodeType !== 3) continue;
+      let value = node.nodeValue;
+      for (const secret of secrets) value = value.split(secret).join('[credential-redacted]');
+      node.nodeValue = value;
+    }
+  }
+}
+
 function transformEmbedHtml(source, options) {
-  const authoredFullDocument = /<(?:!doctype|html|head|body)\b/i.test(source);
-  const dom = new JSDOM(authoredFullDocument ? source : `<body>${source}</body>`);
+  let redactedSource = source;
+  for (const secret of options.sensitiveValues || []) {
+    if (secret) redactedSource = redactedSource.split(String(secret)).join('[credential-redacted]');
+  }
+  const authoredFullDocument = /<(?:!doctype|html|head|body)\b/i.test(redactedSource);
+  const dom = new JSDOM(authoredFullDocument ? redactedSource : `<body>${redactedSource}</body>`);
   const { document } = dom.window;
+  redactSensitiveDom(document, options.sensitiveValues);
   rewriteDocumentUrls(document, options);
   addThemeInjection(document, options);
   addAnnotations(document, options);

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -114,6 +114,16 @@ function buildRawHref(repo, relativePath) {
   return `/raw/${repoPart}/${rel.split('/').map(encodePathSegment).join('/')}`;
 }
 
+function buildEmbedHref(repo, relativePath) {
+  const repoPart = encodePathSegment(repo);
+  const rel = toPosixPath(relativePath);
+  if (!rel) {
+    return `/embed/${repoPart}`;
+  }
+
+  return `/embed/${repoPart}/${rel.split('/').map(encodePathSegment).join('/')}`;
+}
+
 function escapeHtml(value) {
   return String(value)
     .replace(/&/g, '&amp;')
@@ -195,6 +205,7 @@ module.exports = {
   buildSaveHref,
   buildPreviewHref,
   buildRawHref,
+  buildEmbedHref,
   escapeHtml,
   formatFileSize,
   formatMTime,

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2196,6 +2196,7 @@ function renderEditPage({
 }
 
 module.exports = {
+  decorateRenderedHtmlForAnnotations,
   renderDocumentPage,
   renderDirectoryPage,
   renderImagePage,

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -922,11 +922,80 @@ function renderDirectoryPage({ title, repo, currentPath, parentHref, entries, no
   return baseHtml({ title, body, customThemeCss });
 }
 
-function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, mtime, size, editHref = null, rawHtmlHref = null, customThemeCss, queryToken = null, annotationsEnabled = false }) {
+function embeddedHtmlSyncScript(embedHtmlHref) {
+  if (!embedHtmlHref) {
+    return '';
+  }
+
+  const safeEmbedHref = JSON.stringify(embedHtmlHref).replace(/</g, '\\u003c');
+  return `<script>
+    (function () {
+      var frame = document.querySelector('[data-embedded-html]');
+      if (!frame) return;
+
+      function themeState() {
+        return {
+          mode: document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark',
+          scheme: document.documentElement.getAttribute('data-color-scheme') || 'slate'
+        };
+      }
+
+      function frameUrl() {
+        var url = new URL(${safeEmbedHref}, window.location.origin);
+        var state = themeState();
+        url.searchParams.set('lookie-theme', state.mode);
+        url.searchParams.set('lookie-scheme', state.scheme);
+        if (window.location.hash) url.hash = window.location.hash;
+        return url.toString();
+      }
+
+      function postTheme() {
+        if (!frame.contentWindow) return;
+        var state = themeState();
+        frame.contentWindow.postMessage({
+          type: 'lookie-link:set-theme',
+          mode: state.mode,
+          scheme: state.scheme
+        }, window.location.origin);
+      }
+
+      function resizeFrame() {
+        try {
+          var doc = frame.contentDocument;
+          if (!doc || !doc.documentElement) return;
+          var body = doc.body;
+          frame.style.height = Math.max(
+            480,
+            doc.documentElement.scrollHeight || 0,
+            body ? body.scrollHeight : 0
+          ) + 'px';
+        } catch (_error) {}
+      }
+
+      frame.src = frameUrl();
+      frame.addEventListener('load', function () {
+        postTheme();
+        resizeFrame();
+        window.setTimeout(resizeFrame, 100);
+        window.setTimeout(resizeFrame, 500);
+      });
+      new MutationObserver(postTheme).observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['data-theme', 'data-color-scheme']
+      });
+      window.addEventListener('hashchange', function () { frame.src = frameUrl(); });
+      window.addEventListener('resize', resizeFrame);
+    }());
+  </script>`;
+}
+
+function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, mtime, size, editHref = null, rawHtmlHref = null, embedHtmlHref = null, customThemeCss, queryToken = null, annotationsEnabled = false }) {
   const extension = effectiveViewExtension(relativePath);
   const isMarkdown = MARKDOWN_EXTENSIONS.has(extension);
   const isHtmlDocument = HTML_EXTENSIONS.has(extension);
   const isYaml = ['.yaml', '.yml'].includes(extension);
+  const usesEmbeddedHtml = Boolean(isHtmlDocument && embedHtmlHref);
+  const pageAnnotationsEnabled = Boolean(annotationsEnabled && !usesEmbeddedHtml);
   const hasToc = isMarkdown || isHtmlDocument || isYaml;
   const supportsRawToggle = isMarkdown || isHtmlDocument || isYaml;
   const rendered = renderContent(relativePath, source, {
@@ -938,6 +1007,43 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
   const heading = `${repo}/${relativePath}`;
   const rawSourceJson = supportsRawToggle ? jsonForInlineScript(source) : null;
   const rawLanguage = isMarkdown ? 'markdown' : isHtmlDocument ? 'xml' : isYaml ? 'yaml' : null;
+
+  if (usesEmbeddedHtml) {
+    const contentHtml = `<article class="content html-embed-view">
+      <iframe
+        class="embedded-html-frame"
+        title="${escapeHtml(relativePath)}"
+        data-embedded-html
+        src="${escapeHtml(embedHtmlHref)}"
+        loading="lazy"
+      ></iframe>
+    </article>`;
+    const extraButtons = [
+      `<a class="toolbar-btn" href="${escapeHtml(embedHtmlHref)}" target="_blank" rel="noopener" aria-label="Open embedded HTML in new tab">Open embedded</a>`,
+      rawHtmlHref ? `<a class="toolbar-btn" href="${escapeHtml(rawHtmlHref)}" target="_blank" rel="noopener" aria-label="Open byte-preserving raw HTML in new tab">Open raw</a>` : '',
+      editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
+    ].filter(Boolean).join('\n    ');
+    const body = `${toolbarHtml(extraButtons)}
+  <main class="layout">
+    <header class="topbar">
+      <h1>${escapeHtml(path.basename(relativePath))}</h1>
+      <p class="subtitle">${escapeHtml(heading)}</p>
+      ${breadcrumbs(repo, relativePath, queryToken)}
+      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · embedded html</p>
+      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
+    </header>
+
+    ${contentHtml}
+  </main>`;
+
+    return baseHtml({
+      title: heading,
+      customThemeCss,
+      body: `${body}
+  ${themeScript()}
+  ${embeddedHtmlSyncScript(embedHtmlHref)}`,
+    });
+  }
 
   const renderedClass = isMarkdown ? 'markdown' : rendered.kind;
   const contentHtml = `${hasToc ? `<article class="content toc-view" id="toc-view" data-toc-view hidden aria-hidden="true">
@@ -971,7 +1077,7 @@ function renderDocumentPage({ repo, repoRoot, relativePath, source, parentHref, 
     ${contentHtml}
   </main>`;
 
-  const annotationsBootstrap = annotationsEnabled
+  const annotationsBootstrap = pageAnnotationsEnabled
     ? `<script id="lookie-link-annotations-bootstrap" type="application/json">${jsonForInlineScript({
         repo,
         relativePath,

--- a/public/annotations.js
+++ b/public/annotations.js
@@ -294,7 +294,8 @@
 
   function injectAnnotateButtons() {
     const root = document.querySelector('article.content[data-rendered-view]')
-      || document.querySelector('article.content');
+      || document.querySelector('article.content')
+      || document.body;
     if (!root) return;
     const targets = root.querySelectorAll(
       'h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], span.yaml-anchor-wrap[id]'

--- a/public/style.css
+++ b/public/style.css
@@ -848,6 +848,19 @@ tbody tr:last-child td {
   opacity: 0.7;
 }
 
+.html-embed-view {
+  padding: 0;
+  overflow: hidden;
+}
+
+.embedded-html-frame {
+  display: block;
+  width: 100%;
+  min-height: 70vh;
+  border: 0;
+  background: var(--bg);
+}
+
 .yaml-anchor-wrap {
   display: inline-flex;
   align-items: center;

--- a/scripts/validate-raw-html.js
+++ b/scripts/validate-raw-html.js
@@ -20,7 +20,7 @@ const path = require('node:path');
 
 const { createApp } = require('../server');
 
-function fetchText(server, urlPath) {
+function fetchResponse(server, urlPath) {
   return new Promise((resolve, reject) => {
     const { port } = server.address();
     const req = http.request(
@@ -29,10 +29,12 @@ function fetchText(server, urlPath) {
         const chunks = [];
         res.on('data', (chunk) => chunks.push(chunk));
         res.on('end', () => {
+          const body = Buffer.concat(chunks);
           resolve({
             status: res.statusCode,
             contentType: res.headers['content-type'] || '',
-            body: Buffer.concat(chunks).toString('utf8'),
+            body,
+            text: body.toString('utf8'),
           });
         });
       }
@@ -61,11 +63,17 @@ const FLASHCARDS_HTML = [
   '</body></html>',
 ].join('\n');
 
+const ODD_ENCODING_HTML = Buffer.from([
+  0x3c, 0x21, 0x64, 0x6f, 0x63, 0x74, 0x79, 0x70, 0x65, 0x20, 0x68, 0x74, 0x6d, 0x6c, 0x3e,
+  0x0d, 0x0a, 0x3c, 0x70, 0x3e, 0x63, 0x61, 0x66, 0xe9, 0xff, 0x3c, 0x2f, 0x70, 0x3e,
+]);
+
 async function run() {
   const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-raw-html-validate-'));
 
   try {
     await fs.writeFile(path.join(repoDir, 'flashcards.html'), FLASHCARDS_HTML, 'utf8');
+    await fs.writeFile(path.join(repoDir, 'odd-encoding.htm'), ODD_ENCODING_HTML);
     await fs.writeFile(path.join(repoDir, 'notes.md'), '# Notes\n', 'utf8');
 
     const appDisabled = createApp({ mappings: { docs: repoDir }, rawHtmlEnabled: false });
@@ -76,56 +84,60 @@ async function run() {
 
     try {
       // 1. Disabled instance: /raw/* returns 404.
-      const disabledResp = await fetchText(disabledServer, '/raw/docs/flashcards.html');
+      const disabledResp = await fetchResponse(disabledServer, '/raw/docs/flashcards.html');
       assert.equal(disabledResp.status, 404, '/raw/* should 404 when disabled');
-      assert.match(disabledResp.body, /disabled/i, 'disabled body should say disabled');
+      assert.match(disabledResp.text, /disabled/i, 'disabled body should say disabled');
 
-      // 2. Enabled instance: /raw/<.html> serves verbatim text/html.
-      const enabledResp = await fetchText(enabledServer, '/raw/docs/flashcards.html');
+      // 2. /raw exact-byte contract: UTF-8 and odd-encoding fixtures are unchanged.
+      const enabledResp = await fetchResponse(enabledServer, '/raw/docs/flashcards.html');
       assert.equal(enabledResp.status, 200, '/raw/<.html> should 200 when enabled');
       assert.match(enabledResp.contentType, /^text\/html/, 'content-type should be text/html');
-      assert.equal(enabledResp.body, FLASHCARDS_HTML, 'raw body should equal file bytes verbatim');
-      assert.match(enabledResp.body, /<script>document.getElementById/, 'inline <script> must survive raw mode');
+      assert.deepEqual(enabledResp.body, Buffer.from(FLASHCARDS_HTML), 'raw body should equal file bytes verbatim');
+      assert.match(enabledResp.text, /<script>document.getElementById/, 'inline <script> must survive raw mode');
+
+      const oddEncodingResp = await fetchResponse(enabledServer, '/raw/docs/odd-encoding.htm');
+      assert.equal(oddEncodingResp.status, 200, '/raw odd-encoding HTML should 200');
+      assert.deepEqual(oddEncodingResp.body, ODD_ENCODING_HTML, '/raw must not decode or normalize invalid UTF-8 bytes');
 
       // 3. Enabled instance: /raw rejects non-html extensions.
-      const notMdResp = await fetchText(enabledServer, '/raw/docs/notes.md');
+      const notMdResp = await fetchResponse(enabledServer, '/raw/docs/notes.md');
       assert.equal(notMdResp.status, 415, '/raw rejects non-html extensions with 415');
 
       // 4. Enabled instance: unknown repo returns 404.
-      const unknownResp = await fetchText(enabledServer, '/raw/missing/flashcards.html');
+      const unknownResp = await fetchResponse(enabledServer, '/raw/missing/flashcards.html');
       assert.equal(unknownResp.status, 404, 'unknown repo returns 404');
 
       // 5. Enabled instance: directory traversal blocked.
-      const traversalResp = await fetchText(enabledServer, '/raw/docs/../../../etc/passwd');
+      const traversalResp = await fetchResponse(enabledServer, '/raw/docs/../../../etc/passwd');
       assert.notEqual(traversalResp.status, 200, 'directory traversal must not return 200');
 
       // 6. /view/<.html> still wraps + sanitises on both disabled and enabled.
-      const viewDisabled = await fetchText(disabledServer, '/view/docs/flashcards.html');
+      const viewDisabled = await fetchResponse(disabledServer, '/view/docs/flashcards.html');
       assert.equal(viewDisabled.status, 200);
       assert.match(viewDisabled.contentType, /^text\/html/);
-      assert.match(viewDisabled.body, /<title>docs\/flashcards\.html<\/title>/, '/view wraps with viewer title');
+      assert.match(viewDisabled.text, /<title>docs\/flashcards\.html<\/title>/, '/view wraps with viewer title');
       assert.doesNotMatch(
-        viewDisabled.body,
+        viewDisabled.text,
         /<script>document\.getElementById\("root"\)\.textContent = "flipped";<\/script>/,
         '/view must strip inline <script> from rendered output'
       );
 
-      const viewEnabled = await fetchText(enabledServer, '/view/docs/flashcards.html');
+      const viewEnabled = await fetchResponse(enabledServer, '/view/docs/flashcards.html');
       assert.equal(viewEnabled.status, 200);
       assert.doesNotMatch(
-        viewEnabled.body,
+        viewEnabled.text,
         /<script>document\.getElementById\("root"\)\.textContent = "flipped";<\/script>/,
         '/view must strip inline <script> even when raw mode is enabled'
       );
 
       // 7. "Open raw" toolbar appears only when raw HTML is enabled.
-      assert.doesNotMatch(viewDisabled.body, /Open raw/, 'disabled /view should not advertise raw mode');
-      assert.match(viewEnabled.body, /Open raw/, 'enabled /view should advertise raw mode');
-      assert.match(viewEnabled.body, /href="\/raw\/docs\/flashcards\.html"/, 'Open raw button should link to /raw/');
+      assert.doesNotMatch(viewDisabled.text, /Open raw/, 'disabled /view should not advertise raw mode');
+      assert.match(viewEnabled.text, /Open raw/, 'enabled /view should advertise raw mode');
+      assert.match(viewEnabled.text, /href="\/raw\/docs\/flashcards\.html"/, 'Open raw button should link to /raw/');
 
       // 8. healthz reflects rawHtmlEnabled.
-      const healthDisabled = JSON.parse((await fetchText(disabledServer, '/healthz')).body);
-      const healthEnabled = JSON.parse((await fetchText(enabledServer, '/healthz')).body);
+      const healthDisabled = JSON.parse((await fetchResponse(disabledServer, '/healthz')).text);
+      const healthEnabled = JSON.parse((await fetchResponse(enabledServer, '/healthz')).text);
       assert.equal(healthDisabled.rawHtmlEnabled, false);
       assert.equal(healthEnabled.rawHtmlEnabled, true);
 

--- a/scripts/validate-raw-html.js
+++ b/scripts/validate-raw-html.js
@@ -1,11 +1,13 @@
 'use strict';
 
-// Validates raw HTML serving.
+// Validates source and transformed HTML serving.
 //
 // Verifies:
 //   * /raw/<path>.html is 404 when disabled
 //   * /raw/<path>.html serves the file verbatim with text/html when enabled
 //   * /raw/<path>.txt returns 415 (only .html/.htm allowed)
+//   * /embed/<path>.html injects base/theme/navigation without changing /raw
+//   * /embed rejects binary and invalid UTF-8 input
 //   * /view/<path>.html still wraps + sanitises (no inline <script> survives)
 //   * /view exposes an "Open raw" toolbar link only when raw HTML is enabled
 //
@@ -33,6 +35,7 @@ function fetchResponse(server, urlPath) {
           resolve({
             status: res.statusCode,
             contentType: res.headers['content-type'] || '',
+            headers: res.headers,
             body,
             text: body.toString('utf8'),
           });
@@ -77,7 +80,11 @@ async function run() {
     await fs.writeFile(path.join(repoDir, 'notes.md'), '# Notes\n', 'utf8');
 
     const appDisabled = createApp({ mappings: { docs: repoDir }, rawHtmlEnabled: false });
-    const appEnabled = createApp({ mappings: { docs: repoDir }, rawHtmlEnabled: true });
+    const appEnabled = createApp({
+      mappings: { docs: repoDir },
+      rawHtmlEnabled: true,
+      annotationsEnabled: true,
+    });
 
     const disabledServer = await listen(appDisabled);
     const enabledServer = await listen(appEnabled);
@@ -99,19 +106,37 @@ async function run() {
       assert.equal(oddEncodingResp.status, 200, '/raw odd-encoding HTML should 200');
       assert.deepEqual(oddEncodingResp.body, ODD_ENCODING_HTML, '/raw must not decode or normalize invalid UTF-8 bytes');
 
-      // 3. Enabled instance: /raw rejects non-html extensions.
+      // 3. /embed injection contract is separate from /raw byte identity.
+      const embedResp = await fetchResponse(
+        enabledServer,
+        '/embed/docs/flashcards.html?lookie-theme=light&lookie-scheme=teal'
+      );
+      assert.equal(embedResp.status, 200, '/embed/<.html> should 200 when enabled');
+      assert.equal(embedResp.headers['x-lookie-content-mode'], 'transformed-embed');
+      assert.match(embedResp.text, /<base href="\/asset\/docs\/">/, '/embed injects an opaque asset base');
+      assert.match(embedResp.text, /id="lookie-link-embed-theme"/, '/embed injects theme tokens');
+      assert.match(embedResp.text, /data-lookie-link-theme="light"/, '/embed accepts the framed theme mode');
+      assert.match(embedResp.text, /data-lookie-link-scheme="teal"/, '/embed accepts the framed color scheme');
+      assert.match(embedResp.text, /lookie-link-annotations-bootstrap/, '/embed mounts annotations when enabled');
+      assert.match(embedResp.text, /<script>document\.getElementById/, 'authored inline scripts survive /embed');
+      assert.notDeepEqual(embedResp.body, enabledResp.body, '/embed is explicitly transformed');
+
+      const rejectedEmbed = await fetchResponse(enabledServer, '/embed/docs/odd-encoding.htm');
+      assert.equal(rejectedEmbed.status, 415, '/embed rejects invalid UTF-8 while /raw preserves it');
+
+      // 4. Enabled instance: /raw rejects non-html extensions.
       const notMdResp = await fetchResponse(enabledServer, '/raw/docs/notes.md');
       assert.equal(notMdResp.status, 415, '/raw rejects non-html extensions with 415');
 
-      // 4. Enabled instance: unknown repo returns 404.
+      // 5. Enabled instance: unknown repo returns 404.
       const unknownResp = await fetchResponse(enabledServer, '/raw/missing/flashcards.html');
       assert.equal(unknownResp.status, 404, 'unknown repo returns 404');
 
-      // 5. Enabled instance: directory traversal blocked.
+      // 6. Enabled instance: directory traversal blocked.
       const traversalResp = await fetchResponse(enabledServer, '/raw/docs/../../../etc/passwd');
       assert.notEqual(traversalResp.status, 200, 'directory traversal must not return 200');
 
-      // 6. /view/<.html> still wraps + sanitises on both disabled and enabled.
+      // 7. /view/<.html> still wraps + sanitises on both disabled and enabled.
       const viewDisabled = await fetchResponse(disabledServer, '/view/docs/flashcards.html');
       assert.equal(viewDisabled.status, 200);
       assert.match(viewDisabled.contentType, /^text\/html/);
@@ -130,18 +155,18 @@ async function run() {
         '/view must strip inline <script> even when raw mode is enabled'
       );
 
-      // 7. "Open raw" toolbar appears only when raw HTML is enabled.
+      // 8. "Open raw" toolbar appears only when raw HTML is enabled.
       assert.doesNotMatch(viewDisabled.text, /Open raw/, 'disabled /view should not advertise raw mode');
       assert.match(viewEnabled.text, /Open raw/, 'enabled /view should advertise raw mode');
       assert.match(viewEnabled.text, /href="\/raw\/docs\/flashcards\.html"/, 'Open raw button should link to /raw/');
 
-      // 8. healthz reflects rawHtmlEnabled.
+      // 9. healthz reflects rawHtmlEnabled.
       const healthDisabled = JSON.parse((await fetchResponse(disabledServer, '/healthz')).text);
       const healthEnabled = JSON.parse((await fetchResponse(enabledServer, '/healthz')).text);
       assert.equal(healthDisabled.rawHtmlEnabled, false);
       assert.equal(healthEnabled.rawHtmlEnabled, true);
 
-      console.log('OK — /raw HTML serving validates against the acceptance criteria.');
+      console.log('OK — /raw exact bytes and /embed injection validate as separate contracts.');
     } finally {
       await close(disabledServer);
       await close(enabledServer);

--- a/scripts/validate-raw-html.js
+++ b/scripts/validate-raw-html.js
@@ -149,6 +149,16 @@ async function run() {
 
       const viewEnabled = await fetchResponse(enabledServer, '/view/docs/flashcards.html');
       assert.equal(viewEnabled.status, 200);
+      assert.match(
+        viewEnabled.text,
+        /<iframe[\s\S]*data-embedded-html[\s\S]*src="\/embed\/docs\/flashcards\.html"/,
+        '/view frames trusted authored HTML through /embed'
+      );
+      assert.doesNotMatch(
+        viewEnabled.text,
+        /<iframe[\s\S]*src="\/raw\/docs\/flashcards\.html"/,
+        '/view must not use the byte-preserving source route as its transformed runtime'
+      );
       assert.doesNotMatch(
         viewEnabled.text,
         /<script>document\.getElementById\("root"\)\.textContent = "flipped";<\/script>/,

--- a/scripts/validate-raw-html.js
+++ b/scripts/validate-raw-html.js
@@ -19,8 +19,17 @@ const fs = require('node:fs/promises');
 const http = require('node:http');
 const os = require('node:os');
 const path = require('node:path');
+const { JSDOM } = require('jsdom');
 
 const { createApp } = require('../server');
+
+const CURRENT_ANNOTATION_SELECTORS = [
+  '[data-annotations-mount]',
+  '[data-annotate-trigger]',
+  '[data-annotations-stale]',
+  '[data-annotations-toggle]',
+  '[data-rendered-view]',
+];
 
 function fetchResponse(server, urlPath) {
   return new Promise((resolve, reject) => {
@@ -61,6 +70,7 @@ const FLASHCARDS_HTML = [
   '<!doctype html>',
   '<html><head><title>Flashcards</title></head>',
   '<body>',
+  '  <h1>Flashcards</h1>',
   '  <div id="root"></div>',
   '  <script>document.getElementById("root").textContent = "flipped";</script>',
   '</body></html>',
@@ -118,6 +128,14 @@ async function run() {
       assert.match(embedResp.text, /data-lookie-link-theme="light"/, '/embed accepts the framed theme mode');
       assert.match(embedResp.text, /data-lookie-link-scheme="teal"/, '/embed accepts the framed color scheme');
       assert.match(embedResp.text, /lookie-link-annotations-bootstrap/, '/embed mounts annotations when enabled');
+      const embedDocument = new JSDOM(embedResp.text).window.document;
+      for (const selector of CURRENT_ANNOTATION_SELECTORS) {
+        assert.ok(embedDocument.querySelector(selector), `/embed must emit current annotation selector ${selector}`);
+      }
+      const oldAnchorLinkOnly = embedDocument.querySelector('a.anchor-link[data-anchor-id]')
+        && !embedDocument.querySelector('[data-annotations-mount][data-anchor-id]')
+        && !embedDocument.querySelector('[data-annotate-trigger][data-anchor-id]');
+      assert.equal(oldAnchorLinkOnly, false, '/embed must not regress to obsolete anchor-link-only annotation markup');
       assert.match(embedResp.text, /<script>document\.getElementById/, 'authored inline scripts survive /embed');
       assert.notDeepEqual(embedResp.body, enabledResp.body, '/embed is explicitly transformed');
 

--- a/scripts/validate-raw-html.js
+++ b/scripts/validate-raw-html.js
@@ -8,7 +8,7 @@
 //   * /raw/<path>.txt returns 415 (only .html/.htm allowed)
 //   * /embed/<path>.html injects base/theme/navigation without changing /raw
 //   * /embed rejects binary and invalid UTF-8 input
-//   * /view/<path>.html still wraps + sanitises (no inline <script> survives)
+//   * /view uses the sanitised renderer when disabled and frames /embed when enabled
 //   * /view exposes an "Open raw" toolbar link only when raw HTML is enabled
 //
 // Runs the real `createApp` against a tmp repo so the route/middleware wiring
@@ -136,7 +136,7 @@ async function run() {
       const traversalResp = await fetchResponse(enabledServer, '/raw/docs/../../../etc/passwd');
       assert.notEqual(traversalResp.status, 200, 'directory traversal must not return 200');
 
-      // 7. /view/<.html> still wraps + sanitises on both disabled and enabled.
+      // 7. /view sanitises when disabled and frames /embed when enabled.
       const viewDisabled = await fetchResponse(disabledServer, '/view/docs/flashcards.html');
       assert.equal(viewDisabled.status, 200);
       assert.match(viewDisabled.contentType, /^text\/html/);
@@ -162,7 +162,7 @@ async function run() {
       assert.doesNotMatch(
         viewEnabled.text,
         /<script>document\.getElementById\("root"\)\.textContent = "flipped";<\/script>/,
-        '/view must strip inline <script> even when raw mode is enabled'
+        '/view wrapper must not copy authored inline scripts when embed mode is enabled'
       );
 
       // 8. "Open raw" toolbar appears only when raw HTML is enabled.

--- a/server.js
+++ b/server.js
@@ -60,6 +60,10 @@ const {
   createAnnotation,
   updateAnnotation,
 } = require('./lib/annotations');
+const {
+  decodeEmbedHtmlBuffer,
+  transformEmbedHtml,
+} = require('./lib/embed-html');
 
 const IMAGE_MIME_TYPES = {
   '.png': 'image/png',
@@ -1372,6 +1376,116 @@ function createApp(options = {}) {
         res.status(500).type('text/plain').send('Failed to read asset.');
       }
     });
+  });
+
+  app.get('/embed/:repo/*', async (req, res) => {
+    if (!rawHtmlEnabled) {
+      res.status(404).type('text/plain').send('Embedded HTML serving is disabled.');
+      return;
+    }
+
+    const accessContext = resolveAccessContext(req);
+    const repo = req.params.repo;
+    const relativePath = req.params[0] || '';
+    const rootPath = mappings[repo];
+
+    if (!rootPath) {
+      res.status(404).type('text/plain').send(`Unknown repository: ${repo}`);
+      return;
+    }
+    if (!relativePath) {
+      res.status(400).type('text/plain').send('Embedded serving requires a file path.');
+      return;
+    }
+    if (!HTML_EXTENSIONS.has(path.extname(relativePath).toLowerCase())) {
+      res.status(415).type('text/plain').send('Embedded mode only supports .html and .htm files.');
+      return;
+    }
+    if (!canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+      res.status(403).type('text/plain').send('Access denied.');
+      return;
+    }
+
+    let resolved;
+    try {
+      resolved = await safeResolve(rootPath, relativePath);
+    } catch (error) {
+      if (error && error.code === 'EACCES') {
+        res.status(403).type('text/plain').send('Invalid path.');
+        return;
+      }
+      if (error && error.code === 'ENOENT') {
+        res.status(404).type('text/plain').send('File not found.');
+        return;
+      }
+      console.error('Failed to resolve embed path', { rootPath, relativePath, error });
+      res.status(500).type('text/plain').send('Failed to resolve embedded path.');
+      return;
+    }
+
+    let stat;
+    try {
+      stat = await fs.stat(resolved);
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        res.status(404).type('text/plain').send('File not found.');
+        return;
+      }
+      console.error('Failed to stat embed path', { resolved, error });
+      res.status(500).type('text/plain').send('Failed to read file metadata.');
+      return;
+    }
+    if (!stat.isFile()) {
+      res.status(404).type('text/plain').send('File not found.');
+      return;
+    }
+
+    let sourceBuffer;
+    try {
+      sourceBuffer = await fs.readFile(resolved);
+    } catch (error) {
+      console.error('Failed to read embed HTML', { resolved, error });
+      res.status(500).type('text/plain').send('Failed to read file.');
+      return;
+    }
+
+    let source;
+    try {
+      source = decodeEmbedHtmlBuffer(sourceBuffer);
+    } catch (error) {
+      if (error && error.code === 'EINVALIDHTML') {
+        res.status(415).type('text/plain').send(error.message);
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      const html = transformEmbedHtml(source, {
+        repo,
+        rootPath,
+        relativePath,
+        mappings,
+        queryToken: accessContext.queryToken,
+        sensitiveValues: accessContext.source === 'header' ? [extractPresentedToken(req)] : [],
+        annotationsEnabled: annotationsEnabled && canAccessPath(accessContext, 'view', repo, relativePath, 'file'),
+        themeMode: typeof req.query['lookie-theme'] === 'string' ? req.query['lookie-theme'] : 'dark',
+        themeScheme: typeof req.query['lookie-scheme'] === 'string' ? req.query['lookie-scheme'] : 'slate',
+        customThemeCss,
+        canAccess: (targetRepo, targetPath, isDirectory) => canAccessPath(
+          accessContext,
+          'view',
+          targetRepo,
+          targetPath,
+          isDirectory ? 'directory' : 'file'
+        ),
+      });
+      res.set('X-Lookie-Content-Mode', 'transformed-embed');
+      res.status(200).type(RAW_HTML_MIME_TYPE).send(html);
+    } catch (error) {
+      console.error('Failed to transform embed HTML', { repo, relativePath, error });
+      res.status(500).type('text/plain').send('Failed to transform embedded HTML.');
+    }
   });
 
   // Serve trusted HTML files verbatim. See lib/config.js

--- a/server.js
+++ b/server.js
@@ -270,6 +270,10 @@ function sendAccessError(res, accessContext, asJson = false) {
   res.status(accessContext.denialStatus).type('text/plain').send(accessContext.denialMessage);
 }
 
+function sendRawHtmlResponse(res, sourceBuffer) {
+  res.status(200).type(RAW_HTML_MIME_TYPE).send(sourceBuffer);
+}
+
 function parseBooleanQuery(value) {
   if (typeof value !== 'string') {
     return false;
@@ -1444,16 +1448,16 @@ function createApp(options = {}) {
       return;
     }
 
-    res.type(RAW_HTML_MIME_TYPE).sendFile(resolved, (error) => {
-      if (!error) {
-        return;
-      }
+    let sourceBuffer;
+    try {
+      sourceBuffer = await fs.readFile(resolved);
+    } catch (error) {
+      console.error('Failed to read raw HTML', { resolved, error });
+      res.status(500).type('text/plain').send('Failed to read file.');
+      return;
+    }
 
-      console.error('Failed to serve raw HTML', { resolved, error });
-      if (!res.headersSent) {
-        res.status(500).type('text/plain').send('Failed to read file.');
-      }
-    });
+    sendRawHtmlResponse(res, sourceBuffer);
   });
 
   app.get('/view', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -37,6 +37,7 @@ const {
   buildSaveHref,
   buildPreviewHref,
   buildRawHref,
+  buildEmbedHref,
   formatFileSize,
   formatMTime,
   compareEntries,
@@ -736,6 +737,9 @@ function createApp(options = {}) {
         : null,
       rawHtmlHref: rawHtmlEnabled && isHtmlFile
         ? appendAccessToken(buildRawHref(repo, relativePath), accessContext)
+        : null,
+      embedHtmlHref: rawHtmlEnabled && isHtmlFile
+        ? appendAccessToken(buildEmbedHref(repo, relativePath), accessContext)
         : null,
       customThemeCss,
       queryToken: accessContext.queryToken,

--- a/test/access-control.test.js
+++ b/test/access-control.test.js
@@ -365,6 +365,13 @@ test('embed transforms authorized HTML while raw remains exact and bearer creden
     assert.match(queryHtml, /src="\/asset\/alpha\/docs\/diagram\.png\?token=viewer-token"/);
     assert.match(queryHtml, /lookie-link-annotations-bootstrap/);
 
+    const framedView = await server.request('/view/alpha/docs/landing.htm?token=viewer-token');
+    assert.equal(framedView.status, 200);
+    const framedHtml = await framedView.text();
+    assert.match(framedHtml, /<iframe[\s\S]*data-embedded-html[\s\S]*src="\/embed\/alpha\/docs\/landing\.htm\?token=viewer-token"/);
+    assert.match(framedHtml, /href="\/raw\/alpha\/docs\/landing\.htm\?token=viewer-token"[^>]*>Open raw<\/a>/);
+    assert.doesNotMatch(framedHtml, /<iframe[\s\S]*src="\/raw\/alpha\/docs\/landing\.htm/);
+
     const bearerEmbed = await server.request('/embed/alpha/docs/landing.htm', {
       headers: { Authorization: 'Bearer viewer-token' },
     });

--- a/test/access-control.test.js
+++ b/test/access-control.test.js
@@ -333,6 +333,57 @@ test('html and htm files render as sanitized documents with raw toggle and edit 
   }
 });
 
+test('embed transforms authorized HTML while raw remains exact and bearer credentials stay out of output', async () => {
+  const fixture = await makeFixture();
+  const authoredBytes = await fs.readFile(path.join(fixture.mappings.alpha, 'docs', 'landing.htm'));
+  const server = await startTestServer({
+    mappings: fixture.mappings,
+    rawHtmlEnabled: true,
+    annotationsEnabled: true,
+    accessConfig: {
+      humanDefault: 'restricted',
+      tokens: {
+        viewer: {
+          secret: 'viewer-token',
+          repos: { alpha: { paths: ['docs/'] } },
+          permissions: { view: true, edit: false },
+        },
+      },
+    },
+  });
+
+  try {
+    const rawResponse = await server.request('/raw/alpha/docs/landing.htm?token=viewer-token');
+    assert.equal(rawResponse.status, 200);
+    assert.deepEqual(Buffer.from(await rawResponse.arrayBuffer()), authoredBytes);
+
+    const queryEmbed = await server.request('/embed/alpha/docs/landing.htm?token=viewer-token');
+    assert.equal(queryEmbed.status, 200);
+    assert.equal(queryEmbed.headers.get('x-lookie-content-mode'), 'transformed-embed');
+    const queryHtml = await queryEmbed.text();
+    assert.match(queryHtml, /<base href="\/asset\/alpha\/docs\/">/);
+    assert.match(queryHtml, /src="\/asset\/alpha\/docs\/diagram\.png\?token=viewer-token"/);
+    assert.match(queryHtml, /lookie-link-annotations-bootstrap/);
+
+    const bearerEmbed = await server.request('/embed/alpha/docs/landing.htm', {
+      headers: { Authorization: 'Bearer viewer-token' },
+    });
+    assert.equal(bearerEmbed.status, 200);
+    const bearerHtml = await bearerEmbed.text();
+    assert.doesNotMatch(bearerHtml, /viewer-token/);
+    assert.match(bearerHtml, /"queryToken":null/);
+
+    const deniedView = await server.request('/view/beta/notes.md?token=viewer-token');
+    const deniedAsset = await server.request('/asset/beta/notes.md?token=viewer-token');
+    const deniedEmbed = await server.request('/embed/beta/missing.html?token=viewer-token');
+    assert.equal(deniedEmbed.status, deniedView.status);
+    assert.equal(deniedEmbed.status, deniedAsset.status);
+  } finally {
+    await server.close();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test('yaml files render nested key anchors with full-path slugs', async () => {
   const fixture = await makeFixture();
   const server = await startTestServer({

--- a/test/embed-html.test.js
+++ b/test/embed-html.test.js
@@ -6,12 +6,47 @@ const fs = require('node:fs');
 const fsPromises = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
+const { JSDOM } = require('jsdom');
 
 const {
   decodeEmbedHtmlBuffer,
   transformEmbedHtml,
 } = require('../lib/embed-html');
 const { renderDocumentPage } = require('../lib/renderer');
+
+const CURRENT_ANNOTATION_SELECTORS = [
+  '[data-annotations-mount]',
+  '[data-annotate-trigger]',
+  '[data-annotations-stale]',
+  '[data-annotations-toggle]',
+  '[data-rendered-view]',
+];
+
+function assertCurrentAnnotationContract(html) {
+  const document = new JSDOM(html).window.document;
+  for (const selector of CURRENT_ANNOTATION_SELECTORS) {
+    assert.ok(document.querySelector(selector), `missing current annotation selector ${selector}`);
+  }
+
+  const mounts = Array.from(document.querySelectorAll('[data-annotations-mount][data-anchor-id]'));
+  const triggers = Array.from(document.querySelectorAll('[data-annotate-trigger][data-anchor-id]'));
+  const anchors = Array.from(document.querySelectorAll('[data-lookie-annotation-anchor]'));
+  assert.ok(mounts.length > 0, 'current annotation contract requires at least one anchored mount');
+  assert.equal(mounts.length, anchors.length, 'each declared annotation anchor must have a mount');
+  assert.equal(triggers.length, mounts.length, 'each annotation mount must have an annotate trigger');
+  for (const mount of mounts) {
+    const anchorId = mount.getAttribute('data-anchor-id');
+    assert.ok(document.getElementById(anchorId), `annotation mount ${anchorId} must resolve to an anchor node`);
+    assert.ok(
+      triggers.some((trigger) => trigger.getAttribute('data-anchor-id') === anchorId),
+      `annotation mount ${anchorId} must have a matching annotate trigger`
+    );
+  }
+
+  const oldAnchors = Array.from(document.querySelectorAll('a.anchor-link[data-anchor-id]'));
+  const isOldAnchorLinkOnlyContract = oldAnchors.length > 0 && mounts.length === 0 && triggers.length === 0;
+  assert.equal(isOldAnchorLinkOnlyContract, false, 'obsolete anchor-link-only markup must not be the annotation mount');
+}
 
 async function makeFixture() {
   const fixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'lookie-embed-html-'));
@@ -100,14 +135,14 @@ test('embed annotations are opt-in and query credentials are limited to required
   const fixture = await makeFixture();
   try {
     const enabled = transformEmbedHtml(
-      '<h1>Annotate me</h1><img src="image.png"><a href="guide.html?token=authored-token&mode=print">Guide</a><p data-secret="bearer&amp;example">Credential</p>',
+      '<h1>Annotate me</h1><h2 id="second-target">Second target</h2><img src="image.png"><a href="guide.html?token=authored-token&mode=print">Guide</a><p data-secret="bearer&amp;example">Credential</p>',
       options(fixture, {
         annotationsEnabled: true,
         queryToken: 'query-example',
         sensitiveValues: ['bearer&example'],
       })
     );
-    assert.match(enabled, /<h1 id="annotate-me">Annotate me<a class="anchor-link"/);
+    assertCurrentAnnotationContract(enabled);
     assert.match(enabled, /lookie-link-annotations-bootstrap/);
     assert.match(enabled, /"queryToken":"query-example"/);
     assert.match(enabled, /src="\/asset\/alpha\/docs\/image\.png\?token=query-example"/);
@@ -117,10 +152,20 @@ test('embed annotations are opt-in and query credentials are limited to required
 
     const disabled = transformEmbedHtml('<h1>Plain</h1>', options(fixture, { annotationsEnabled: false }));
     assert.doesNotMatch(disabled, /lookie-link-annotations-bootstrap/);
-    assert.doesNotMatch(disabled, /class="anchor-link"/);
+    for (const selector of CURRENT_ANNOTATION_SELECTORS) {
+      assert.equal(new JSDOM(disabled).window.document.querySelector(selector), null);
+    }
   } finally {
     await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
   }
+});
+
+test('annotation contract negative canary rejects obsolete anchor-link-only markup', () => {
+  const obsolete = '<!doctype html><body><h1 id="legacy">Legacy<a class="anchor-link" href="#legacy" data-anchor-id="legacy">🔗</a></h1></body>';
+  assert.throws(
+    () => assertCurrentAnnotationContract(obsolete),
+    /missing current annotation selector \[data-annotations-mount\]/
+  );
 });
 
 test('embed output redacts host roots and inaccessible cross-repo targets', async () => {

--- a/test/embed-html.test.js
+++ b/test/embed-html.test.js
@@ -100,18 +100,20 @@ test('embed annotations are opt-in and query credentials are limited to required
   const fixture = await makeFixture();
   try {
     const enabled = transformEmbedHtml(
-      '<h1>Annotate me</h1><img src="image.png"><script>window.credential = "bearer-example";</script>',
+      '<h1>Annotate me</h1><img src="image.png"><a href="guide.html?token=authored-token&mode=print">Guide</a><p data-secret="bearer&amp;example">Credential</p>',
       options(fixture, {
         annotationsEnabled: true,
         queryToken: 'query-example',
-        sensitiveValues: ['bearer-example'],
+        sensitiveValues: ['bearer&example'],
       })
     );
     assert.match(enabled, /<h1 id="annotate-me">Annotate me<a class="anchor-link"/);
     assert.match(enabled, /lookie-link-annotations-bootstrap/);
     assert.match(enabled, /"queryToken":"query-example"/);
     assert.match(enabled, /src="\/asset\/alpha\/docs\/image\.png\?token=query-example"/);
-    assert.doesNotMatch(enabled, /bearer-example/);
+    assert.match(enabled, /href="\/view\/alpha\/docs\/guide\.html\?mode=print&amp;token=query-example"/);
+    assert.doesNotMatch(enabled, /authored-token/);
+    assert.doesNotMatch(enabled, /bearer(?:&|&amp;)example/);
 
     const disabled = transformEmbedHtml('<h1>Plain</h1>', options(fixture, { annotationsEnabled: false }));
     assert.doesNotMatch(disabled, /lookie-link-annotations-bootstrap/);

--- a/test/embed-html.test.js
+++ b/test/embed-html.test.js
@@ -11,6 +11,7 @@ const {
   decodeEmbedHtmlBuffer,
   transformEmbedHtml,
 } = require('../lib/embed-html');
+const { renderDocumentPage } = require('../lib/renderer');
 
 async function makeFixture() {
   const fixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'lookie-embed-html-'));
@@ -153,4 +154,27 @@ test('embed module does not depend on authored files being writable', async () =
   } finally {
     await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
   }
+});
+
+test('document viewer frames HTML through embed while retaining a distinct raw-source action', () => {
+  const html = renderDocumentPage({
+    repo: 'alpha',
+    repoRoot: '/srv/example/alpha',
+    relativePath: 'docs/page.html',
+    source: '<script>window.authored = true;</script>',
+    parentHref: '/view/alpha/docs',
+    mtime: '2026-01-01',
+    size: '1 KB',
+    rawHtmlHref: '/raw/alpha/docs/page.html',
+    embedHtmlHref: '/embed/alpha/docs/page.html',
+    annotationsEnabled: true,
+  });
+
+  assert.match(html, /<iframe[\s\S]*data-embedded-html[\s\S]*src="\/embed\/alpha\/docs\/page\.html"/);
+  assert.match(html, /href="\/embed\/alpha\/docs\/page\.html"[^>]*>Open embedded<\/a>/);
+  assert.match(html, /href="\/raw\/alpha\/docs\/page\.html"[^>]*>Open raw<\/a>/);
+  assert.match(html, /lookie-link:set-theme/);
+  assert.match(html, /MutationObserver/);
+  assert.doesNotMatch(html, /<iframe[\s\S]*src="\/raw\/alpha\/docs\/page\.html"/);
+  assert.doesNotMatch(html, /lookie-link-annotations-bootstrap/);
 });

--- a/test/embed-html.test.js
+++ b/test/embed-html.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const fsPromises = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  decodeEmbedHtmlBuffer,
+  transformEmbedHtml,
+} = require('../lib/embed-html');
+
+async function makeFixture() {
+  const fixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'lookie-embed-html-'));
+  const alphaRoot = path.join(fixtureRoot, 'alpha');
+  const betaRoot = path.join(fixtureRoot, 'beta');
+  await fsPromises.mkdir(path.join(alphaRoot, 'docs'), { recursive: true });
+  await fsPromises.mkdir(path.join(betaRoot, 'one'), { recursive: true });
+  await fsPromises.mkdir(path.join(betaRoot, 'two'), { recursive: true });
+  await fsPromises.writeFile(path.join(alphaRoot, 'docs', 'guide.html'), '<h1>Guide</h1>');
+  await fsPromises.writeFile(path.join(alphaRoot, 'docs', 'image.png'), 'image');
+  await fsPromises.writeFile(path.join(alphaRoot, 'docs', 'theme.css'), 'body {}');
+  await fsPromises.writeFile(path.join(betaRoot, 'unique.html'), '<h1>Unique</h1>');
+  await fsPromises.writeFile(path.join(betaRoot, 'one', 'duplicate.html'), '<h1>One</h1>');
+  await fsPromises.writeFile(path.join(betaRoot, 'two', 'duplicate.html'), '<h1>Two</h1>');
+  return { fixtureRoot, alphaRoot, betaRoot };
+}
+
+function options(fixture, overrides = {}) {
+  return {
+    repo: 'alpha',
+    rootPath: fixture.alphaRoot,
+    relativePath: 'docs/page.html',
+    mappings: { alpha: fixture.alphaRoot, beta: fixture.betaRoot },
+    canAccess: () => true,
+    ...overrides,
+  };
+}
+
+test('embed transformation preserves scripts and injects base, theme, local assets, and navigation', async () => {
+  const fixture = await makeFixture();
+  try {
+    const source = `<!doctype html>
+<html><head><title>Authored</title><link rel="stylesheet" href="theme.css"><script>window.authoredScript = true;</script></head>
+<body><h1>Hello</h1><img src="image.png"><a id="same" href="guide.html#part">Same</a><a id="fragment" href="#hello">Fragment</a></body></html>`;
+    const html = transformEmbedHtml(source, options(fixture, {
+      themeMode: 'light',
+      themeScheme: 'teal',
+    }));
+
+    assert.match(html, /<base href="\/asset\/alpha\/docs\/">/);
+    assert.match(html, /id="lookie-link-embed-theme"/);
+    assert.match(html, /data-lookie-link-theme="light"/);
+    assert.match(html, /data-lookie-link-scheme="teal"/);
+    assert.match(html, /<script>window\.authoredScript = true;<\/script>/);
+    assert.match(html, /src="\/asset\/alpha\/docs\/image\.png"/);
+    assert.match(html, /href="\/asset\/alpha\/docs\/theme\.css"/);
+    assert.match(html, /id="same" href="\/view\/alpha\/docs\/guide\.html#part" target="_top"/);
+    assert.match(html, /id="fragment" href="\/view\/alpha\/docs\/page\.html#hello" target="_top"/);
+  } finally {
+    await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('embed transformation wraps fragments and full documents that omit head', async () => {
+  const fixture = await makeFixture();
+  try {
+    const fragment = transformEmbedHtml('<section>Fragment<script>window.fragment = 1;</script></section>', options(fixture));
+    assert.match(fragment, /^<!doctype html>/i);
+    assert.match(fragment, /<head><base href="\/asset\/alpha\/docs\/">/);
+    assert.match(fragment, /<body><section>Fragment<script>window\.fragment = 1;<\/script><\/section><\/body>/);
+
+    const missingHead = transformEmbedHtml('<html><body><p>No head</p></body></html>', options(fixture));
+    assert.match(missingHead, /<html[^>]*><head><base href="\/asset\/alpha\/docs\/">/);
+    assert.match(missingHead, /<body><p>No head<\/p><\/body>/);
+  } finally {
+    await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('embed navigation resolves cross-repo and unique wiki links while containing ambiguity', async () => {
+  const fixture = await makeFixture();
+  try {
+    const html = transformEmbedHtml(
+      '<a id="cross" href="~/beta/unique.html">Cross</a><a id="wiki" href="[[unique]]">Wiki</a><a id="ambiguous" href="[[duplicate]]">Ambiguous</a>',
+      options(fixture)
+    );
+    assert.match(html, /id="cross" href="\/view\/beta\/unique\.html" target="_top"/);
+    assert.match(html, /id="wiki" href="\/view\/beta\/unique\.html" target="_top"/);
+    assert.match(html, /id="ambiguous" href="#unresolved-wiki-link"/);
+  } finally {
+    await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('embed annotations are opt-in and query credentials are limited to required generated URLs', async () => {
+  const fixture = await makeFixture();
+  try {
+    const enabled = transformEmbedHtml(
+      '<h1>Annotate me</h1><img src="image.png"><script>window.credential = "bearer-example";</script>',
+      options(fixture, {
+        annotationsEnabled: true,
+        queryToken: 'query-example',
+        sensitiveValues: ['bearer-example'],
+      })
+    );
+    assert.match(enabled, /<h1 id="annotate-me">Annotate me<a class="anchor-link"/);
+    assert.match(enabled, /lookie-link-annotations-bootstrap/);
+    assert.match(enabled, /"queryToken":"query-example"/);
+    assert.match(enabled, /src="\/asset\/alpha\/docs\/image\.png\?token=query-example"/);
+    assert.doesNotMatch(enabled, /bearer-example/);
+
+    const disabled = transformEmbedHtml('<h1>Plain</h1>', options(fixture, { annotationsEnabled: false }));
+    assert.doesNotMatch(disabled, /lookie-link-annotations-bootstrap/);
+    assert.doesNotMatch(disabled, /class="anchor-link"/);
+  } finally {
+    await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('embed output redacts host roots and inaccessible cross-repo targets', async () => {
+  const fixture = await makeFixture();
+  try {
+    const authoredPrivatePath = path.join(fixture.alphaRoot, 'docs', 'guide.html');
+    const html = transformEmbedHtml(
+      `<p>${fixture.alphaRoot}</p><script>window.privateRoot = ${JSON.stringify(fixture.betaRoot)};</script><a href="${authoredPrivatePath}">Mapped</a><a href="~/beta/unique.html">Denied</a>`,
+      options(fixture, { canAccess: (repo) => repo === 'alpha' })
+    );
+    assert.doesNotMatch(html, new RegExp(fixture.fixtureRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.doesNotMatch(html, new RegExp(os.homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.doesNotMatch(html, /rootPath|repoMappings/);
+    assert.match(html, /href="\/view\/alpha\/docs\/guide\.html"/);
+    assert.match(html, /href="#unavailable-link"/);
+  } finally {
+    await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('embed decoding rejects binary and invalid UTF-8 while accepting valid UTF-8', () => {
+  assert.equal(decodeEmbedHtmlBuffer(Buffer.from('<p>valid ✓</p>')), '<p>valid ✓</p>');
+  assert.throws(() => decodeEmbedHtmlBuffer(Buffer.from([0x3c, 0x00, 0x3e])), /binary data/);
+  assert.throws(() => decodeEmbedHtmlBuffer(Buffer.from([0x3c, 0xff, 0x3e])), /valid UTF-8/);
+});
+
+test('embed module does not depend on authored files being writable', async () => {
+  const fixture = await makeFixture();
+  try {
+    fs.chmodSync(path.join(fixture.alphaRoot, 'docs', 'guide.html'), 0o444);
+    const html = transformEmbedHtml('<a href="guide.html">Guide</a>', options(fixture));
+    assert.match(html, /href="\/view\/alpha\/docs\/guide\.html"/);
+  } finally {
+    await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Part of #91 (reconciliation Step 7 — the raw-HTML contract repair). Resolves the validator-vs-runtime contradiction the inventory found (validator asserted byte-verbatim `/raw` while the dirty route always injected).

- **`/raw/:repo/*`** is now genuinely byte-preserving: reads a Buffer, passes it to a single `sendRawHtmlResponse` responder, no decode or markup transform. HTML-only, opt-in, view-scoped.
- **`GET /embed/:repo/*`** (new) carries the transformed trusted-artifact behavior: opaque `/asset` base, theme runtime, server-resolved navigation, optional annotation mount, authored inline scripts preserved; declares `X-Lookie-Content-Mode: transformed-embed`. Rejects binary/invalid-UTF-8 with 415 (same bytes still available from `/raw`).
- **Security**: `/embed` output contains no `os.homedir()`, source roots, or repo mappings (server-side opaque resolution, same approach as #149); bearer credentials redacted before/after DOM parse (incl. entity-decoded attrs); authored `?token=` stripped before any scoped token is appended; `/embed` access checks identical to `/view`/`/asset`.
- **`/view`** frames `/embed`; "Open raw" vs "Open embedded" remain separately reachable.
- **Validator** split: one section proves `/raw` exact bytes, another proves `/embed` injection.
- **#106 seam**: `sendRawHtmlResponse` is the single responder where #106 can attach the CSP sandbox header without touching byte handling. No sandbox header added here; no test asserts one (that stays forms-gated).

Merged with current main (annotation client + video + links); conflict in `public/annotations.js` resolved in favor of main's evolved marker-based client. Verification: 36/36 tests on the merged branch. **Independent security + integration review requested before merge** (annotation-mount contract changed under this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)