### PR TITLE
feat: port publishing — immutable revisioned store + capability-gated routes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ Route enforcement in phase 1:
 - `/edit/*` and `/api/save/*` require `write` (`edit` remains a backward-compatible alias)
 - `/api/preview/*` requires `view` and still respects global editing mode
 - annotation reads require `view`; annotation creates and updates require `write`; all annotation routes return `404` when annotations are disabled
-- `/api/publish*` mutations require `publish`; readback under the configured publish repo requires `view`
+- `/api/publish*` mutations require repo-level `publish` access to the configured publish repo; path-scoped publish credentials are rejected. Readback under that repo requires normal path-aware `view` access.
 
 Invalid tokens return `403`. Missing tokens return `401` when unauthenticated human access is restricted.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,9 @@
 | `GET /api/annotations/<repo>/<path>` | Read sidecar annotations for a file. Supports repeatable `?state=open|claimed|resolved`. Returns an empty schema document when no sidecar exists. |
 | `POST /api/annotations/<repo>/<path>` | Create an annotation. Requires `write` access and `enableAnnotations: true`. |
 | `PATCH /api/annotations/<repo>/<path>` | Apply `claim`, `resolve`, `reopen`, `reply`, or `redact` with stale-write protection. Requires `write` access and `enableAnnotations: true`. |
+| `POST /api/publish` | Create a publish slug and immutable revision 1 |
+| `POST /api/publish/:slug` | Create the next immutable revision with an `expectedRevision` guard |
+| `POST /api/publish/:slug/revoke` | Revoke current and historical readback for a publish slug |
 | `GET /api/grants` | List managed grants (`Authorization: Bearer <admin-token>`) |
 | `POST /api/grants` | Create a managed grant and return token + issue comment helper |
 | `POST /api/grants/:grantId/renew` | Renew a managed grant and return issue comment helper |
@@ -36,8 +39,28 @@ Route enforcement in phase 1:
 - `/edit/*` and `/api/save/*` require `write` (`edit` remains a backward-compatible alias)
 - `/api/preview/*` requires `view` and still respects global editing mode
 - annotation reads require `view`; annotation creates and updates require `write`; all annotation routes return `404` when annotations are disabled
+- `/api/publish*` mutations require `publish`; readback under the configured publish repo requires `view`
 
 Invalid tokens return `403`. Missing tokens return `401` when unauthenticated human access is restricted.
+
+## Publish Endpoints
+
+Publishing is available when `publish.areaPath` is configured and `publish.enabled` is not `false`.
+
+`POST /api/publish` accepts a non-empty `files` array and an optional slug, `entryPath`, public `metadata`, and non-projected `privateMetadata`. File content is UTF-8 by default; use `"encoding": "base64"` for binary data. It returns `201` with the slug, revision, publication projection, and view URL.
+
+`POST /api/publish/:slug` accepts the same complete-bundle payload plus a mandatory positive `expectedRevision`. Every successful call creates a new immutable numbered snapshot. A stale guard returns `409` with `currentRevision` and the safe current publication projection.
+
+`POST /api/publish/:slug/revoke` requires `{ "reason": "..." }`. After revocation, current and historical readback return `410`.
+
+Readback reuses the existing routes under a virtual repo namespace:
+
+- `/view/published/<slug>/<path>`
+- `/asset/published/<slug>/<path>`
+- `/raw/published/<slug>/<path>` when raw HTML is enabled
+- append `?version=<positive-integer>` to select a historical revision
+
+The configured `publish.repoId` replaces `published` in these paths when customized. Published metadata is never interpreted as an authorization grant or source-repository mapping, and public metadata containing absolute filesystem paths is rejected. `privateMetadata` and the publish area's control files are not reachable through published readback. See [PUBLISHING.md](PUBLISHING.md) for the complete contract and examples.
 
 ## HTML Bundle Validation
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -78,9 +78,11 @@ Notes:
 
 - `areaPath` enables the publish store unless `enabled` is explicitly `false`.
 - `repoId` is the virtual repo used by published `view`, `asset`, and `raw` URLs. It defaults to `published`.
+- `repoId` must not match a configured `repositories` key; Lookie-Link rejects that collision at startup so the virtual publish namespace cannot shadow a real repository.
 - The file, byte, metadata, and revision limits above are the defaults. All limit values must be positive integers.
 - `maxRevisions` rejects another update at the limit. It does not prune historical revisions.
-- A credential needs `publish: true` plus scope for `repoId` to create, update, or revoke. Readback needs normal `view` scope.
+- Publish is a repo-level capability: a credential needs `publish: true` plus whole-repo scope for `repoId` (or `repos: all`) to create, update, or revoke. Path-scoped publish credentials are rejected rather than treated as slug-level grants. Readback still uses normal path-aware `view` scope.
+- Publish routes inherit `access.humanDefault`. Because the default is `full`, enabling publishing without explicit access control also enables anonymous publish, update, and revoke. Multi-user deployments should set `humanDefault: restricted` or `none` and issue explicit publish credentials.
 - Source paths belong in `privateMetadata`, which is stored internally but omitted from responses and artifact readback. Public `metadata` is descriptive and never changes authorization.
 - See [PUBLISHING.md](PUBLISHING.md) for immutability, atomicity, history, and revocation semantics.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,6 +47,7 @@ access:
       permissions:
         view: true
         write: true
+        publish: false
 ```
 
 Notes:
@@ -58,6 +59,30 @@ Notes:
 - Static tokens still accept legacy `edit: true|false` and normalize it to `write` for backward compatibility.
 - Static tokens may carry optional `subject`, `issuer`, and `audit` metadata so future agent-facing `whoami/repos/grant` APIs can identify the Paperclip issue, agent, or projected grant behind a token without changing the phase 1 config shape.
 - Query-string tokens are preserved across rendered links so tokenized browser sessions can keep navigating.
+
+## Publish Artifacts
+
+```yaml
+publish:
+  enabled: true
+  areaPath: ~/.local/share/lookie-link/published
+  repoId: published
+  maxFiles: 100
+  maxFileBytes: 2097152
+  maxRevisionBytes: 10485760
+  maxMetadataBytes: 65536
+  maxRevisions: 20
+```
+
+Notes:
+
+- `areaPath` enables the publish store unless `enabled` is explicitly `false`.
+- `repoId` is the virtual repo used by published `view`, `asset`, and `raw` URLs. It defaults to `published`.
+- The file, byte, metadata, and revision limits above are the defaults. All limit values must be positive integers.
+- `maxRevisions` rejects another update at the limit. It does not prune historical revisions.
+- A credential needs `publish: true` plus scope for `repoId` to create, update, or revoke. Readback needs normal `view` scope.
+- Source paths belong in `privateMetadata`, which is stored internally but omitted from responses and artifact readback. Public `metadata` is descriptive and never changes authorization.
+- See [PUBLISHING.md](PUBLISHING.md) for immutability, atomicity, history, and revocation semantics.
 
 ## Managed Grants
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,90 @@
+# Publishing
+
+Publishing creates a stable, slug-addressed lineage of finished artifact bundles without writing into a configured source repository.
+
+## Immutability And Revisions
+
+“Immutable” applies to each numbered revision, not to the slug. A slug is a stable pointer whose current revision can advance from 1 to 2 and so on. Advancing the slug always creates a complete new snapshot; it never changes files in an existing revision. Historical revisions remain readable until the slug is revoked.
+
+`maxRevisions` is a creation limit, not a retention policy. When a slug reaches the configured limit, another update is rejected; Lookie-Link does not delete older revisions.
+
+## Configuration
+
+```yaml
+publish:
+  enabled: true
+  areaPath: ~/.local/share/lookie-link/published
+  repoId: published
+  maxFiles: 100
+  maxFileBytes: 2097152
+  maxRevisionBytes: 10485760
+  maxMetadataBytes: 65536
+  maxRevisions: 20
+```
+
+The publish area is exposed only through the virtual `published` repo namespace. Internal publication metadata and the configured filesystem path are not mounted into the viewer.
+
+A publishing credential needs `publish: true` and scope for the configured publish repo. Reading an artifact separately needs `view` scope for its slug or path.
+
+## Create A Slug
+
+```bash
+curl -X POST http://localhost:9876/api/publish \
+  -H 'Authorization: Bearer <publish-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "slug": "release-notes",
+    "files": [
+      { "path": "index.md", "content": "# Release notes\n" },
+      { "path": "diagram.png", "encoding": "base64", "content": "<base64-data>" }
+    ],
+    "entryPath": "index.md",
+    "metadata": { "label": "Release notes" },
+    "privateMetadata": { "sourceRepo": "internal-docs" }
+  }'
+```
+
+Omit `slug` to mint a random slug. A supplied slug must contain 1–64 lowercase letters, digits, or internal hyphens. File paths must be relative, cannot contain traversal or symlink ancestors, and must be unique within the payload.
+
+`metadata` is returned in publication responses but is descriptive only: it never grants access to a repo or path, and absolute filesystem paths are rejected. `privateMetadata` is stored in the publication control record but is omitted from every API projection and published readback path. Put source repository names and filesystem paths only in `privateMetadata`.
+
+## Create A New Revision
+
+Updates submit another complete bundle, not a partial file patch:
+
+```bash
+curl -X POST http://localhost:9876/api/publish/release-notes \
+  -H 'Authorization: Bearer <publish-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "expectedRevision": 1,
+    "files": [
+      { "path": "index.md", "content": "# Revised release notes\n" }
+    ],
+    "entryPath": "index.md"
+  }'
+```
+
+`expectedRevision` is mandatory. A stale value returns `409 Conflict` with the current revision. Multi-file revisions are staged outside the visible revision path and committed together; a failed publish does not expose a partial bundle. An interrupted, unreferenced next revision is removed when the same update is retried.
+
+## Read Current And Historical Content
+
+- Current rendered entry: `/view/published/release-notes/index.md`
+- Revision 1 rendered entry: `/view/published/release-notes/index.md?version=1`
+- Revision 1 asset: `/asset/published/release-notes/diagram.png?version=1`
+- Revision 1 raw HTML, when raw HTML is enabled: `/raw/published/release-notes/page.html?version=1`
+
+These routes reuse the normal viewer authorization and rendering rules under the `published` repo name. They never use metadata to resolve or authorize a source repository.
+
+## Revoke A Slug
+
+```bash
+curl -X POST http://localhost:9876/api/publish/release-notes/revoke \
+  -H 'Authorization: Bearer <publish-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{ "reason": "artifact superseded" }'
+```
+
+Revocation returns `410 Gone` for current and historical `view`, `asset`, and `raw` reads. It does not rewrite or delete the immutable revision snapshots.
+
+Managed agent API keys record `publish.create`, `publish.update`, and `publish.revoke` audit events in the API-key audit store.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -22,9 +22,11 @@ publish:
   maxRevisions: 20
 ```
 
