### PR TITLE
test(auth): fix cross-PR fixture collision in query-token rejection test

### DIFF
--- a/test/access-control.test.js
+++ b/test/access-control.test.js
@@ -320,6 +320,7 @@ test('edit-scoped token can save while restricted humans and invalid tokens are 
     assert.doesNotMatch(editHtml, /api\/preview[^"\\]*token=/);
 
     const beforeStat = await fs.stat(targetFile);
+    const originalContent = await fs.readFile(targetFile, 'utf8');
     const annotationSidecar = path.join(
       fixture.mappings.alpha,
       '.lookie-link',
@@ -358,7 +359,7 @@ test('edit-scoped token can save while restricted humans and invalid tokens are 
         body: JSON.stringify(body),
       });
       assert.equal(response.status, 400, requestPath);
-      assert.equal(await fs.readFile(targetFile, 'utf8'), '# Guide\n![Diagram](diagram.png)\n');
+      assert.equal(await fs.readFile(targetFile, 'utf8'), originalContent);
       await assert.rejects(fs.stat(annotationSidecar), (error) => error && error.code === 'ENOENT');
     }
 


### PR DESCRIPTION
Post-merge integration fix. #149 (portable links) and #150 (auth foundations) each passed CI alone, but both edited `test/access-control.test.js`: #149 enriched the `guide.md` fixture with link forms; #150's query-token-rejection test hard-coded the old fixture content in its 'file unchanged after rejected mutation' assertion. The merge combined them → 1 failing test on main.

Fix: capture the fixture's original content at test setup and assert against it, so the file-unchanged check can't rot when the fixture changes. Full suite: 50/50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)