### PR TITLE
fix(validate): embed anti-regression canary returns null on valid output

### DIFF
--- a/scripts/validate-raw-html.js
+++ b/scripts/validate-raw-html.js
@@ -132,7 +132,7 @@ async function run() {
       for (const selector of CURRENT_ANNOTATION_SELECTORS) {
         assert.ok(embedDocument.querySelector(selector), `/embed must emit current annotation selector ${selector}`);
       }
-      const oldAnchorLinkOnly = embedDocument.querySelector('a.anchor-link[data-anchor-id]')
+      const oldAnchorLinkOnly = Boolean(embedDocument.querySelector('a.anchor-link[data-anchor-id]'))
         && !embedDocument.querySelector('[data-annotations-mount][data-anchor-id]')
         && !embedDocument.querySelector('[data-annotate-trigger][data-anchor-id]');
       assert.equal(oldAnchorLinkOnly, false, '/embed must not regress to obsolete anchor-link-only annotation markup');


### PR DESCRIPTION
The `/embed` anti-regression canary added in #152 (`scripts/validate-raw-html.js`) is buggy: `querySelector('a.anchor-link[data-anchor-id]') && !mount && !trigger` evaluates to `null` in the correct current state (no obsolete anchor-link element), so `assert.equal(oldAnchorLinkOnly, false)` throws `null !== false` on perfectly valid marker-based output. The validator has been red on main since #152 (it's a standalone script, not part of `node --test`, so the test suite stayed green).

Fix: wrap the first term in `Boolean()`. The canary now passes correct markup and fails only a real regression (anchor-link present AND mounts absent). Verified: `validate:raw-html` exit 0, `validate:editable` exit 0, `node --test` 60/60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)