-The publish area is exposed only through the virtual `published` repo namespace. Internal publication metadata and the configured filesystem path are not mounted into the viewer.
+The publish area is exposed only through the virtual `published` repo namespace. Its `repoId` must not collide with a configured source-repository mapping; Lookie-Link rejects a collision at startup. Internal publication metadata and the configured filesystem path are not mounted into the viewer.
 
-A publishing credential needs `publish: true` and scope for the configured publish repo. Reading an artifact separately needs `view` scope for its slug or path.
+Publishing is a repo-level capability. A publishing credential needs `publish: true` and whole-repo scope for the configured publish repo (or `repos: all`). Path-scoped publish credentials are rejected for create, update, and revoke rather than silently treating a path as a slug-management boundary. Reading an artifact separately remains path-aware and needs `view` scope for its slug or path.
+
+Publish routes use the instance's normal default-access posture. The default `access.humanDefault: full` therefore allows anonymous publish, update, and revoke when publishing is enabled. Multi-user deployments should use `humanDefault: restricted` or `none` and explicit publish credentials.
 
 ## Create A Slug
 
@@ -66,6 +68,8 @@ curl -X POST http://localhost:9876/api/publish/release-notes \
 ```
 
 `expectedRevision` is mandatory. A stale value returns `409 Conflict` with the current revision. Multi-file revisions are staged outside the visible revision path and committed together; a failed publish does not expose a partial bundle. An interrupted, unreferenced next revision is removed when the same update is retried.
+
+The `expectedRevision` check and per-slug lock coordinate one Lookie-Link process. Deployments must not run multiple server instances against the same `areaPath`; cross-process locking is not currently provided.
 
 ## Read Current And Historical Content
 

--- a/lib/access-control.js
+++ b/lib/access-control.js
@@ -382,6 +382,26 @@ function canAccessPath(accessContext, action, repo, relativePath, pathType = 'fi
   return scopes.some((scope) => scopeAllowsFile(scope, relativePath));
 }
 
+function canAccessRepo(accessContext, action, repo) {
+  if (accessContext.mode === 'denied') {
+    return false;
+  }
+
+  const permission = action === 'edit' ? 'write' : action;
+  const allowed = permission === 'write'
+    ? accessContext.permissions.write === true || accessContext.permissions.edit === true
+    : accessContext.permissions[permission] === true;
+  if (!allowed) {
+    return false;
+  }
+
+  if (accessContext.mode === 'unrestricted' || accessContext.allRepos) {
+    return true;
+  }
+
+  return getRepoScopes(accessContext, repo).some((scope) => scope.type === 'all');
+}
+
 function appendAccessToken(url, accessContext) {
   if (!accessContext || !accessContext.queryToken) {
     return url;
@@ -395,6 +415,7 @@ module.exports = {
   parseAccessConfig,
   authenticateRequest,
   canAccessPath,
+  canAccessRepo,
   appendAccessToken,
   extractBearerToken,
   extractQueryToken,

--- a/lib/config.js
+++ b/lib/config.js
@@ -202,6 +202,20 @@ function getAccessConfig() {
   return {};
 }
 
+function getPublishConfig() {
+  const config = getConfig();
+  if (!config.publish || typeof config.publish !== 'object') {
+    return {};
+  }
+
+  return {
+    ...config.publish,
+    areaPath: typeof config.publish.areaPath === 'string'
+      ? path.resolve(expandHome(config.publish.areaPath))
+      : config.publish.areaPath,
+  };
+}
+
 function parseBoolean(value) {
   if (typeof value === 'boolean') {
     return value;
@@ -389,6 +403,7 @@ module.exports = {
   getAnnotationsEnabled,
   getRawHtmlEnabled,
   getAccessConfig,
+  getPublishConfig,
   loadCustomThemes,
   generateCustomThemeCss,
   BUILT_IN_THEMES,

--- a/lib/publish-store.js
+++ b/lib/publish-store.js
@@ -1,0 +1,501 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const { safeResolve, toPosixPath } = require('./path-utils');
+
+const DEFAULT_LIMITS = Object.freeze({
+  maxFiles: 100,
+  maxFileBytes: 2 * 1024 * 1024,
+  maxRevisionBytes: 10 * 1024 * 1024,
+  maxMetadataBytes: 64 * 1024,
+  maxRevisions: 20,
+});
+
+function codedError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function positiveInteger(value, fallback, name) {
+  if (value == null) {
+    return fallback;
+  }
+  const normalized = Number(value);
+  if (!Number.isSafeInteger(normalized) || normalized < 1) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return normalized;
+}
+
+function normalizeRepoId(rawRepoId) {
+  const value = String(rawRepoId || 'published').trim();
+  if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(value)) {
+    throw new Error('publish.repoId is invalid.');
+  }
+  return value;
+}
+
+function normalizeSlug(rawSlug) {
+  const value = String(rawSlug || '').trim();
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(value)) {
+    throw new Error('slug is invalid. Use 1-64 lowercase letters, digits, or internal hyphens.');
+  }
+  return value;
+}
+
+function normalizeRelativePath(rawPath, fieldName = 'path', allowEmpty = false) {
+  if (typeof rawPath !== 'string' || rawPath.includes('\0') || rawPath.includes('\\')) {
+    throw new Error(`${fieldName} is invalid.`);
+  }
+  if (rawPath.startsWith('/') || /^[a-zA-Z]:/.test(rawPath)) {
+    throw new Error(`${fieldName} is invalid.`);
+  }
+
+  const normalized = toPosixPath(rawPath).replace(/\/$/, '');
+  if (!normalized) {
+    if (allowEmpty) {
+      return '';
+    }
+    throw new Error(`${fieldName} is required.`);
+  }
+  if (normalized.split('/').some((segment) => !segment || segment === '.' || segment === '..')) {
+    throw new Error(`${fieldName} is invalid.`);
+  }
+  return normalized;
+}
+
+function cloneJsonValue(value) {
+  return value == null ? null : JSON.parse(JSON.stringify(value));
+}
+
+function containsAbsoluteFilesystemPath(value) {
+  if (typeof value === 'string') {
+    return value.startsWith('/') || value.startsWith('~/') || /^[a-zA-Z]:[\\/]/.test(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsAbsoluteFilesystemPath);
+  }
+  return Boolean(value && typeof value === 'object' && Object.values(value).some(containsAbsoluteFilesystemPath));
+}
+
+function normalizeMetadata(rawMetadata, fieldName, maxBytes) {
+  if (rawMetadata == null) {
+    return null;
+  }
+  if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
+    throw new Error(`${fieldName} must be an object when provided.`);
+  }
+
+  let serialized;
+  try {
+    serialized = JSON.stringify(rawMetadata);
+  } catch (_error) {
+    throw new Error(`${fieldName} must be JSON-serializable.`);
+  }
+  if (serialized === undefined) {
+    throw new Error(`${fieldName} must be JSON-serializable.`);
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+    throw codedError(`${fieldName} exceeds the ${maxBytes}-byte limit.`, 'ELIMIT');
+  }
+  const normalized = JSON.parse(serialized);
+  if (fieldName === 'metadata' && containsAbsoluteFilesystemPath(normalized)) {
+    throw new Error('metadata must not contain absolute filesystem paths; use privateMetadata instead.');
+  }
+  return normalized;
+}
+
+function decodeBase64(content, fieldName) {
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(content)) {
+    throw new Error(`${fieldName} is not valid base64.`);
+  }
+  return Buffer.from(content, 'base64');
+}
+
+function normalizeFiles(rawFiles, limits) {
+  if (!Array.isArray(rawFiles) || rawFiles.length === 0) {
+    throw new Error('files must be a non-empty array.');
+  }
+  if (rawFiles.length > limits.maxFiles) {
+    throw codedError(`files exceeds the ${limits.maxFiles}-file limit.`, 'ELIMIT');
+  }
+
+  const seenPaths = new Set();
+  const files = rawFiles.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`files[${index}] must be an object.`);
+    }
+    const filePath = normalizeRelativePath(entry.path, `files[${index}].path`);
+    if (seenPaths.has(filePath)) {
+      throw new Error(`Duplicate publish file path: ${filePath}`);
+    }
+    seenPaths.add(filePath);
+
+    if (typeof entry.content !== 'string') {
+      throw new Error(`files[${index}].content must be a string.`);
+    }
+    const encoding = entry.encoding == null ? 'utf8' : String(entry.encoding).trim().toLowerCase();
+    let buffer;
+    if (encoding === 'utf8' || encoding === 'utf-8') {
+      buffer = Buffer.from(entry.content, 'utf8');
+    } else if (encoding === 'base64') {
+      buffer = decodeBase64(entry.content, `files[${index}].content`);
+    } else {
+      throw new Error(`Unsupported encoding for files[${index}]: ${encoding}`);
+    }
+    if (buffer.length > limits.maxFileBytes) {
+      throw codedError(`files[${index}] exceeds the ${limits.maxFileBytes}-byte limit.`, 'ELIMIT');
+    }
+    return { path: filePath, buffer };
+  });
+
+  const sortedPaths = [...seenPaths].sort();
+  for (let index = 1; index < sortedPaths.length; index += 1) {
+    if (sortedPaths[index].startsWith(`${sortedPaths[index - 1]}/`)) {
+      throw new Error(`Publish paths cannot be both a file and a directory: ${sortedPaths[index - 1]}`);
+    }
+  }
+  const sizeBytes = files.reduce((total, file) => total + file.buffer.length, 0);
+  if (sizeBytes > limits.maxRevisionBytes) {
+    throw codedError(`revision exceeds the ${limits.maxRevisionBytes}-byte limit.`, 'ELIMIT');
+  }
+  return { files, sizeBytes };
+}
+
+function inferEntryPath(files) {
+  const preferred = ['index.html', 'index.htm', 'index.md', 'README.md'];
+  return preferred.find((candidate) => files.some((file) => file.path === candidate))
+    || (files.length === 1 ? files[0].path : null);
+}
+
+function normalizeEntryPath(rawEntryPath, files) {
+  const entryPath = rawEntryPath == null || rawEntryPath === ''
+    ? inferEntryPath(files)
+    : normalizeRelativePath(rawEntryPath, 'entryPath');
+  if (entryPath && !files.some((file) => file.path === entryPath)) {
+    throw new Error('entryPath must reference a file included in the publish payload.');
+  }
+  return entryPath;
+}
+
+async function assertNoSymlinkComponents(targetPath) {
+  const absolute = path.resolve(targetPath);
+  const parsed = path.parse(absolute);
+  const segments = absolute.slice(parsed.root.length).split(path.sep).filter(Boolean);
+  let current = parsed.root;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    try {
+      const stat = await fs.lstat(current);
+      if (stat.isSymbolicLink()) {
+        throw codedError('Publish storage paths must not contain symbolic links.', 'EACCES');
+      }
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+function createPublicationProjection(repoId, publication) {
+  const current = publication.revisions.find((entry) => entry.revision === publication.currentRevision) || null;
+  const entryPath = current ? current.entryPath : null;
+  const entrySuffix = entryPath ? `/${entryPath.split('/').map(encodeURIComponent).join('/')}` : '';
+  const base = `/view/${encodeURIComponent(repoId)}/${encodeURIComponent(publication.slug)}`;
+  return {
+    slug: publication.slug,
+    repoId,
+    state: publication.revokedAt ? 'revoked' : 'active',
+    createdAt: publication.createdAt,
+    updatedAt: publication.updatedAt,
+    currentRevision: publication.currentRevision,
+    entryPath,
+    metadata: cloneJsonValue(publication.metadata),
+    revokedAt: publication.revokedAt || null,
+    revokedReason: publication.revokedReason || null,
+    viewUrl: `${base}${entrySuffix}`,
+    rootViewUrl: base,
+    revisions: publication.revisions.map((revision) => ({
+      revision: revision.revision,
+      createdAt: revision.createdAt,
+      entryPath: revision.entryPath,
+      fileCount: revision.fileCount,
+      sizeBytes: revision.sizeBytes,
+      metadata: cloneJsonValue(revision.metadata),
+      viewUrl: `${base}${revision.entryPath ? `/${revision.entryPath.split('/').map(encodeURIComponent).join('/')}` : ''}?version=${revision.revision}`,
+    })),
+  };
+}
+
+class PublishStore {
+  static fromConfig(rawConfig) {
+    if (!rawConfig || typeof rawConfig !== 'object' || rawConfig.enabled === false) {
+      return null;
+    }
+    const areaPath = typeof rawConfig.areaPath === 'string' && rawConfig.areaPath.trim()
+      ? path.resolve(rawConfig.areaPath.trim())
+      : null;
+    return areaPath ? new PublishStore({ ...rawConfig, areaPath }) : null;
+  }
+
+  constructor(config) {
+    if (!config || typeof config.areaPath !== 'string' || !config.areaPath.trim()) {
+      throw new Error('publish.areaPath is required.');
+    }
+    this.areaPath = path.resolve(config.areaPath);
+    this.repoId = normalizeRepoId(config.repoId);
+    this.limits = {
+      maxFiles: positiveInteger(config.maxFiles, DEFAULT_LIMITS.maxFiles, 'publish.maxFiles'),
+      maxFileBytes: positiveInteger(config.maxFileBytes, DEFAULT_LIMITS.maxFileBytes, 'publish.maxFileBytes'),
+      maxRevisionBytes: positiveInteger(config.maxRevisionBytes, DEFAULT_LIMITS.maxRevisionBytes, 'publish.maxRevisionBytes'),
+      maxMetadataBytes: positiveInteger(config.maxMetadataBytes, DEFAULT_LIMITS.maxMetadataBytes, 'publish.maxMetadataBytes'),
+      maxRevisions: positiveInteger(config.maxRevisions, DEFAULT_LIMITS.maxRevisions, 'publish.maxRevisions'),
+    };
+    this.slugLocks = new Map();
+  }
+
+  isEnabled() { return true; }
+  getRepoId() { return this.repoId; }
+  getRuntimeRoot() { return this.areaPath; }
+  getLimits() { return { ...this.limits }; }
+  publicationDir(slug) { return path.join(this.areaPath, slug); }
+  publicationMetadataPath(slug) { return path.join(this.publicationDir(slug), 'publication.json'); }
+  revisionDir(slug, revision) { return path.join(this.publicationDir(slug), 'revisions', String(revision)); }
+
+  async ensureAreaPath() {
+    await assertNoSymlinkComponents(this.areaPath);
+    await fs.mkdir(this.areaPath, { recursive: true });
+    await assertNoSymlinkComponents(this.areaPath);
+  }
+
+  async withSlugLock(slug, operation) {
+    const previous = this.slugLocks.get(slug) || Promise.resolve();
+    let release;
+    const current = new Promise((resolve) => { release = resolve; });
+    const queued = previous.then(() => current);
+    this.slugLocks.set(slug, queued);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.slugLocks.get(slug) === queued) {
+        this.slugLocks.delete(slug);
+      }
+    }
+  }
+
+  async generateSlug() {
+    for (let attempts = 0; attempts < 10; attempts += 1) {
+      const candidate = crypto.randomBytes(9).toString('hex');
+      try {
+        await fs.lstat(this.publicationDir(candidate));
+      } catch (error) {
+        if (error && error.code === 'ENOENT') return candidate;
+        throw error;
+      }
+    }
+    throw new Error('Failed to allocate a unique slug.');
+  }
+
+  async readPublication(slug) {
+    const normalizedSlug = normalizeSlug(slug);
+    await this.ensureAreaPath();
+    await assertNoSymlinkComponents(this.publicationDir(normalizedSlug));
+    try {
+      const parsed = JSON.parse(await fs.readFile(this.publicationMetadataPath(normalizedSlug), 'utf8'));
+      return { ...parsed, slug: normalizedSlug };
+    } catch (error) {
+      if (error && error.code === 'ENOENT') return null;
+      throw error;
+    }
+  }
+
+  serializePublication(publication) {
+    return createPublicationProjection(this.repoId, publication);
+  }
+
+  async writeJsonFile(targetPath, value) {
+    const tempPath = path.join(path.dirname(targetPath), `.publish-metadata-${process.pid}-${crypto.randomBytes(6).toString('hex')}`);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    try {
+      await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+      await fs.rename(tempPath, targetPath);
+    } catch (error) {
+      await fs.rm(tempPath, { force: true });
+      throw error;
+    }
+  }
+
+  async writeRevisionFiles(rootPath, files) {
+    for (const file of files) {
+      const targetPath = path.join(rootPath, file.path);
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await assertNoSymlinkComponents(path.dirname(targetPath));
+      await fs.writeFile(targetPath, file.buffer, { flag: 'wx', mode: 0o600 });
+    }
+  }
+
+  buildInput(input) {
+    const normalized = normalizeFiles(input && input.files, this.limits);
+    return {
+      ...normalized,
+      entryPath: normalizeEntryPath(input && input.entryPath, normalized.files),
+      metadata: normalizeMetadata(input && input.metadata, 'metadata', this.limits.maxMetadataBytes),
+      privateMetadata: normalizeMetadata(input && input.privateMetadata, 'privateMetadata', this.limits.maxMetadataBytes),
+    };
+  }
+
+  async createPublication(input) {
+    await this.ensureAreaPath();
+    const bundle = this.buildInput(input);
+    const slug = input && input.slug != null ? normalizeSlug(input.slug) : await this.generateSlug();
+    return this.withSlugLock(slug, async () => {
+      await assertNoSymlinkComponents(this.publicationDir(slug));
+      if (await this.readPublication(slug)) {
+        const conflict = codedError('Published slug already exists.', 'ECONFLICT');
+        conflict.current = await this.readPublication(slug);
+        throw conflict;
+      }
+
+      const now = new Date().toISOString();
+      const revisionRecord = {
+        revision: 1, createdAt: now, entryPath: bundle.entryPath,
+        fileCount: bundle.files.length, sizeBytes: bundle.sizeBytes, metadata: bundle.metadata,
+      };
+      const publication = {
+        slug, createdAt: now, updatedAt: now, currentRevision: 1,
+        metadata: bundle.metadata, privateMetadata: bundle.privateMetadata,
+        revokedAt: null, revokedReason: null, revisions: [revisionRecord],
+      };
+      const tempDir = path.join(this.areaPath, `.publish-${slug}-${process.pid}-${crypto.randomBytes(6).toString('hex')}`);
+      try {
+        await fs.mkdir(path.join(tempDir, 'revisions', '1'), { recursive: true });
+        await this.writeRevisionFiles(path.join(tempDir, 'revisions', '1'), bundle.files);
+        await this.writeJsonFile(path.join(tempDir, 'publication.json'), publication);
+        await fs.rename(tempDir, this.publicationDir(slug));
+      } catch (error) {
+        await fs.rm(tempDir, { recursive: true, force: true });
+        if (['EEXIST', 'ENOTEMPTY'].includes(error && error.code)) {
+          const conflict = codedError('Published slug already exists.', 'ECONFLICT');
+          conflict.current = await this.readPublication(slug);
+          throw conflict;
+        }
+        throw error;
+      }
+      return { publication: this.serializePublication(publication) };
+    });
+  }
+
+  async updatePublication(slug, input) {
+    const normalizedSlug = normalizeSlug(slug);
+    const expectedRevision = Number(input && input.expectedRevision);
+    if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 1) {
+      throw new Error('expectedRevision is required and must be a positive integer.');
+    }
+    const bundle = this.buildInput(input);
+    return this.withSlugLock(normalizedSlug, async () => {
+      const publication = await this.readPublication(normalizedSlug);
+      if (!publication) throw codedError('Published artifact not found.', 'ENOENT');
+      if (publication.revokedAt) {
+        const error = codedError('Published artifact has been revoked.', 'EREVOKED');
+        error.current = publication;
+        throw error;
+      }
+      if (publication.currentRevision !== expectedRevision) {
+        const error = codedError('Conflict detected.', 'ECONFLICT');
+        error.current = publication;
+        throw error;
+      }
+      if (publication.revisions.length >= this.limits.maxRevisions) {
+        throw codedError(`Published artifact reached the ${this.limits.maxRevisions}-revision limit.`, 'ELIMIT');
+      }
+
+      const nextRevision = publication.currentRevision + 1;
+      const now = new Date().toISOString();
+      const revisionRecord = {
+        revision: nextRevision, createdAt: now, entryPath: bundle.entryPath,
+        fileCount: bundle.files.length, sizeBytes: bundle.sizeBytes, metadata: bundle.metadata,
+      };
+      const nextPublication = {
+        ...publication,
+        updatedAt: now,
+        currentRevision: nextRevision,
+        metadata: bundle.metadata,
+        privateMetadata: bundle.privateMetadata == null ? publication.privateMetadata || null : bundle.privateMetadata,
+        revisions: [...publication.revisions, revisionRecord],
+      };
+      const finalDir = this.revisionDir(normalizedSlug, nextRevision);
+      const tempDir = path.join(path.dirname(finalDir), `.publish-revision-${nextRevision}-${process.pid}-${crypto.randomBytes(6).toString('hex')}`);
+      let revisionCommitted = false;
+      try {
+        // A process can stop after the revision rename but before metadata advances.
+        // Such an unreferenced next revision was never published and is safe to
+        // remove before retrying the same expectedRevision transaction.
+        await assertNoSymlinkComponents(finalDir);
+        await fs.rm(finalDir, { recursive: true, force: true });
+        await fs.mkdir(tempDir, { recursive: false });
+        await this.writeRevisionFiles(tempDir, bundle.files);
+        await fs.rename(tempDir, finalDir);
+        revisionCommitted = true;
+        await this.writeJsonFile(this.publicationMetadataPath(normalizedSlug), nextPublication);
+      } catch (error) {
+        await fs.rm(tempDir, { recursive: true, force: true });
+        if (revisionCommitted) {
+          await fs.rm(finalDir, { recursive: true, force: true });
+        }
+        throw error;
+      }
+      return { publication: this.serializePublication(nextPublication) };
+    });
+  }
+
+  async revokePublication(slug, input) {
+    const normalizedSlug = normalizeSlug(slug);
+    const reason = String(input && input.reason || '').trim();
+    if (!reason) throw new Error('reason is required.');
+    if (Buffer.byteLength(reason, 'utf8') > 1000) throw codedError('reason exceeds the 1000-byte limit.', 'ELIMIT');
+    return this.withSlugLock(normalizedSlug, async () => {
+      const publication = await this.readPublication(normalizedSlug);
+      if (!publication) throw codedError('Published artifact not found.', 'ENOENT');
+      if (publication.revokedAt) throw codedError('Published artifact is already revoked.', 'EREVOKED');
+      const revokedAt = new Date().toISOString();
+      const nextPublication = { ...publication, revokedAt, revokedReason: reason, updatedAt: revokedAt };
+      await this.writeJsonFile(this.publicationMetadataPath(normalizedSlug), nextPublication);
+      return { publication: this.serializePublication(nextPublication) };
+    });
+  }
+
+  async resolvePath(slug, relativePath = '', revision = null) {
+    const normalizedSlug = normalizeSlug(slug);
+    const publication = await this.readPublication(normalizedSlug);
+    if (!publication) throw codedError('Published artifact not found.', 'ENOENT');
+    const targetRevision = revision == null ? publication.currentRevision : Number(revision);
+    if (!Number.isSafeInteger(targetRevision) || targetRevision < 1) {
+      throw codedError('version must be a positive integer.', 'EINVAL');
+    }
+    const revisionRecord = publication.revisions.find((entry) => entry.revision === targetRevision);
+    if (!revisionRecord) throw codedError('Published revision not found.', 'ENOENT');
+    const normalizedPath = normalizeRelativePath(relativePath || '', 'path', true);
+    const rootPath = this.revisionDir(normalizedSlug, targetRevision);
+    await assertNoSymlinkComponents(path.join(rootPath, normalizedPath));
+    return {
+      publication,
+      revision: revisionRecord,
+      rootPath,
+      relativePath: normalizedPath,
+      resolved: await safeResolve(rootPath, normalizedPath),
+    };
+  }
+}
+
+module.exports = {
+  DEFAULT_LIMITS,
+  PublishStore,
+};

--- a/lookie-link.yaml.example
+++ b/lookie-link.yaml.example
@@ -73,6 +73,18 @@ repositories:
 #       paperclip:
 #         secretEnv: LOOKIE_LINK_GRANT_ADMIN_TOKEN
 
+# Optional immutable-revision publish area
+# A slug can advance, but each numbered revision remains unchanged.
+# publish:
+#   enabled: true
+#   areaPath: ~/.local/share/lookie-link/published
+#   repoId: published
+#   maxFiles: 100
+#   maxFileBytes: 2097152
+#   maxRevisionBytes: 10485760
+#   maxMetadataBytes: 65536
+#   maxRevisions: 20
+
 # Custom themes
 # Each theme needs dark and/or light variants.
 # CSS property names use underscores (bg_elev → --bg-elev).

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ const {
   getAnnotationsEnabled,
   getRawHtmlEnabled,
   getAccessConfig,
+  getPublishConfig,
   loadCustomThemes,
   generateCustomThemeCss,
   BUILT_IN_THEMES,
@@ -31,6 +32,7 @@ const {
   buildIssueComment,
 } = require('./lib/grant-store');
 const { ApiKeyStore } = require('./lib/api-key-store');
+const { PublishStore } = require('./lib/publish-store');
 const {
   safeResolve,
   toPosixPath,
@@ -515,6 +517,7 @@ function createApp(options = {}) {
   const rawHtmlEnabled = options.rawHtmlEnabled === undefined ? getRawHtmlEnabled() : Boolean(options.rawHtmlEnabled);
   const customThemeCss = options.customThemeCss || '';
   const rawAccessConfig = options.accessConfig === undefined ? getAccessConfig() : options.accessConfig;
+  const rawPublishConfig = options.publishConfig === undefined ? getPublishConfig() : options.publishConfig;
   const accessConfig = parseAccessConfig(rawAccessConfig);
   const apiKeyStore = options.apiKeyStore === undefined
     ? ApiKeyStore.fromAccessConfig(rawAccessConfig.apiKeys)
@@ -522,6 +525,9 @@ function createApp(options = {}) {
   const grantStore = options.grantStore === undefined
     ? GrantStore.fromAccessConfig(rawAccessConfig.grants)
     : options.grantStore;
+  const publishStore = options.publishStore === undefined
+    ? PublishStore.fromConfig(rawPublishConfig)
+    : options.publishStore;
   const resolveAccessContext = (req) => {
     if (req.accessContext) {
       return req.accessContext;
@@ -583,9 +589,58 @@ function createApp(options = {}) {
     return apiKeyStore.recordAuditEvent(type, accessContext, target, metadata);
   };
 
+  const publishedRepo = publishStore ? publishStore.getRepoId() : 'published';
+  const canPublishTarget = (accessContext, slug = '') => canAccessPath(
+    accessContext,
+    'publish',
+    publishedRepo,
+    slug,
+    'directory'
+  );
+  const resolvePublishedTarget = async (repo, relativePath, version) => {
+    if (!publishStore || !publishStore.isEnabled() || repo !== publishedRepo) {
+      return null;
+    }
+    const parts = toPosixPath(relativePath).split('/').filter(Boolean);
+    if (parts.length === 0) {
+      return { error: { status: 404, message: 'Published artifact not found.' } };
+    }
+    const slug = parts.shift();
+    try {
+      const published = await publishStore.resolvePath(slug, parts.join('/'), version);
+      if (published.publication.revokedAt) {
+        return { error: { status: 410, message: 'Published artifact has been revoked.' } };
+      }
+      return {
+        repo,
+        relativePath,
+        rootPath: published.rootPath,
+        resolved: published.resolved,
+        published,
+      };
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        return { error: { status: 404, message: 'Published artifact not found.' } };
+      }
+      if (error && error.code === 'EINVAL') {
+        return { error: { status: 400, message: error.message } };
+      }
+      if (error && error.code === 'EACCES') {
+        return { error: { status: 403, message: 'Invalid path.' } };
+      }
+      throw error;
+    }
+  };
+
   app.disable('x-powered-by');
   app.set('trust proxy', true);
 
+  if (publishStore && publishStore.isEnabled()) {
+    const limits = publishStore.getLimits();
+    const encodedContentBudget = Math.ceil(limits.maxRevisionBytes * 4 / 3);
+    const manifestBudget = limits.maxMetadataBytes * 2 + limits.maxFiles * 1024 + 64 * 1024;
+    app.use('/api/publish', express.json({ limit: encodedContentBudget + manifestBudget }));
+  }
   app.use(express.json({ limit: '2mb' }));
   app.use((req, res, next) => {
     if (mutationUsesQueryToken(req)) {
@@ -602,6 +657,109 @@ function createApp(options = {}) {
     etag: true,
     maxAge: '1h',
   }));
+
+  app.post('/api/publish', async (req, res) => {
+    if (!publishStore || !publishStore.isEnabled()) {
+      sendPathJsonError(res, { status: 404, message: 'Publishing is not configured.' });
+      return;
+    }
+    const accessContext = resolveAccessContext(req);
+    const requestedSlug = req.body && typeof req.body.slug === 'string' ? req.body.slug : '';
+    if (!canPublishTarget(accessContext, requestedSlug)) {
+      sendAccessError(res, accessContext, true);
+      return;
+    }
+    try {
+      const result = await publishStore.createPublication(req.body || {});
+      const revision = result.publication.revisions.at(-1);
+      recordApiKeyAuditEvent('publish.create', accessContext, {
+        repo: publishedRepo,
+        relativePath: result.publication.slug,
+      }, { byteCount: revision.sizeBytes });
+      res.status(201).json({
+        ok: true,
+        slug: result.publication.slug,
+        revision: result.publication.currentRevision,
+        created: true,
+        publication: result.publication,
+        viewUrl: result.publication.viewUrl,
+      });
+    } catch (error) {
+      const status = error.code === 'ECONFLICT' ? 409 : 400;
+      res.status(status).json({
+        ok: false,
+        error: error.message,
+        current: error.current ? publishStore.serializePublication(error.current) : null,
+      });
+    }
+  });
+
+  app.post('/api/publish/:slug', async (req, res) => {
+    if (!publishStore || !publishStore.isEnabled()) {
+      sendPathJsonError(res, { status: 404, message: 'Publishing is not configured.' });
+      return;
+    }
+    const accessContext = resolveAccessContext(req);
+    if (!canPublishTarget(accessContext, req.params.slug)) {
+      sendAccessError(res, accessContext, true);
+      return;
+    }
+    try {
+      const result = await publishStore.updatePublication(req.params.slug, req.body || {});
+      const revision = result.publication.revisions.at(-1);
+      recordApiKeyAuditEvent('publish.update', accessContext, {
+        repo: publishedRepo,
+        relativePath: result.publication.slug,
+      }, { byteCount: revision.sizeBytes });
+      res.status(200).json({
+        ok: true,
+        slug: result.publication.slug,
+        revision: result.publication.currentRevision,
+        created: false,
+        publication: result.publication,
+        viewUrl: result.publication.viewUrl,
+      });
+    } catch (error) {
+      if (error.code === 'ECONFLICT') {
+        res.status(409).json({
+          ok: false,
+          error: error.message,
+          currentRevision: error.current ? error.current.currentRevision : null,
+          current: error.current ? publishStore.serializePublication(error.current) : null,
+        });
+        return;
+      }
+      const status = error.code === 'ENOENT' ? 404 : error.code === 'EREVOKED' ? 410 : 400;
+      sendPathJsonError(res, { status, message: error.message });
+    }
+  });
+
+  app.post('/api/publish/:slug/revoke', async (req, res) => {
+    if (!publishStore || !publishStore.isEnabled()) {
+      sendPathJsonError(res, { status: 404, message: 'Publishing is not configured.' });
+      return;
+    }
+    const accessContext = resolveAccessContext(req);
+    if (!canPublishTarget(accessContext, req.params.slug)) {
+      sendAccessError(res, accessContext, true);
+      return;
+    }
+    try {
+      const result = await publishStore.revokePublication(req.params.slug, req.body || {});
+      recordApiKeyAuditEvent('publish.revoke', accessContext, {
+        repo: publishedRepo,
+        relativePath: result.publication.slug,
+      });
+      res.status(200).json({
+        ok: true,
+        slug: result.publication.slug,
+        revokedAt: result.publication.revokedAt,
+      });
+    } catch (error) {
+      const status = error.code === 'ENOENT' ? 404 : error.code === 'EREVOKED' ? 410 : 400;
+      sendPathJsonError(res, { status, message: error.message });
+    }
+  });
 
   app.get('/api/agent-keys', (req, res) => {
     const auth = authenticateApiKeyAdmin(req);
@@ -802,9 +960,18 @@ function createApp(options = {}) {
 
   app.get('/view/*', async (req, res) => {
     const accessContext = resolveAccessContext(req);
+    const requestedVersion = req.query && Object.prototype.hasOwnProperty.call(req.query, 'version')
+      ? req.query.version
+      : null;
+    const requestedPath = splitViewPath(req.params[0] || '');
     let resolvedInput;
     try {
-      resolvedInput = await resolveFromRequest(mappings, req.params[0] || '');
+      resolvedInput = requestedPath
+        ? await resolvePublishedTarget(requestedPath.repo, requestedPath.relativePath, requestedVersion)
+        : null;
+      if (!resolvedInput) {
+        resolvedInput = await resolveFromRequest(mappings, req.params[0] || '');
+      }
     } catch (error) {
       console.error('Failed to resolve path', { error });
       res.status(500).type('text/plain').send('Failed to resolve path.');
@@ -1686,9 +1853,10 @@ function createApp(options = {}) {
     const accessContext = resolveAccessContext(req);
     const repo = req.params.repo;
     const relativePath = req.params[0] || '';
-    const rootPath = mappings[repo];
+    let rootPath = mappings[repo];
+    let resolved;
 
-    if (!rootPath) {
+    if (!rootPath && repo !== publishedRepo) {
       res.status(404).type('text/plain').send(`Unknown repository: ${repo}`);
       return;
     }
@@ -1705,9 +1873,18 @@ function createApp(options = {}) {
       return;
     }
 
-    let resolved;
     try {
-      resolved = await safeResolve(rootPath, relativePath);
+      const published = await resolvePublishedTarget(repo, relativePath, req.query && req.query.version);
+      if (published && published.error) {
+        sendPathError(res, published.error);
+        return;
+      }
+      if (published) {
+        rootPath = published.rootPath;
+        resolved = published.resolved;
+      } else {
+        resolved = await safeResolve(rootPath, relativePath);
+      }
     } catch (error) {
       if (error && error.code === 'EACCES') {
         res.status(403).type('text/plain').send('Invalid path.');
@@ -1768,9 +1945,10 @@ function createApp(options = {}) {
     const accessContext = resolveAccessContext(req);
     const repo = req.params.repo;
     const relativePath = req.params[0] || '';
-    const rootPath = mappings[repo];
+    let rootPath = mappings[repo];
+    let resolved;
 
-    if (!rootPath) {
+    if (!rootPath && repo !== publishedRepo) {
       res.status(404).type('text/plain').send(`Unknown repository: ${repo}`);
       return;
     }
@@ -1791,9 +1969,18 @@ function createApp(options = {}) {
       return;
     }
 
-    let resolved;
     try {
-      resolved = await safeResolve(rootPath, relativePath);
+      const published = await resolvePublishedTarget(repo, relativePath, req.query && req.query.version);
+      if (published && published.error) {
+        sendPathError(res, published.error);
+        return;
+      }
+      if (published) {
+        rootPath = published.rootPath;
+        resolved = published.resolved;
+      } else {
+        resolved = await safeResolve(rootPath, relativePath);
+      }
     } catch (error) {
       if (error && error.code === 'EACCES') {
         res.status(403).type('text/plain').send('Invalid path.');

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ const {
 const {
   parseAccessConfig,
   canAccessPath,
+  canAccessRepo,
   appendAccessToken,
   extractBearerToken,
   extractPresentedToken,
@@ -599,13 +600,11 @@ function createApp(options = {}) {
   };
 
   const publishedRepo = publishStore ? publishStore.getRepoId() : 'published';
-  const canPublishTarget = (accessContext, slug = '') => canAccessPath(
-    accessContext,
-    'publish',
-    publishedRepo,
-    slug,
-    'directory'
-  );
+  if (publishStore && publishStore.isEnabled()
+      && Object.prototype.hasOwnProperty.call(mappings, publishedRepo)) {
+    throw new Error(`publish.repoId "${publishedRepo}" conflicts with a configured repository mapping.`);
+  }
+  const canPublishTarget = (accessContext) => canAccessRepo(accessContext, 'publish', publishedRepo);
   const resolvePublishedTarget = async (repo, relativePath, version) => {
     if (!publishStore || !publishStore.isEnabled() || repo !== publishedRepo) {
       return null;
@@ -673,8 +672,7 @@ function createApp(options = {}) {
       return;
     }
     const accessContext = resolveAccessContext(req);
-    const requestedSlug = req.body && typeof req.body.slug === 'string' ? req.body.slug : '';
-    if (!canPublishTarget(accessContext, requestedSlug)) {
+    if (!canPublishTarget(accessContext)) {
       sendAccessError(res, accessContext, true);
       return;
     }
@@ -709,7 +707,7 @@ function createApp(options = {}) {
       return;
     }
     const accessContext = resolveAccessContext(req);
-    if (!canPublishTarget(accessContext, req.params.slug)) {
+    if (!canPublishTarget(accessContext)) {
       sendAccessError(res, accessContext, true);
       return;
     }
@@ -749,7 +747,7 @@ function createApp(options = {}) {
       return;
     }
     const accessContext = resolveAccessContext(req);
-    if (!canPublishTarget(accessContext, req.params.slug)) {
+    if (!canPublishTarget(accessContext)) {
       sendAccessError(res, accessContext, true);
       return;
     }

--- a/test/auth-foundations.test.js
+++ b/test/auth-foundations.test.js
@@ -94,7 +94,7 @@ test('managed grants normalize legacy edit to canonical write', async () => {
   }
 });
 
-test('publish is authorization vocabulary only and implies no write or endpoint', async () => {
+test('publish remains independent from write and is consumed by the publish endpoint', async () => {
   const config = parseAccessConfig({
     humanDefault: 'restricted',
     tokens: {
@@ -127,7 +127,11 @@ test('publish is authorization vocabulary only and implies no write or endpoint'
   const routePaths = app._router.stack
     .map((layer) => layer.route && layer.route.path)
     .filter(Boolean);
-  assert.equal(routePaths.some((routePath) => String(routePath).includes('publish')), false);
+  assert.deepEqual(routePaths.filter((routePath) => String(routePath).includes('publish')), [
+    '/api/publish',
+    '/api/publish/:slug',
+    '/api/publish/:slug/revoke',
+  ]);
 
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-auth-publish-'));
   const repoRoot = path.join(root, 'docs');

--- a/test/auth-foundations.test.js
+++ b/test/auth-foundations.test.js
@@ -9,6 +9,7 @@ const path = require('node:path');
 const {
   authenticateRequest,
   canAccessPath,
+  canAccessRepo,
   parseAccessConfig,
 } = require('../lib/access-control');
 const { GrantStore } = require('../lib/grant-store');
@@ -121,6 +122,7 @@ test('publish remains independent from write and is consumed by the publish endp
   assert.deepEqual(access.permissions, { view: true, write: false, edit: false, publish: true });
   assert.deepEqual(roundTrippedAccess.permissions, { view: true, write: false, edit: false, publish: true });
   assert.equal(canAccessPath(access, 'publish', 'docs', 'release.md'), true);
+  assert.equal(canAccessRepo(access, 'publish', 'docs'), true);
   assert.equal(canAccessPath(access, 'write', 'docs', 'release.md'), false);
 
   const app = createApp({ mappings: {}, accessConfig: config });
@@ -166,6 +168,7 @@ test('publish remains independent from write and is consumed by the publish endp
 
     assert.deepEqual(created.grant.permissions, { view: true, write: false, edit: false, publish: true });
     assert.equal(canAccessPath(grantAccess, 'publish', 'docs', 'releases/v1.md'), true);
+    assert.equal(canAccessRepo(grantAccess, 'publish', 'docs'), false);
     assert.equal(canAccessPath(grantAccess, 'write', 'docs', 'releases/v1.md'), false);
   } finally {
     await fs.rm(root, { recursive: true, force: true });

--- a/test/publish-store.test.js
+++ b/test/publish-store.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+
+const { PublishStore } = require('../lib/publish-store');
+
+async function fixture(options = {}) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-publish-store-'));
+  return {
+    root,
+    store: new PublishStore({ areaPath: path.join(root, 'published'), ...options }),
+  };
+}
+
+async function removeFixture(root) {
+  await fs.rm(root, { recursive: true, force: true });
+}
+
+test('publish revisions are immutable snapshots and stale updates cannot mutate history', async () => {
+  const { root, store } = await fixture();
+  try {
+    await store.createPublication({
+      slug: 'release-notes',
+      files: [{ path: 'index.md', content: '# One\n' }, { path: 'asset.txt', content: 'first' }],
+      entryPath: 'index.md',
+    });
+    await store.updatePublication('release-notes', {
+      expectedRevision: 1,
+      files: [{ path: 'index.md', content: '# Two\n' }, { path: 'asset.txt', content: 'second' }],
+      entryPath: 'index.md',
+    });
+
+    assert.equal(await fs.readFile((await store.resolvePath('release-notes', 'asset.txt', 1)).resolved, 'utf8'), 'first');
+    assert.equal(await fs.readFile((await store.resolvePath('release-notes', 'asset.txt')).resolved, 'utf8'), 'second');
+    await assert.rejects(
+      store.updatePublication('release-notes', {
+        expectedRevision: 1,
+        files: [{ path: 'index.md', content: '# Stale\n' }],
+      }),
+      (error) => error.code === 'ECONFLICT' && error.current.currentRevision === 2
+    );
+    assert.equal(await fs.readFile((await store.resolvePath('release-notes', 'index.md', 1)).resolved, 'utf8'), '# One\n');
+  } finally {
+    await removeFixture(root);
+  }
+});
+
+test('a failed multi-file create is never visible as a half-written revision', async () => {
+  const { root, store } = await fixture();
+  try {
+    const originalWrite = store.writeRevisionFiles.bind(store);
+    store.writeRevisionFiles = async (target, files) => {
+      await originalWrite(target, files.slice(0, 1));
+      throw new Error('injected second-file failure');
+    };
+    await assert.rejects(store.createPublication({
+      slug: 'atomic-create',
+      files: [{ path: 'one.txt', content: 'one' }, { path: 'two.txt', content: 'two' }],
+    }), /injected second-file failure/);
+    assert.equal(await store.readPublication('atomic-create'), null);
+    const entries = await fs.readdir(store.getRuntimeRoot());
+    assert.deepEqual(entries, []);
+  } finally {
+    await removeFixture(root);
+  }
+});
+
+test('a metadata failure rolls back a staged update and leaves the prior revision current', async () => {
+  const { root, store } = await fixture();
+  try {
+    await store.createPublication({ slug: 'atomic-update', files: [{ path: 'index.md', content: 'one' }] });
+    const originalWriteJson = store.writeJsonFile.bind(store);
+    store.writeJsonFile = async (target, value) => {
+      if (target === store.publicationMetadataPath('atomic-update') && value.currentRevision === 2) {
+        throw new Error('injected metadata failure');
+      }
+      return originalWriteJson(target, value);
+    };
+    await assert.rejects(store.updatePublication('atomic-update', {
+      expectedRevision: 1,
+      files: [{ path: 'index.md', content: 'two' }],
+    }), /injected metadata failure/);
+    assert.equal((await store.readPublication('atomic-update')).currentRevision, 1);
+    await assert.rejects(fs.access(store.revisionDir('atomic-update', 2)), { code: 'ENOENT' });
+    assert.equal(await fs.readFile((await store.resolvePath('atomic-update', 'index.md')).resolved, 'utf8'), 'one');
+  } finally {
+    await removeFixture(root);
+  }
+});
+
+test('an unreferenced revision left by interruption is recovered before retry', async () => {
+  const { root, store } = await fixture();
+  try {
+    await store.createPublication({ slug: 'recover-update', files: [{ path: 'index.md', content: 'one' }] });
+    const orphan = store.revisionDir('recover-update', 2);
+    await fs.mkdir(orphan, { recursive: true });
+    await fs.writeFile(path.join(orphan, 'half.txt'), 'half');
+
+    const result = await store.updatePublication('recover-update', {
+      expectedRevision: 1,
+      files: [{ path: 'index.md', content: 'complete' }],
+    });
+    assert.equal(result.publication.currentRevision, 2);
+    assert.equal(await fs.readFile(path.join(orphan, 'index.md'), 'utf8'), 'complete');
+    await assert.rejects(fs.access(path.join(orphan, 'half.txt')), { code: 'ENOENT' });
+  } finally {
+    await removeFixture(root);
+  }
+});
+
+test('publish rejects slug traversal, file traversal, and symlink ancestors', async () => {
+  const { root, store } = await fixture();
+  try {
+    await assert.rejects(store.createPublication({ slug: '../escape', files: [{ path: 'x.txt', content: 'x' }] }), /slug is invalid/);
+    for (const badPath of ['../escape.txt', 'dir/../../escape.txt', '/absolute.txt', 'dir\\escape.txt']) {
+      await assert.rejects(store.createPublication({ slug: 'safe-slug', files: [{ path: badPath, content: 'x' }] }), /path is invalid/);
+    }
+    await fs.mkdir(store.getRuntimeRoot(), { recursive: true });
+    const outside = path.join(root, 'outside');
+    await fs.mkdir(outside);
+    await fs.symlink(outside, store.publicationDir('linked-slug'));
+    await assert.rejects(
+      store.createPublication({ slug: 'linked-slug', files: [{ path: 'x.txt', content: 'x' }] }),
+      (error) => error.code === 'EACCES'
+    );
+    assert.deepEqual(await fs.readdir(outside), []);
+  } finally {
+    await removeFixture(root);
+  }
+});
+
+test('publish enforces file, byte, metadata, and revision limits without exposing private metadata', async () => {
+  const { root, store } = await fixture({
+    maxFiles: 1,
+    maxFileBytes: 4,
+    maxRevisionBytes: 4,
+    maxMetadataBytes: 24,
+    maxRevisions: 1,
+  });
+  try {
+    await assert.rejects(store.createPublication({
+      slug: 'too-many',
+      files: [{ path: 'a', content: 'a' }, { path: 'b', content: 'b' }],
+    }), (error) => error.code === 'ELIMIT');
+    await assert.rejects(store.createPublication({ slug: 'too-large', files: [{ path: 'a', content: '12345' }] }), (error) => error.code === 'ELIMIT');
+    await assert.rejects(store.createPublication({
+      slug: 'metadata-large', files: [{ path: 'a', content: 'a' }], metadata: { value: 'x'.repeat(30) },
+    }), (error) => error.code === 'ELIMIT');
+    await assert.rejects(store.createPublication({
+      slug: 'public-source-path', files: [{ path: 'a', content: 'a' }], metadata: { sourceRoot: '/x' },
+    }), /use privateMetadata/);
+
+    const created = await store.createPublication({
+      slug: 'private-source',
+      files: [{ path: 'a', content: 'a' }],
+      metadata: { label: 'public' },
+      privateMetadata: { path: '/srv/private' },
+    });
+    assert.deepEqual(created.publication.metadata, { label: 'public' });
+    assert.equal(Object.prototype.hasOwnProperty.call(created.publication, 'privateMetadata'), false);
+    assert.doesNotMatch(JSON.stringify(created.publication), /\/srv\/private/);
+    await assert.rejects(store.updatePublication('private-source', {
+      expectedRevision: 1,
+      files: [{ path: 'a', content: 'b' }],
+    }), (error) => error.code === 'ELIMIT');
+  } finally {
+    await removeFixture(root);
+  }
+});

--- a/test/publish-store.test.js
+++ b/test/publish-store.test.js
@@ -92,6 +92,29 @@ test('a metadata failure rolls back a staged update and leaves the prior revisio
   }
 });
 
+test('a mid-update failure removes partial revision staging', async () => {
+  const { root, store } = await fixture();
+  try {
+    await store.createPublication({ slug: 'clean-staging', files: [{ path: 'index.md', content: 'one' }] });
+    const originalWrite = store.writeRevisionFiles.bind(store);
+    store.writeRevisionFiles = async (target, files) => {
+      await originalWrite(target, files.slice(0, 1));
+      throw new Error('injected staged update failure');
+    };
+
+    await assert.rejects(store.updatePublication('clean-staging', {
+      expectedRevision: 1,
+      files: [{ path: 'index.md', content: 'two' }, { path: 'asset.txt', content: 'partial' }],
+    }), /injected staged update failure/);
+
+    const revisionsPath = path.join(store.publicationDir('clean-staging'), 'revisions');
+    assert.deepEqual(await fs.readdir(revisionsPath), ['1']);
+    assert.equal((await store.readPublication('clean-staging')).currentRevision, 1);
+  } finally {
+    await removeFixture(root);
+  }
+});
+
 test('an unreferenced revision left by interruption is recovered before retry', async () => {
   const { root, store } = await fixture();
   try {

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -50,7 +50,7 @@ async function startTestServer(fixture) {
   };
 }
 
-async function createKey(server, permissions) {
+async function createKey(server, permissions, repos = { published: true }) {
   const response = await server.request('/api/agent-keys', {
     method: 'POST',
     headers: { Authorization: `Bearer ${ADMIN_TOKEN}`, 'Content-Type': 'application/json' },
@@ -58,7 +58,7 @@ async function createKey(server, permissions) {
       label: 'Publisher',
       subject: { companyId: 'example', agentId: `agent-${Date.now()}`, label: 'Publish test' },
       permissions,
-      repos: { published: true },
+      repos,
       issuer: { actorType: 'operator', actorId: 'test' },
     }),
   });
@@ -189,6 +189,65 @@ test('publish mutations require publish capability and matching expectedRevision
     assert.equal(payload.currentRevision, 2);
   } finally {
     await server.close();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('publish requires whole-repo scope for create, update, and revoke', async () => {
+  const fixture = await makeFixture();
+  const server = await startTestServer(fixture);
+  try {
+    const repoPublisher = await createKey(server, { view: true, publish: true });
+    const create = await server.request('/api/publish', publishRequest(repoPublisher.token, {
+      slug: 'repo-level', files: [{ path: 'index.md', content: 'one' }],
+    }));
+    assert.equal(create.status, 201);
+
+    const pathPublisher = await createKey(
+      server,
+      { view: true, publish: true },
+      { published: { paths: ['repo-level/'] } }
+    );
+    const deniedRequests = [
+      server.request('/api/publish', publishRequest(pathPublisher.token, {
+        files: [{ path: 'index.md', content: 'must not mint an out-of-scope slug' }],
+      })),
+      server.request('/api/publish/repo-level', publishRequest(pathPublisher.token, {
+        expectedRevision: 1, files: [{ path: 'index.md', content: 'must not update' }],
+      })),
+      server.request('/api/publish/repo-level/revoke', publishRequest(pathPublisher.token, {
+        reason: 'must not revoke',
+      })),
+    ];
+
+    for (const response of await Promise.all(deniedRequests)) {
+      assert.equal(response.status, 403);
+      assert.deepEqual(await response.json(), { ok: false, error: 'Access denied.' });
+    }
+
+    const entries = await fs.readdir(fixture.publishArea);
+    assert.deepEqual(entries, ['repo-level']);
+    const publication = JSON.parse(await fs.readFile(
+      path.join(fixture.publishArea, 'repo-level', 'publication.json'),
+      'utf8'
+    ));
+    assert.equal(publication.currentRevision, 1);
+    assert.equal(publication.revokedAt, null);
+  } finally {
+    await server.close();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('publish repo id cannot shadow a configured repository mapping', async () => {
+  const fixture = await makeFixture();
+  try {
+    assert.throws(() => createApp({
+      mappings: { published: fixture.sourceRepo },
+      accessConfig: { humanDefault: 'restricted' },
+      publishConfig: { areaPath: fixture.publishArea, repoId: 'published' },
+    }), /publish\.repoId "published" conflicts with a configured repository mapping/);
+  } finally {
     await fs.rm(fixture.root, { recursive: true, force: true });
   }
 });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+
+const { createApp } = require('../server');
+
+const ADMIN_TOKEN = 'publish-test-admin-token';
+
+async function makeFixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-publish-routes-'));
+  const sourceRepo = path.join(root, 'private-source');
+  await fs.mkdir(sourceRepo);
+  await fs.writeFile(path.join(sourceRepo, 'secret.md'), '# not published\n');
+  return {
+    root,
+    sourceRepo,
+    publishArea: path.join(root, 'publish-area'),
+    apiKeyStorePath: path.join(root, 'agent-api-keys.yaml'),
+  };
+}
+
+async function startTestServer(fixture) {
+  const app = createApp({
+    mappings: { secret: fixture.sourceRepo },
+    rawHtmlEnabled: true,
+    accessConfig: {
+      humanDefault: 'restricted',
+      apiKeys: {
+        storePath: fixture.apiKeyStorePath,
+        adminTokens: { operator: { secret: ADMIN_TOKEN } },
+      },
+    },
+    publishConfig: { areaPath: fixture.publishArea },
+  });
+  const server = await new Promise((resolve) => {
+    const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+  });
+  const address = server.address();
+  return {
+    async request(targetPath, init) {
+      return fetch(`http://127.0.0.1:${address.port}${targetPath}`, init);
+    },
+    async close() {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    },
+  };
+}
+
+async function createKey(server, permissions) {
+  const response = await server.request('/api/agent-keys', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${ADMIN_TOKEN}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      label: 'Publisher',
+      subject: { companyId: 'example', agentId: `agent-${Date.now()}`, label: 'Publish test' },
+      permissions,
+      repos: { published: true },
+      issuer: { actorType: 'operator', actorId: 'test' },
+    }),
+  });
+  assert.equal(response.status, 201);
+  return response.json();
+}
+
+function publishRequest(token, body) {
+  return {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+test('publish routes create immutable history, reuse view/asset/raw readback, revoke, and audit', async () => {
+  const fixture = await makeFixture();
+  const server = await startTestServer(fixture);
+  try {
+    const { token } = await createKey(server, { view: true, publish: true });
+    const createdResponse = await server.request('/api/publish', publishRequest(token, {
+      slug: 'route-history',
+      files: [
+        { path: 'index.md', content: '# First revision\n\n![Asset](asset.txt)\n' },
+        { path: 'asset.txt', content: 'first asset' },
+        { path: 'page.html', content: '<!doctype html><title>Raw one</title>' },
+      ],
+      entryPath: 'index.md',
+    }));
+    assert.equal(createdResponse.status, 201);
+    const created = await createdResponse.json();
+    assert.equal(created.viewUrl, '/view/published/route-history/index.md');
+
+    const updateResponse = await server.request('/api/publish/route-history', publishRequest(token, {
+      expectedRevision: 1,
+      files: [
+        { path: 'index.md', content: '# Second revision\n' },
+        { path: 'asset.txt', content: 'second asset' },
+        { path: 'page.html', content: '<!doctype html><title>Raw two</title>' },
+      ],
+      entryPath: 'index.md',
+    }));
+    assert.equal(updateResponse.status, 200);
+
+    const latest = await server.request('/view/published/route-history/index.md', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(latest.status, 200);
+    assert.match(await latest.text(), /Second revision/);
+
+    const historical = await server.request('/view/published/route-history/index.md?version=1', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(historical.status, 200);
+    assert.match(await historical.text(), /First revision/);
+
+    const asset = await server.request('/asset/published/route-history/asset.txt?version=1', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(asset.status, 200);
+    assert.equal(await asset.text(), 'first asset');
+
+    const raw = await server.request('/raw/published/route-history/page.html?version=1', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(raw.status, 200);
+    assert.match(await raw.text(), /Raw one/);
+
+    const revoke = await server.request('/api/publish/route-history/revoke', publishRequest(token, {
+      reason: 'superseded',
+    }));
+    assert.equal(revoke.status, 200);
+    for (const url of [
+      '/view/published/route-history/index.md',
+      '/asset/published/route-history/asset.txt?version=1',
+      '/raw/published/route-history/page.html?version=1',
+    ]) {
+      const response = await server.request(url, { headers: { Authorization: `Bearer ${token}` } });
+      assert.equal(response.status, 410);
+    }
+
+    const audit = await server.request('/api/agent-keys?includeAudit=1', {
+      headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    });
+    assert.equal(audit.status, 200);
+    const auditPayload = await audit.json();
+    const eventTypes = auditPayload.auditEvents.map((event) => event.type);
+    assert.ok(eventTypes.includes('publish.create'));
+    assert.ok(eventTypes.includes('publish.update'));
+    assert.ok(eventTypes.includes('publish.revoke'));
+  } finally {
+    await server.close();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('publish mutations require publish capability and matching expectedRevision', async () => {
+  const fixture = await makeFixture();
+  const server = await startTestServer(fixture);
+  try {
+    const viewKey = await createKey(server, { view: true, write: true, publish: false });
+    const denied = await server.request('/api/publish', publishRequest(viewKey.token, {
+      slug: 'denied', files: [{ path: 'index.md', content: 'denied' }],
+    }));
+    assert.equal(denied.status, 403);
+
+    const missing = await server.request('/api/publish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'missing', files: [{ path: 'index.md', content: 'missing' }] }),
+    });
+    assert.equal(missing.status, 401);
+
+    const publishKey = await createKey(server, { view: true, publish: true });
+    const create = await server.request('/api/publish', publishRequest(publishKey.token, {
+      slug: 'stale-guard', files: [{ path: 'index.md', content: 'one' }],
+    }));
+    assert.equal(create.status, 201);
+    const update = await server.request('/api/publish/stale-guard', publishRequest(publishKey.token, {
+      expectedRevision: 1, files: [{ path: 'index.md', content: 'two' }],
+    }));
+    assert.equal(update.status, 200);
+    const conflict = await server.request('/api/publish/stale-guard', publishRequest(publishKey.token, {
+      expectedRevision: 1, files: [{ path: 'index.md', content: 'stale' }],
+    }));
+    assert.equal(conflict.status, 409);
+    const payload = await conflict.json();
+    assert.equal(payload.currentRevision, 2);
+  } finally {
+    await server.close();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('private publish metadata is not exposed and never grants source-repo access', async () => {
+  const fixture = await makeFixture();
+  const server = await startTestServer(fixture);
+  try {
+    const { token } = await createKey(server, { view: true, publish: true });
+    const response = await server.request('/api/publish', publishRequest(token, {
+      slug: 'isolated',
+      files: [{ path: 'index.md', content: '# Public artifact\n' }],
+      metadata: { sourceRepo: 'secret', label: 'safe public label' },
+      privateMetadata: { sourceRepo: 'secret', sourceRoot: fixture.sourceRepo },
+    }));
+    assert.equal(response.status, 201);
+    const payloadText = await response.text();
+    assert.doesNotMatch(payloadText, new RegExp(fixture.sourceRepo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.doesNotMatch(payloadText, /privateMetadata/);
+
+    const source = await server.request('/view/secret/secret.md', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(source.status, 403);
+
+    const internalMetadata = await server.request('/asset/published/isolated/publication.json', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(internalMetadata.status, 404);
+  } finally {
+    await server.close();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Part of #91 (reconciliation Step 9). Adds the publish endpoint consuming the `publish` capability that landed with #150.

1. **Immutable revisioned store**: numbered complete-snapshot revisions, mandatory `expectedRevision` on update (stale → conflict), revocation, historical resolution, per-slug in-process serialization. Configurable max file count / per-file bytes / total bytes / metadata bytes / revision count; `maxRevisions` rejects further updates and never prunes history.
2. **Capability-gated routes** (publish/update/revoke) + historical readback via a virtual `published` repo namespace reusing `/view`/`/asset`/`/raw` (`?version=<n>`); revocation → 410.
3. **Docs** (PUBLISHING.md + API/config, sanitized).

**Security/correctness**: atomic multi-file staging+rename with partial-failure recovery (failed create removes staging; failed metadata advance removes the unreferenced next revision; retry recovers an interrupted next-revision dir); symlink-component rejection on publish area / slug / revision / resolved-artifact paths; slug/path traversal rejected; absolute paths rejected in public metadata; `privateMetadata` and `publication.json` never exposed through the virtual repo and never participate in authorization. Repo resolution refactored into a shared `resolvePublishedTarget` helper (the `rootPath` local-var churn is that refactor, no API payload field removed).

Merged with current main (incl. the /embed work); clean auto-merge. Verification: 69/69 tests + `validate:raw-html`; added-line scan clean of private values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)