### PR TITLE
feat: port managed repositories (registry/CRUD + allow-root protection) and scoped search

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,15 @@
 | `GET /api/annotations/<repo>/<path>` | Read sidecar annotations for a file. Supports repeatable `?state=open|claimed|resolved`. Returns an empty schema document when no sidecar exists. |
 | `POST /api/annotations/<repo>/<path>` | Create an annotation. Requires `write` access and `enableAnnotations: true`. |
 | `PATCH /api/annotations/<repo>/<path>` | Apply `claim`, `resolve`, `reopen`, `reply`, or `redact` with stale-write protection. Requires `write` access and `enableAnnotations: true`. |
+| `GET /api/managed-repos` | List managed repositories visible to the caller |
+| `POST /api/managed-repos` | Register a root beneath an operator-configured allow-root |
+| `GET /api/managed-repos/:repo/tree` | Return a bounded, caller-filtered file tree |
+| `GET /api/managed-repos/:repo/changes` | Return bounded, mtime-based changes visible to the caller |
+| `GET /api/managed-repos/:repo/files/<path>` | Read a managed file |
+| `PUT /api/managed-repos/:repo/files/<path>` | Atomically create or update a managed file; accepts `expectedMtimeMs` |
+| `DELETE /api/managed-repos/:repo/files/<path>` | Soft-delete a file by default, or hard-delete with `?hard=1` |
+| `POST /api/managed-repos/:repo/trash/:trashId/restore` | Restore a soft-deleted file |
+| `DELETE /api/managed-repos/:repo/trash/:trashId` | Permanently remove a soft-deleted file |
 | `GET /api/grants` | List managed grants (`Authorization: Bearer <admin-token>`) |
 | `POST /api/grants` | Create a managed grant and return token + issue comment helper |
 | `POST /api/grants/:grantId/renew` | Renew a managed grant and return issue comment helper |
@@ -38,6 +47,17 @@ Route enforcement in phase 1:
 - annotation reads require `view`; annotation creates and updates require `write`; all annotation routes return `404` when annotations are disabled
 
 Invalid tokens return `403`. Missing tokens return `401` when unauthenticated human access is restricted.
+
+Managed file routes deliberately return the same `404 {"ok":false,"error":"Not found."}`
+for missing and out-of-scope repositories or paths. Registry responses do not
+include host filesystem roots. Managed mutations require `write`; operator
+registration requires a separate admin token in the `Authorization` header.
+
+Writes use a same-directory temporary file and rename. Passing `expectedMtimeMs`
+returns `409` if the file changed; passing `null` asserts that it does not exist.
+Tree and change responses accept `maxEntries` (capped at 5,000), and tree depth
+is capped at 10. Soft delete returns a `trashId` that can be restored or later
+hard-deleted.
 
 ## HTML Bundle Validation
 
@@ -75,6 +95,8 @@ Lets agents discover served repos at runtime without parsing the HTML index or r
 ```
 
 The list is filtered to the repos the caller can `view`: with a scoped token the response only contains repos that token can reach; unauthenticated callers see all mappings when `access.humanDefault` allows it and otherwise receive `401`. `viewUrl` and `assetUrl` are repo-rooted paths — append your own `?token=...` if you authenticate via query string.
+`rootPath` remains present for legacy static mappings but is omitted for managed
+repositories so registry additions do not disclose host filesystem paths.
 
 ## Save Endpoint
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,6 +22,8 @@
 | `DELETE /api/managed-repos/:repo/files/<path>` | Soft-delete a file by default, or hard-delete with `?hard=1` |
 | `POST /api/managed-repos/:repo/trash/:trashId/restore` | Restore a soft-deleted file |
 | `DELETE /api/managed-repos/:repo/trash/:trashId` | Permanently remove a soft-deleted file |
+| `GET /api/search?q=<text>` | Search path and text content across caller-visible managed files |
+| `GET /api/search/suggest?q=<text>` | Suggest caller-visible managed paths |
 | `GET /api/grants` | List managed grants (`Authorization: Bearer <admin-token>`) |
 | `POST /api/grants` | Create a managed grant and return token + issue comment helper |
 | `POST /api/grants/:grantId/renew` | Renew a managed grant and return issue comment helper |
@@ -58,6 +60,13 @@ returns `409` if the file changed; passing `null` asserts that it does not exist
 Tree and change responses accept `maxEntries` (capped at 5,000), and tree depth
 is capped at 10. Soft delete returns a `trashId` that can be restored or later
 hard-deleted.
+
+Search and suggest accept repeatable or comma-separated `scope=<repo>`, plus
+bounded `limit` and `maxEntries` parameters. Result limits are capped at 100,
+traversal at 5,000 entries, each searched file at 1 MiB, and aggregate content
+reads at 10 MiB. Responses report `truncated` and their effective limits.
+Traversal prunes directories outside the caller's path scopes before reading
+file contents; inaccessible repo names and paths never appear in results.
 
 ## HTML Bundle Validation
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,6 +19,24 @@ Each key under `repositories` becomes a URL prefix: `/view/docs/...`, `/view/not
 
 A sample config is included: `lookie-link.yaml.example`.
 
+## Managed Repositories
+
+```yaml
+managedRepos:
+  storePath: ~/.local/share/lookie-link/managed-repos.yaml
+  allowRoots:
+    - ~/shared-workspaces
+  adminTokens:
+    local_operator:
+      secretEnv: LOOKIE_LINK_MANAGED_REPO_ADMIN_TOKEN
+```
+
+`storePath` enables the registry and mutable-content routes. Each `allowRoots`
+entry must be an existing directory. Registration resolves real paths and only
+creates a repository below a real, in-scope ancestor, so a symlink ancestor
+cannot redirect creation outside the allow-root. Keep admin secrets in the
+environment; normal file mutations use caller `write` capability.
+
 ## Access Tokens
 
 Phase 1 agent access control is config-driven under `access.tokens`. Secrets should come from environment variables when possible.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -143,6 +143,19 @@ When `server.enableAnnotations: true`, the document viewer adds an inline annota
 
 See `docs/ANNOTATIONS-SPEC.md` for the full sidecar schema, phase split, and the agent-feedback loop the API enables. The HTTP transport and viewer UX are both available.
 
+## Managed Repositories
+
+Operators can register mutable repository roots beneath existing configured
+allow-roots. Managed callers can read and atomically write files, inspect a
+bounded tree or mtime-based change list, and use optimistic `expectedMtimeMs`
+conflict detection. File mutations require `write` capability.
+
+Deletes are recoverable by default: the response returns a `trashId` that can
+be restored or permanently deleted. Realpath checks cover both existing paths
+and the nearest existing ancestor of a new path, preventing symlink-ancestor
+escapes. Missing and unauthorized managed paths have the same not-found
+response, and registry responses omit host filesystem roots.
+
 ## Themes
 
 10 built-in color themes, each with dark and light variants:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -156,6 +156,12 @@ and the nearest existing ancestor of a new path, preventing symlink-ancestor
 escapes. Missing and unauthorized managed paths have the same not-found
 response, and registry responses omit host filesystem roots.
 
+`GET /api/search` performs bounded path and full-text matching over supported
+text formats; `GET /api/search/suggest` performs bounded path suggestions.
+Both prune traversal using the caller's repository and path scopes, silently
+exclude requested scopes the caller cannot see, cap work and result counts, and
+report when a response was truncated.
+
 ## Themes
 
 10 built-in color themes, each with dark and light variants:

--- a/lib/config.js
+++ b/lib/config.js
@@ -202,6 +202,23 @@ function getAccessConfig() {
   return {};
 }
 
+function getManagedReposConfig() {
+  const config = getConfig();
+  if (!config.managedRepos || typeof config.managedRepos !== 'object') {
+    return {};
+  }
+
+  return {
+    ...config.managedRepos,
+    storePath: config.managedRepos.storePath
+      ? path.resolve(expandHome(String(config.managedRepos.storePath)))
+      : undefined,
+    allowRoots: Array.isArray(config.managedRepos.allowRoots)
+      ? config.managedRepos.allowRoots.map((entry) => path.resolve(expandHome(String(entry))))
+      : [],
+  };
+}
+
 function parseBoolean(value) {
   if (typeof value === 'boolean') {
     return value;
@@ -389,6 +406,7 @@ module.exports = {
   getAnnotationsEnabled,
   getRawHtmlEnabled,
   getAccessConfig,
+  getManagedReposConfig,
   loadCustomThemes,
   generateCustomThemeCss,
   BUILT_IN_THEMES,

--- a/lib/managed-repo-search.js
+++ b/lib/managed-repo-search.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const path = require('node:path');
+const { buildHref, buildAssetHref } = require('./path-utils');
+
+const SEARCHABLE_EXTENSIONS = new Set(['.md', '.markdown', '.txt', '.yaml', '.yml', '.json', '.csv', '.html', '.htm']);
+const DEFAULT_RESULT_LIMIT = 50;
+const MAX_RESULT_LIMIT = 100;
+const DEFAULT_MAX_ENTRIES = 2000;
+const MAX_SEARCH_ENTRIES = 5000;
+const MAX_FILE_BYTES = 1024 * 1024;
+const MAX_TOTAL_BYTES = 10 * 1024 * 1024;
+
+function boundedInteger(value, fallback, maximum) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(1, Math.min(maximum, Math.trunc(number)));
+}
+
+function normalizeScopeFilter(scope) {
+  const values = Array.isArray(scope) ? scope : scope == null ? [] : [scope];
+  return new Set(values.flatMap((value) => String(value || '').split(','))
+    .map((value) => value.trim())
+    .filter(Boolean));
+}
+
+function snippet(content, query) {
+  const source = String(content || '');
+  const index = source.toLowerCase().indexOf(query.toLowerCase());
+  if (index < 0) return source.slice(0, 160).replace(/\s+/g, ' ').trim();
+  return source.slice(Math.max(0, index - 60), Math.min(source.length, index + query.length + 100))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function candidateRepos(repos, scopeFilter, canView) {
+  return repos
+    .filter((repo) => scopeFilter.size === 0 || scopeFilter.has(repo.id))
+    .filter((repo) => canView(repo.id, '', 'directory'))
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+async function searchManagedRepos(options) {
+  const query = String(options.query || '').trim();
+  if (!query) throw new Error('q is required.');
+  const lowerQuery = query.toLowerCase();
+  const limit = boundedInteger(options.limit, DEFAULT_RESULT_LIMIT, MAX_RESULT_LIMIT);
+  const maxEntries = boundedInteger(options.maxEntries, DEFAULT_MAX_ENTRIES, MAX_SEARCH_ENTRIES);
+  const scopeFilter = normalizeScopeFilter(options.scope);
+  const repos = candidateRepos(options.repos, scopeFilter, options.canView);
+  const results = [];
+  let remainingEntries = maxEntries;
+  let bytesRead = 0;
+  let truncated = false;
+
+  outer: for (const repo of repos) {
+    if (remainingEntries <= 0) { truncated = true; break; }
+    const tree = await options.store.listTree(repo, '', {
+      maxDepth: 10,
+      maxEntries: remainingEntries,
+      includeEntry: (entry) => entry.type === 'file' && options.canView(repo.id, entry.path, 'file'),
+      shouldDescend: (entry) => options.canView(repo.id, entry.path, 'directory'),
+    });
+    remainingEntries -= tree.visited;
+    truncated = truncated || tree.truncated;
+
+    for (const entry of tree.entries) {
+      if (!SEARCHABLE_EXTENSIONS.has(path.extname(entry.path).toLowerCase())) continue;
+      const pathMatches = entry.path.toLowerCase().includes(lowerQuery);
+      let content = '';
+      let bodyMatches = false;
+      if (entry.size <= MAX_FILE_BYTES && bytesRead + entry.size <= MAX_TOTAL_BYTES) {
+        try {
+          const file = await options.store.readFile(repo, entry.path);
+          content = file.content;
+          bytesRead += Buffer.byteLength(content, 'utf8');
+          bodyMatches = content.toLowerCase().includes(lowerQuery);
+        } catch (error) {
+          if (!error || !['ENOENT', 'EACCES'].includes(error.code)) throw error;
+          continue;
+        }
+      } else {
+        truncated = true;
+      }
+      if (!pathMatches && !bodyMatches) continue;
+      results.push({
+        repo: repo.id,
+        path: entry.path,
+        score: pathMatches && bodyMatches ? 2 : 1,
+        snippet: snippet(content, query),
+        lastModified: entry.mtimeMs,
+        viewUrl: buildHref(repo.id, entry.path),
+        rawUrl: buildAssetHref(repo.id, entry.path),
+      });
+      if (results.length >= limit) { truncated = true; break outer; }
+    }
+  }
+
+  results.sort((left, right) => right.score - left.score || right.lastModified - left.lastModified || left.repo.localeCompare(right.repo) || left.path.localeCompare(right.path));
+  return { results, count: results.length, truncated, limits: { results: limit, entries: maxEntries, fileBytes: MAX_FILE_BYTES, totalBytes: MAX_TOTAL_BYTES } };
+}
+
+async function suggestManagedRepos(options) {
+  const query = String(options.query || '').trim().toLowerCase();
+  if (!query) throw new Error('q is required.');
+  const limit = boundedInteger(options.limit, 25, MAX_RESULT_LIMIT);
+  const maxEntries = boundedInteger(options.maxEntries, DEFAULT_MAX_ENTRIES, MAX_SEARCH_ENTRIES);
+  const scopeFilter = normalizeScopeFilter(options.scope);
+  const repos = candidateRepos(options.repos, scopeFilter, options.canView);
+  const suggestions = [];
+  let remainingEntries = maxEntries;
+  let truncated = false;
+
+  outer: for (const repo of repos) {
+    if (remainingEntries <= 0) { truncated = true; break; }
+    const tree = await options.store.listTree(repo, '', {
+      maxDepth: 10,
+      maxEntries: remainingEntries,
+      includeEntry: (entry) => options.canView(repo.id, entry.path, entry.type === 'directory' ? 'directory' : 'file'),
+      shouldDescend: (entry) => options.canView(repo.id, entry.path, 'directory'),
+    });
+    remainingEntries -= tree.visited;
+    truncated = truncated || tree.truncated;
+    for (const entry of tree.entries) {
+      if (!entry.path.toLowerCase().includes(query)) continue;
+      suggestions.push({ repo: repo.id, path: entry.path, type: entry.type });
+      if (suggestions.length >= limit) { truncated = true; break outer; }
+    }
+  }
+  suggestions.sort((left, right) => left.repo.localeCompare(right.repo) || left.path.localeCompare(right.path));
+  return { suggestions, count: suggestions.length, truncated, limits: { results: limit, entries: maxEntries } };
+}
+
+module.exports = {
+  searchManagedRepos,
+  suggestManagedRepos,
+  MAX_RESULT_LIMIT,
+  MAX_SEARCH_ENTRIES,
+  MAX_FILE_BYTES,
+  MAX_TOTAL_BYTES,
+};

--- a/lib/managed-repo-store.js
+++ b/lib/managed-repo-store.js
@@ -1,0 +1,439 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_TRASH_DIR = '.lookie-link-trash';
+const STORE_VERSION = 1;
+const MAX_TREE_DEPTH = 10;
+const MAX_TREE_ENTRIES = 5000;
+const MAX_MANAGED_REPOS = 1000;
+
+function codedError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function isWithin(rootPath, candidatePath) {
+  return candidatePath === rootPath || candidatePath.startsWith(`${rootPath}${path.sep}`);
+}
+
+function normalizeRepoId(value) {
+  const repoId = String(value || '').trim().toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(repoId)) {
+    throw codedError('EINVAL', 'repoId must contain only lowercase letters, numbers, dots, underscores, and hyphens.');
+  }
+  return repoId;
+}
+
+function normalizeRelativePath(value, { allowEmpty = false } = {}) {
+  const raw = String(value || '').replace(/\\/g, '/');
+  if (raw.includes('\0') || raw.startsWith('/') || /^[a-z]:\//i.test(raw)) {
+    throw codedError('EINVAL', 'Invalid path.');
+  }
+  const parts = raw.split('/').filter((part) => part && part !== '.');
+  if (parts.some((part) => part === '..')) {
+    throw codedError('EINVAL', 'Invalid path.');
+  }
+  const normalized = parts.join('/');
+  if (!normalized && !allowEmpty) {
+    throw codedError('EINVAL', 'A file path is required.');
+  }
+  return normalized;
+}
+
+function serializeStore(storePath, store) {
+  if (/\.ya?ml$/i.test(storePath)) {
+    return yaml.dump(store, { noRefs: true, sortKeys: true });
+  }
+  return `${JSON.stringify(store, null, 2)}\n`;
+}
+
+function atomicWriteFileSync(targetPath, content, mode = 0o600) {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true, mode: 0o700 });
+  const tempPath = path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  let fd;
+  try {
+    fd = fs.openSync(tempPath, 'wx', mode);
+    fs.writeFileSync(fd, content, 'utf8');
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(tempPath, targetPath);
+  } catch (error) {
+    if (fd !== undefined && fd !== null) {
+      try { fs.closeSync(fd); } catch (_closeError) { /* best effort */ }
+    }
+    try { fs.unlinkSync(tempPath); } catch (_unlinkError) { /* best effort */ }
+    throw error;
+  }
+}
+
+function readStore(storePath) {
+  try {
+    const raw = fs.readFileSync(storePath, 'utf8');
+    const parsed = /\.ya?ml$/i.test(storePath) ? yaml.load(raw) : JSON.parse(raw);
+    return {
+      version: Number.isInteger(parsed && parsed.version) ? parsed.version : STORE_VERSION,
+      repos: Array.isArray(parsed && parsed.repos) ? parsed.repos : [],
+    };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return { version: STORE_VERSION, repos: [] };
+    }
+    throw error;
+  }
+}
+
+function resolveSecret(config) {
+  if (!config || typeof config !== 'object') return null;
+  if (typeof config.secretEnv === 'string' && config.secretEnv.trim()) {
+    const secret = process.env[config.secretEnv.trim()];
+    if (typeof secret === 'string' && secret.trim()) return secret.trim();
+  }
+  return typeof config.secret === 'string' && config.secret.trim() ? config.secret.trim() : null;
+}
+
+function constantTimeEqual(left, right) {
+  const leftDigest = crypto.createHash('sha256').update(String(left || '')).digest();
+  const rightDigest = crypto.createHash('sha256').update(String(right || '')).digest();
+  return crypto.timingSafeEqual(leftDigest, rightDigest);
+}
+
+function existingAncestor(targetPath) {
+  let current = targetPath;
+  while (true) {
+    try {
+      fs.lstatSync(current);
+      return current;
+    } catch (error) {
+      if (!error || error.code !== 'ENOENT') throw error;
+      const parent = path.dirname(current);
+      if (parent === current) throw error;
+      current = parent;
+    }
+  }
+}
+
+function resolveForCreation(realRoot, targetPath) {
+  const ancestor = existingAncestor(targetPath);
+  const realAncestor = fs.realpathSync(ancestor);
+  if (!isWithin(realRoot, realAncestor)) {
+    throw codedError('EACCES', 'Path escapes managed repo root.');
+  }
+  return targetPath;
+}
+
+function cloneRepo(repo) {
+  return {
+    id: repo.id,
+    label: repo.label || null,
+    rootPath: repo.rootPath,
+    policy: {
+      softDelete: !repo.policy || repo.policy.softDelete !== false,
+      trashDirName: repo.policy && repo.policy.trashDirName || DEFAULT_TRASH_DIR,
+    },
+    createdAt: repo.createdAt,
+    updatedAt: repo.updatedAt,
+    createdBy: repo.createdBy || null,
+  };
+}
+
+class ManagedRepoStore {
+  static fromConfig(config) {
+    if (!config || typeof config !== 'object' || !config.storePath) return null;
+    return new ManagedRepoStore(config);
+  }
+
+  constructor(config) {
+    this.storePath = path.resolve(String(config.storePath));
+    this.allowRoots = (Array.isArray(config.allowRoots) ? config.allowRoots : []).map((rootPath) => {
+      const realRoot = fs.realpathSync(path.resolve(String(rootPath)));
+      if (!fs.statSync(realRoot).isDirectory()) {
+        throw codedError('EINVAL', 'managedRepos.allowRoots entries must be existing directories.');
+      }
+      return realRoot;
+    });
+    this.adminTokens = Object.entries(config.adminTokens || {}).map(([name, tokenConfig]) => ({
+      name,
+      secret: resolveSecret(tokenConfig),
+    })).filter((entry) => entry.secret);
+    this.mutationLocks = new Map();
+  }
+
+  isEnabled() {
+    return true;
+  }
+
+  authenticateAdminToken(secret) {
+    const token = secret && this.adminTokens.find((entry) => constantTimeEqual(entry.secret, secret));
+    return token ? { tokenName: token.name } : null;
+  }
+
+  listRepos() {
+    const repos = [];
+    for (const storedRepo of readStore(this.storePath).repos) {
+      if (repos.length >= MAX_MANAGED_REPOS) break;
+      try {
+        const repo = cloneRepo(storedRepo);
+        if (normalizeRepoId(repo.id) !== repo.id) continue;
+        normalizeRelativePath(repo.policy.trashDirName);
+        if (repo.policy.trashDirName.includes('/')) continue;
+        const realRoot = fs.realpathSync(repo.rootPath);
+        if (!fs.statSync(realRoot).isDirectory()) continue;
+        if (!this.allowRoots.some((allowRoot) => isWithin(allowRoot, realRoot))) continue;
+        repo.rootPath = realRoot;
+        repos.push(repo);
+      } catch (_error) {
+        // Invalid, missing, or out-of-policy registry entries fail closed.
+      }
+    }
+    return { repos };
+  }
+
+  getRepo(repoId) {
+    let normalized;
+    try { normalized = normalizeRepoId(repoId); } catch (_error) { return null; }
+    const repo = this.listRepos().repos.find((entry) => entry.id === normalized);
+    return repo ? cloneRepo(repo) : null;
+  }
+
+  createRepo(input, admin = null) {
+    if (this.allowRoots.length === 0) {
+      throw codedError('EACCES', 'managedRepos.allowRoots must contain at least one existing directory.');
+    }
+    const repoId = normalizeRepoId(input && input.repoId);
+    const requestedRoot = path.resolve(String(input && input.rootPath || ''));
+    if (!input || !String(input.rootPath || '').trim() || !path.isAbsolute(String(input.rootPath))) {
+      throw codedError('EINVAL', 'rootPath must be absolute.');
+    }
+
+    const lexicalAllowed = this.allowRoots.some((allowRoot) => isWithin(allowRoot, requestedRoot));
+    if (!lexicalAllowed) throw codedError('EACCES', 'rootPath is outside managedRepos.allowRoots.');
+    resolveForCreation(this.allowRoots.find((allowRoot) => isWithin(allowRoot, requestedRoot)), requestedRoot);
+
+    const store = readStore(this.storePath);
+    if (store.repos.length >= MAX_MANAGED_REPOS) {
+      throw codedError('ECONFLICT', 'Managed repo registry limit reached.');
+    }
+    if (store.repos.some((entry) => entry.id === repoId)) {
+      throw codedError('ECONFLICT', 'Managed repo already exists.');
+    }
+
+    fs.mkdirSync(requestedRoot, { recursive: true });
+    const realRoot = fs.realpathSync(requestedRoot);
+    if (!this.allowRoots.some((allowRoot) => isWithin(allowRoot, realRoot))) {
+      throw codedError('EACCES', 'rootPath is outside managedRepos.allowRoots.');
+    }
+
+    const now = new Date().toISOString();
+    const trashDirName = normalizeRelativePath(input.policy && input.policy.trashDirName || DEFAULT_TRASH_DIR);
+    if (trashDirName.includes('/')) throw codedError('EINVAL', 'trashDirName must be a single directory name.');
+    const repo = {
+      id: repoId,
+      label: input.label == null ? null : String(input.label).trim() || null,
+      rootPath: realRoot,
+      policy: {
+        softDelete: !(input.policy && input.policy.softDelete === false),
+        trashDirName,
+      },
+      createdAt: now,
+      updatedAt: now,
+      createdBy: admin && admin.tokenName || null,
+    };
+    store.repos.push(repo);
+    atomicWriteFileSync(this.storePath, serializeStore(this.storePath, store));
+    return { repo: cloneRepo(repo) };
+  }
+
+  resolvePath(repo, relativePath, { allowEmpty = false, allowMissing = false } = {}) {
+    const normalized = normalizeRelativePath(relativePath, { allowEmpty });
+    const realRoot = fs.realpathSync(repo.rootPath);
+    const targetPath = path.resolve(realRoot, ...normalized.split('/').filter(Boolean));
+    if (!isWithin(realRoot, targetPath)) throw codedError('EACCES', 'Path escapes managed repo root.');
+    if (allowMissing) {
+      resolveForCreation(realRoot, targetPath);
+      return { relativePath: normalized, absolutePath: targetPath, realRoot };
+    }
+    const realTarget = fs.realpathSync(targetPath);
+    if (!isWithin(realRoot, realTarget)) throw codedError('EACCES', 'Path escapes managed repo root.');
+    return { relativePath: normalized, absolutePath: realTarget, realRoot };
+  }
+
+  isInternalPath(repo, relativePath) {
+    const normalized = normalizeRelativePath(relativePath, { allowEmpty: true });
+    return normalized === repo.policy.trashDirName || normalized.startsWith(`${repo.policy.trashDirName}/`);
+  }
+
+  async readFile(repo, relativePath) {
+    if (this.isInternalPath(repo, relativePath)) throw codedError('EACCES', 'Not found.');
+    const resolved = this.resolvePath(repo, relativePath);
+    const stat = await fs.promises.stat(resolved.absolutePath);
+    if (!stat.isFile()) throw codedError('ENOENT', 'Not found.');
+    return {
+      path: resolved.relativePath,
+      content: await fs.promises.readFile(resolved.absolutePath, 'utf8'),
+      mtimeMs: Math.trunc(stat.mtimeMs),
+      size: stat.size,
+    };
+  }
+
+  async writeFile(repo, relativePath, content, expectedMtimeMs) {
+    const lockPath = normalizeRelativePath(relativePath);
+    if (this.isInternalPath(repo, lockPath)) throw codedError('EACCES', 'Not found.');
+    return this.withMutationLock(`${repo.id}:${lockPath}`, () => (
+      this.writeFileUnlocked(repo, lockPath, content, expectedMtimeMs)
+    ));
+  }
+
+  async writeFileUnlocked(repo, relativePath, content, expectedMtimeMs) {
+    const resolved = this.resolvePath(repo, relativePath, { allowMissing: true });
+    let current = null;
+    try {
+      current = await fs.promises.stat(resolved.absolutePath);
+      if (!current.isFile()) throw codedError('ENOENT', 'Not found.');
+    } catch (error) {
+      if (!error || error.code !== 'ENOENT') throw error;
+    }
+
+    if (expectedMtimeMs !== undefined) {
+      const expected = expectedMtimeMs === null ? null : Number(expectedMtimeMs);
+      if (expected !== null && !Number.isFinite(expected)) throw codedError('EINVAL', 'Invalid expectedMtimeMs value.');
+      const actual = current ? Math.trunc(current.mtimeMs) : null;
+      if (actual !== (expected === null ? null : Math.trunc(expected))) {
+        const conflict = codedError('ECONFLICT', 'Conflict detected.');
+        conflict.current = current ? { exists: true, mtimeMs: actual } : { exists: false, mtimeMs: null };
+        throw conflict;
+      }
+    }
+
+    await fs.promises.mkdir(path.dirname(resolved.absolutePath), { recursive: true });
+    this.resolvePath(repo, path.posix.dirname(resolved.relativePath) === '.' ? '' : path.posix.dirname(resolved.relativePath), { allowEmpty: true });
+    const tempPath = path.join(path.dirname(resolved.absolutePath), `.${path.basename(resolved.absolutePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+    try {
+      await fs.promises.writeFile(tempPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+      await fs.promises.rename(tempPath, resolved.absolutePath);
+    } catch (error) {
+      try { await fs.promises.unlink(tempPath); } catch (_cleanupError) { /* best effort */ }
+      throw error;
+    }
+    let stat = await fs.promises.stat(resolved.absolutePath);
+    if (current && Math.trunc(stat.mtimeMs) === Math.trunc(current.mtimeMs)) {
+      const bumped = new Date(Math.trunc(current.mtimeMs) + 1);
+      await fs.promises.utimes(resolved.absolutePath, bumped, bumped);
+      stat = await fs.promises.stat(resolved.absolutePath);
+    }
+    return { path: resolved.relativePath, mtimeMs: Math.trunc(stat.mtimeMs), size: stat.size, created: !current };
+  }
+
+  async withMutationLock(key, operation) {
+    const previous = this.mutationLocks.get(key) || Promise.resolve();
+    let release;
+    const current = new Promise((resolve) => { release = resolve; });
+    this.mutationLocks.set(key, current);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.mutationLocks.get(key) === current) this.mutationLocks.delete(key);
+    }
+  }
+
+  async deleteFile(repo, relativePath, { hard = false } = {}) {
+    const lockPath = normalizeRelativePath(relativePath);
+    if (this.isInternalPath(repo, lockPath)) throw codedError('EACCES', 'Not found.');
+    return this.withMutationLock(`${repo.id}:${lockPath}`, () => (
+      this.deleteFileUnlocked(repo, lockPath, { hard })
+    ));
+  }
+
+  async deleteFileUnlocked(repo, relativePath, { hard = false } = {}) {
+    const resolved = this.resolvePath(repo, relativePath);
+    const stat = await fs.promises.stat(resolved.absolutePath);
+    if (!stat.isFile()) throw codedError('ENOENT', 'Not found.');
+    if (hard || repo.policy.softDelete === false) {
+      await fs.promises.unlink(resolved.absolutePath);
+      return { path: resolved.relativePath, deleted: 'hard' };
+    }
+
+    const trashId = crypto.randomUUID();
+    const trashRoot = this.resolvePath(repo, repo.policy.trashDirName, { allowMissing: true });
+    const recordDir = path.join(trashRoot.absolutePath, trashId);
+    await fs.promises.mkdir(recordDir, { recursive: true, mode: 0o700 });
+    const payloadPath = path.join(recordDir, 'payload');
+    await fs.promises.rename(resolved.absolutePath, payloadPath);
+    const metadata = { version: 1, trashId, originalPath: resolved.relativePath, deletedAt: new Date().toISOString() };
+    atomicWriteFileSync(path.join(recordDir, 'metadata.json'), `${JSON.stringify(metadata, null, 2)}\n`);
+    return { path: resolved.relativePath, deleted: 'soft', trashId };
+  }
+
+  async restoreTrash(repo, trashId) {
+    const { record, metadata } = await this.getTrashMetadata(repo, trashId);
+    const destination = this.resolvePath(repo, metadata.originalPath, { allowMissing: true });
+    try {
+      await fs.promises.lstat(destination.absolutePath);
+      throw codedError('ECONFLICT', 'Restore destination already exists.');
+    } catch (error) {
+      if (!error || error.code !== 'ENOENT') throw error;
+    }
+    await fs.promises.mkdir(path.dirname(destination.absolutePath), { recursive: true });
+    this.resolvePath(repo, path.posix.dirname(destination.relativePath) === '.' ? '' : path.posix.dirname(destination.relativePath), { allowEmpty: true });
+    await fs.promises.rename(path.join(record.absolutePath, 'payload'), destination.absolutePath);
+    await fs.promises.rm(record.absolutePath, { recursive: true });
+    return { path: metadata.originalPath, restored: true };
+  }
+
+  async hardDeleteTrash(repo, trashId) {
+    const { record } = await this.getTrashMetadata(repo, trashId);
+    await fs.promises.rm(record.absolutePath, { recursive: true });
+    return { trashId, deleted: 'hard' };
+  }
+
+  async getTrashMetadata(repo, trashId) {
+    if (!/^[0-9a-f-]{36}$/i.test(String(trashId || ''))) throw codedError('ENOENT', 'Not found.');
+    const record = this.resolvePath(repo, `${repo.policy.trashDirName}/${trashId}`);
+    const metadata = JSON.parse(await fs.promises.readFile(path.join(record.absolutePath, 'metadata.json'), 'utf8'));
+    return { record, metadata };
+  }
+
+  async listTree(repo, relativePath = '', options = {}) {
+    const maxDepth = Math.max(0, Math.min(MAX_TREE_DEPTH, Number.isFinite(Number(options.maxDepth)) ? Math.trunc(Number(options.maxDepth)) : 5));
+    const maxEntries = Math.max(1, Math.min(MAX_TREE_ENTRIES, Number.isFinite(Number(options.maxEntries)) ? Math.trunc(Number(options.maxEntries)) : 1000));
+    const start = this.resolvePath(repo, relativePath, { allowEmpty: true });
+    const entries = [];
+    let visited = 0;
+    let truncated = false;
+    const walk = async (directory, relativeDirectory, depth) => {
+      if (visited >= maxEntries || depth > maxDepth) { truncated = true; return; }
+      const directoryHandle = await fs.promises.opendir(directory);
+      for await (const dirent of directoryHandle) {
+        if (visited >= maxEntries) { truncated = true; break; }
+        visited += 1;
+        if (!relativeDirectory && dirent.name === repo.policy.trashDirName) continue;
+        if (dirent.isSymbolicLink()) continue;
+        const entryRelative = relativeDirectory ? `${relativeDirectory}/${dirent.name}` : dirent.name;
+        const resolvedEntry = this.resolvePath(repo, entryRelative);
+        const entryPath = resolvedEntry.absolutePath;
+        const stat = await fs.promises.stat(entryPath);
+        const type = dirent.isDirectory() ? 'directory' : dirent.isFile() ? 'file' : 'other';
+        const entry = { path: entryRelative, type, size: type === 'file' ? stat.size : null, mtimeMs: Math.trunc(stat.mtimeMs) };
+        if (!options.includeEntry || options.includeEntry(entry)) entries.push(entry);
+        if (type === 'directory' && depth < maxDepth && (!options.shouldDescend || options.shouldDescend(entry))) {
+          await walk(entryPath, entryRelative, depth + 1);
+        }
+      }
+    };
+    await walk(start.absolutePath, start.relativePath, 0);
+    return { entries, truncated, maxDepth, maxEntries, visited };
+  }
+}
+
+module.exports = {
+  ManagedRepoStore,
+  MAX_TREE_DEPTH,
+  MAX_TREE_ENTRIES,
+};

--- a/lib/managed-repo-store.js
+++ b/lib/managed-repo-store.js
@@ -401,6 +401,7 @@ class ManagedRepoStore {
   }
 
   async listTree(repo, relativePath = '', options = {}) {
+    if (this.isInternalPath(repo, relativePath)) throw codedError('ENOENT', 'Not found.');
     const maxDepth = Math.max(0, Math.min(MAX_TREE_DEPTH, Number.isFinite(Number(options.maxDepth)) ? Math.trunc(Number(options.maxDepth)) : 5));
     const maxEntries = Math.max(1, Math.min(MAX_TREE_ENTRIES, Number.isFinite(Number(options.maxEntries)) ? Math.trunc(Number(options.maxEntries)) : 1000));
     const start = this.resolvePath(repo, relativePath, { allowEmpty: true });

--- a/lookie-link.yaml.example
+++ b/lookie-link.yaml.example
@@ -73,6 +73,16 @@ repositories:
 #       paperclip:
 #         secretEnv: LOOKIE_LINK_GRANT_ADMIN_TOKEN
 
+# Optional mutable managed repositories. Every allow-root must already exist;
+# newly registered repositories may only be created beneath one of them.
+# managedRepos:
+#   storePath: ~/.local/share/lookie-link/managed-repos.yaml
+#   allowRoots:
+#     - ~/shared-workspaces
+#   adminTokens:
+#     local_operator:
+#       secretEnv: LOOKIE_LINK_MANAGED_REPO_ADMIN_TOKEN
+
 # Custom themes
 # Each theme needs dark and/or light variants.
 # CSS property names use underscores (bg_elev → --bg-elev).

--- a/out/worker-p8b.DONE
+++ b/out/worker-p8b.DONE
@@ -1,0 +1,67 @@
+# worker-p8b — managed-repos trash-enumeration fix
+
+## R1: two-layer fix
+
+- `ManagedRepoStore.listTree` now rejects a walk whose start path is the managed
+  repository's trash directory or any descendant. It throws `ENOENT` with
+  `Not found.` before resolving or opening the directory.
+- `GET /api/managed-repos/:repo/tree` now applies the same
+  `isManagedInternalPath` route guard used by the other managed read surfaces.
+  Internal paths therefore receive the uniform managed `404` response before
+  `listTree` is called.
+
+## Regression coverage
+
+- Added a root-scoped, view-only principal to the managed-repo HTTP fixture.
+  Requests for both `.lookie-link-trash` and the nested trash-record path assert
+  the uniform `404 {"ok":false,"error":"Not found."}` response and assert that
+  neither the trash ID nor metadata appears in the response.
+- The existing path-narrowed viewer remains denied access to the trash tree.
+- Added socket-free route-level coverage proving the route guard rejects both
+  trash starts without calling `listTree`.
+- Added store-level coverage proving `listTree` itself returns `ENOENT` for both
+  trash starts.
+
+## Advisories
+
+- A1 deferred: the realpath-to-rename TOCTOU requires a concurrent local process
+  capable of changing the managed root. No remote symlink-creation API exists,
+  so `openat`/`O_NOFOLLOW` hardening remains a future item unless local co-tenancy
+  enters the threat model.
+- A2 deferred: grants model repository/path scope and capabilities, but do not
+  model ownership of deleted items. Restore and hard-delete retain exact
+  `originalPath` scope authorization; no new ownership model was invented here.
+- A3 applied: restore and hard-delete now require write capability with a scope
+  intersecting the repository before `getTrashMetadata` can read from disk, then
+  retain the exact original-path write authorization after metadata is read.
+  A route-level spy test proves a root-scoped view-only caller triggers zero
+  metadata reads for both existing and missing trash IDs, with identical 404s.
+
+## Security-property re-verification
+
+- Allow-root boundary: unchanged; the store symlink/ancestor escape tests pass.
+- Capability gate: preserved; trash mutations require a metadata-free write
+  precheck and the existing exact original-path write check.
+- Uniform 404: preserved for internal tree paths, unauthorized trash mutations,
+  and existing versus missing trash IDs.
+- Search scope: unchanged; managed-search and access-control foundation tests pass.
+- Hard-delete: unchanged; the store recovery/hard-delete test passes and confirms
+  metadata is absent afterward.
+
+## Verification
+
+- `node --check` passed for every touched JavaScript file.
+- `git diff --check` passed.
+- Socket-free managed store/route tests: 2/2 files passed.
+- All non-listening test files: 13/13 passed.
+- `npm test`: 13/15 files passed. The two socket-bound suites are:
+  - `test/access-control.test.js`
+  - `test/managed-repos.test.js`
+- `node scripts/validate-raw-html.js; echo $?`: exit 1.
+- `node scripts/validate-editable-mode.js; echo $?`: exit 1.
+
+The two test files and both validators fail before assertions because this
+execution sandbox rejects `listen(0, '127.0.0.1')` with
+`EPERM: operation not permitted`. Consequently, validator exit 0 could not be
+confirmed in this environment. The new behavior is additionally covered by the
+socket-free route test so both route-level requirements were executed here.

--- a/server.js
+++ b/server.js
@@ -701,7 +701,11 @@ function createApp(options = {}) {
     const accessContext = resolveAccessContext(req);
     const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
     const relativePath = typeof req.query.path === 'string' ? req.query.path : '';
-    if (!repo || !canAccessPath(accessContext, 'view', repo.id, relativePath, 'directory')) {
+    if (
+      !repo
+      || isManagedInternalPath(repo.id, relativePath)
+      || !canAccessPath(accessContext, 'view', repo.id, relativePath, 'directory')
+    ) {
       managedNotFound(res);
       return;
     }
@@ -830,7 +834,10 @@ function createApp(options = {}) {
   app.post('/api/managed-repos/:repo/trash/:trashId/restore', async (req, res) => {
     const accessContext = resolveAccessContext(req);
     const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
-    if (!repo) { managedNotFound(res); return; }
+    if (!repo || !canAccessPath(accessContext, 'write', repo.id, '', 'directory')) {
+      managedNotFound(res);
+      return;
+    }
     try {
       const { metadata } = await managedRepoStore.getTrashMetadata(repo, req.params.trashId);
       if (!canAccessPath(accessContext, 'write', repo.id, metadata.originalPath, 'file')) {
@@ -848,7 +855,10 @@ function createApp(options = {}) {
   app.delete('/api/managed-repos/:repo/trash/:trashId', async (req, res) => {
     const accessContext = resolveAccessContext(req);
     const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
-    if (!repo) { managedNotFound(res); return; }
+    if (!repo || !canAccessPath(accessContext, 'write', repo.id, '', 'directory')) {
+      managedNotFound(res);
+      return;
+    }
     try {
       const { metadata } = await managedRepoStore.getTrashMetadata(repo, req.params.trashId);
       if (!canAccessPath(accessContext, 'write', repo.id, metadata.originalPath, 'file')) {

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ const {
   getAnnotationsEnabled,
   getRawHtmlEnabled,
   getAccessConfig,
+  getManagedReposConfig,
   loadCustomThemes,
   generateCustomThemeCss,
   BUILT_IN_THEMES,
@@ -31,6 +32,7 @@ const {
   buildIssueComment,
 } = require('./lib/grant-store');
 const { ApiKeyStore } = require('./lib/api-key-store');
+const { ManagedRepoStore } = require('./lib/managed-repo-store');
 const {
   safeResolve,
   toPosixPath,
@@ -292,6 +294,28 @@ function parseBooleanQuery(value) {
   return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
 }
 
+function managedNotFound(res) {
+  res.status(404).json({ ok: false, error: 'Not found.' });
+}
+
+function publicManagedRepo(repo) {
+  return {
+    id: repo.id,
+    label: repo.label,
+    policy: repo.policy,
+    createdAt: repo.createdAt,
+    updatedAt: repo.updatedAt,
+    viewUrl: buildHref(repo.id, ''),
+  };
+}
+
+function managedErrorStatus(error) {
+  if (error && error.code === 'ECONFLICT') return 409;
+  if (error && (error.code === 'ENOENT' || error.code === 'EACCES')) return 404;
+  if (error && error.code === 'EINVAL') return 400;
+  return 500;
+}
+
 function buildAssetBaseHref(repo, relativePath, accessContext) {
   const normalized = toPosixPath(relativePath);
   const currentDir = path.posix.dirname(normalized) === '.' ? '' : path.posix.dirname(normalized);
@@ -509,12 +533,13 @@ function sendApiKeyJsonError(res, status, error) {
 
 function createApp(options = {}) {
   const app = express();
-  const mappings = options.mappings || loadRootMappings();
+  const mappings = { ...(options.mappings || loadRootMappings()) };
   const editingEnabled = options.editingEnabled === undefined ? getEditingEnabled() : Boolean(options.editingEnabled);
   const annotationsEnabled = options.annotationsEnabled === undefined ? getAnnotationsEnabled() : Boolean(options.annotationsEnabled);
   const rawHtmlEnabled = options.rawHtmlEnabled === undefined ? getRawHtmlEnabled() : Boolean(options.rawHtmlEnabled);
   const customThemeCss = options.customThemeCss || '';
   const rawAccessConfig = options.accessConfig === undefined ? getAccessConfig() : options.accessConfig;
+  const rawManagedReposConfig = options.managedReposConfig === undefined ? getManagedReposConfig() : options.managedReposConfig;
   const accessConfig = parseAccessConfig(rawAccessConfig);
   const apiKeyStore = options.apiKeyStore === undefined
     ? ApiKeyStore.fromAccessConfig(rawAccessConfig.apiKeys)
@@ -522,6 +547,21 @@ function createApp(options = {}) {
   const grantStore = options.grantStore === undefined
     ? GrantStore.fromAccessConfig(rawAccessConfig.grants)
     : options.grantStore;
+  const managedRepoStore = options.managedRepoStore === undefined
+    ? ManagedRepoStore.fromConfig(rawManagedReposConfig)
+    : options.managedRepoStore;
+  if (managedRepoStore && managedRepoStore.isEnabled()) {
+    for (const repo of managedRepoStore.listRepos().repos) {
+      if (!mappings[repo.id]) mappings[repo.id] = repo.rootPath;
+    }
+  }
+  const getManagedRepo = (repoId) => managedRepoStore && managedRepoStore.isEnabled()
+    ? managedRepoStore.getRepo(repoId)
+    : null;
+  const isManagedInternalPath = (repoId, relativePath) => {
+    const repo = getManagedRepo(repoId);
+    return Boolean(repo && managedRepoStore.isInternalPath(repo, relativePath));
+  };
   const resolveAccessContext = (req) => {
     if (req.accessContext) {
       return req.accessContext;
@@ -576,6 +616,18 @@ function createApp(options = {}) {
     return { ok: true, admin };
   };
 
+  const authenticateManagedRepoAdmin = (req) => {
+    if (!managedRepoStore || !managedRepoStore.isEnabled()) {
+      return { ok: false, status: 404, error: 'Managed repos are not configured.' };
+    }
+    const secret = extractBearerToken(req);
+    if (!secret) return { ok: false, status: 401, error: 'Managed repo admin authentication required.' };
+    const admin = managedRepoStore.authenticateAdminToken(secret);
+    return admin
+      ? { ok: true, admin }
+      : { ok: false, status: 403, error: 'Invalid managed repo admin token.' };
+  };
+
   const recordApiKeyAuditEvent = (type, accessContext, target, metadata) => {
     if (!apiKeyStore || !apiKeyStore.isEnabled()) {
       return null;
@@ -602,6 +654,204 @@ function createApp(options = {}) {
     etag: true,
     maxAge: '1h',
   }));
+
+  app.get('/api/managed-repos', (req, res) => {
+    if (!managedRepoStore || !managedRepoStore.isEnabled()) {
+      managedNotFound(res);
+      return;
+    }
+    const accessContext = resolveAccessContext(req);
+    const repos = managedRepoStore.listRepos().repos
+      .filter((repo) => canAccessPath(accessContext, 'view', repo.id, '', 'directory'))
+      .map(publicManagedRepo);
+    res.status(200).json({ ok: true, repos, count: repos.length });
+  });
+
+  app.post('/api/managed-repos', (req, res) => {
+    const auth = authenticateManagedRepoAdmin(req);
+    if (!auth.ok) {
+      res.status(auth.status).json({ ok: false, error: auth.error });
+      return;
+    }
+    try {
+      if (req.body && mappings[String(req.body.repoId || '').trim().toLowerCase()]) {
+        res.status(409).json({ ok: false, error: 'Repository id already exists.' });
+        return;
+      }
+      const result = managedRepoStore.createRepo(req.body || {}, auth.admin);
+      mappings[result.repo.id] = result.repo.rootPath;
+      res.status(201).json({ ok: true, repo: publicManagedRepo(result.repo) });
+    } catch (error) {
+      const status = managedErrorStatus(error);
+      res.status(status).json({ ok: false, error: status === 404 ? 'Not found.' : error.message });
+    }
+  });
+
+  app.get('/api/managed-repos/:repo/tree', async (req, res) => {
+    const accessContext = resolveAccessContext(req);
+    const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
+    const relativePath = typeof req.query.path === 'string' ? req.query.path : '';
+    if (!repo || !canAccessPath(accessContext, 'view', repo.id, relativePath, 'directory')) {
+      managedNotFound(res);
+      return;
+    }
+    try {
+      const tree = await managedRepoStore.listTree(repo, relativePath, {
+        maxDepth: req.query.maxDepth,
+        maxEntries: req.query.maxEntries,
+        includeEntry: (entry) => canAccessPath(
+          accessContext,
+          'view',
+          repo.id,
+          entry.path,
+          entry.type === 'directory' ? 'directory' : 'file'
+        ),
+        shouldDescend: (entry) => canAccessPath(accessContext, 'view', repo.id, entry.path, 'directory'),
+      });
+      const entries = tree.entries;
+      res.status(200).json({
+        ok: true,
+        repo: repo.id,
+        path: toPosixPath(relativePath),
+        entries,
+        count: entries.length,
+        truncated: tree.truncated,
+        limits: { maxDepth: tree.maxDepth, maxEntries: tree.maxEntries },
+      });
+    } catch (error) {
+      const status = managedErrorStatus(error);
+      res.status(status).json({ ok: false, error: status === 404 ? 'Not found.' : error.message });
+    }
+  });
+
+  app.get('/api/managed-repos/:repo/changes', async (req, res) => {
+    const accessContext = resolveAccessContext(req);
+    const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
+    if (!repo || !canAccessPath(accessContext, 'view', repo.id, '', 'directory')) {
+      managedNotFound(res);
+      return;
+    }
+    const since = req.query.since == null || req.query.since === '' ? null : Number(req.query.since);
+    if (since !== null && !Number.isFinite(since)) {
+      res.status(400).json({ ok: false, error: 'since must be a unix timestamp.' });
+      return;
+    }
+    try {
+      const tree = await managedRepoStore.listTree(repo, '', {
+        maxDepth: 10,
+        maxEntries: req.query.maxEntries,
+        includeEntry: (entry) => entry.type === 'file' && canAccessPath(accessContext, 'view', repo.id, entry.path, 'file'),
+        shouldDescend: (entry) => canAccessPath(accessContext, 'view', repo.id, entry.path, 'directory'),
+      });
+      const entries = tree.entries
+        .filter((entry) => since === null || entry.mtimeMs >= since)
+        .map((entry) => ({ path: entry.path, mtimeMs: entry.mtimeMs, size: entry.size, change: 'modified' }));
+      res.status(200).json({ ok: true, repo: repo.id, entries, count: entries.length, truncated: tree.truncated });
+    } catch (error) {
+      const status = managedErrorStatus(error);
+      res.status(status).json({ ok: false, error: status === 404 ? 'Not found.' : error.message });
+    }
+  });
+
+  app.get('/api/managed-repos/:repo/files/*', async (req, res) => {
+    const accessContext = resolveAccessContext(req);
+    const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
+    const relativePath = req.params[0] || '';
+    if (!repo || !canAccessPath(accessContext, 'view', repo.id, relativePath, 'file')) {
+      managedNotFound(res);
+      return;
+    }
+    try {
+      const result = await managedRepoStore.readFile(repo, relativePath);
+      res.status(200).json({ ok: true, repo: repo.id, ...result, viewUrl: buildHref(repo.id, result.path) });
+    } catch (error) {
+      const status = managedErrorStatus(error);
+      res.status(status).json({ ok: false, error: status === 404 ? 'Not found.' : error.message });
+    }
+  });
+
+  app.put('/api/managed-repos/:repo/files/*', async (req, res) => {
+    const accessContext = resolveAccessContext(req);
+    const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
+    const relativePath = req.params[0] || '';
+    if (!repo || !canAccessPath(accessContext, 'write', repo.id, relativePath, 'file')) {
+      managedNotFound(res);
+      return;
+    }
+    if (!req.body || typeof req.body.content !== 'string') {
+      res.status(400).json({ ok: false, error: 'content is required.' });
+      return;
+    }
+    try {
+      const result = await managedRepoStore.writeFile(repo, relativePath, req.body.content, req.body.expectedMtimeMs);
+      recordApiKeyAuditEvent('content.write', accessContext, { repo: repo.id, relativePath: result.path }, {
+        outcome: 'accepted',
+        byteCount: Buffer.byteLength(req.body.content, 'utf8'),
+      });
+      res.status(result.created ? 201 : 200).json({ ok: true, repo: repo.id, ...result });
+    } catch (error) {
+      const status = managedErrorStatus(error);
+      res.status(status).json({
+        ok: false,
+        error: status === 404 ? 'Not found.' : error.message,
+        ...(status === 409 ? { current: error.current } : {}),
+      });
+    }
+  });
+
+  app.delete('/api/managed-repos/:repo/files/*', async (req, res) => {
+    const accessContext = resolveAccessContext(req);
+    const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
+    const relativePath = req.params[0] || '';
+    if (!repo || !canAccessPath(accessContext, 'write', repo.id, relativePath, 'file')) {
+      managedNotFound(res);
+      return;
+    }
+    try {
+      const result = await managedRepoStore.deleteFile(repo, relativePath, { hard: parseBooleanQuery(req.query.hard) });
+      recordApiKeyAuditEvent('content.delete', accessContext, { repo: repo.id, relativePath: result.path }, { mode: result.deleted });
+      res.status(200).json({ ok: true, repo: repo.id, ...result });
+    } catch (error) {
+      const status = managedErrorStatus(error);
+      res.status(status).json({ ok: false, error: status === 404 ? 'Not found.' : error.message });
+    }
+  });
+
+  app.post('/api/managed-repos/:repo/trash/:trashId/restore', async (req, res) => {
+    const accessContext = resolveAccessContext(req);
+    const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
+    if (!repo) { managedNotFound(res); return; }
+    try {
+      const { metadata } = await managedRepoStore.getTrashMetadata(repo, req.params.trashId);
+      if (!canAccessPath(accessContext, 'write', repo.id, metadata.originalPath, 'file')) {
+        managedNotFound(res);
+        return;
+      }
+      const result = await managedRepoStore.restoreTrash(repo, req.params.trashId);
+      res.status(200).json({ ok: true, repo: repo.id, ...result });
+    } catch (error) {
+      const status = managedErrorStatus(error);
+      res.status(status).json({ ok: false, error: status === 404 ? 'Not found.' : error.message });
+    }
+  });
+
+  app.delete('/api/managed-repos/:repo/trash/:trashId', async (req, res) => {
+    const accessContext = resolveAccessContext(req);
+    const repo = managedRepoStore && managedRepoStore.getRepo(req.params.repo);
+    if (!repo) { managedNotFound(res); return; }
+    try {
+      const { metadata } = await managedRepoStore.getTrashMetadata(repo, req.params.trashId);
+      if (!canAccessPath(accessContext, 'write', repo.id, metadata.originalPath, 'file')) {
+        managedNotFound(res);
+        return;
+      }
+      const result = await managedRepoStore.hardDeleteTrash(repo, req.params.trashId);
+      res.status(200).json({ ok: true, repo: repo.id, ...result });
+    } catch (error) {
+      const status = managedErrorStatus(error);
+      res.status(status).json({ ok: false, error: status === 404 ? 'Not found.' : error.message });
+    }
+  });
 
   app.get('/api/agent-keys', (req, res) => {
     const auth = authenticateApiKeyAdmin(req);
@@ -789,11 +1039,14 @@ function createApp(options = {}) {
       sendAccessError(res, accessContext);
       return;
     }
+    const managedRepoIds = new Set(managedRepoStore && managedRepoStore.isEnabled()
+      ? managedRepoStore.listRepos().repos.map((repo) => repo.id)
+      : []);
     const repos = Object.entries(mappings)
       .filter(([repo]) => canAccessPath(accessContext, 'view', repo, '', 'directory'))
       .map(([repo, rootPath]) => ({
         repo,
-        rootPath,
+        ...(managedRepoIds.has(repo) ? {} : { rootPath }),
         viewUrl: `/view/${encodeURIComponent(repo)}/`,
         assetUrl: `/asset/${encodeURIComponent(repo)}/`,
       }));
@@ -802,6 +1055,13 @@ function createApp(options = {}) {
 
   app.get('/view/*', async (req, res) => {
     const accessContext = resolveAccessContext(req);
+    const requested = splitViewPath(req.params[0] || '');
+    if (requested && getManagedRepo(requested.repo)
+      && !canAccessPath(accessContext, 'view', requested.repo, requested.relativePath, 'file')
+      && !canAccessPath(accessContext, 'view', requested.repo, requested.relativePath, 'directory')) {
+      res.status(404).type('text/plain').send('File or directory not found.');
+      return;
+    }
     let resolvedInput;
     try {
       resolvedInput = await resolveFromRequest(mappings, req.params[0] || '');
@@ -817,6 +1077,10 @@ function createApp(options = {}) {
     }
 
     const { repo, relativePath, rootPath, resolved } = resolvedInput;
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).type('text/plain').send('File or directory not found.');
+      return;
+    }
 
     let stat;
     try {
@@ -1118,6 +1382,13 @@ function createApp(options = {}) {
       return;
     }
 
+    const requested = splitViewPath(req.params[0] || '');
+    if (requested && getManagedRepo(requested.repo)
+      && !canAccessPath(accessContext, 'write', requested.repo, requested.relativePath, 'file')) {
+      res.status(404).type('text/plain').send('File not found.');
+      return;
+    }
+
     let resolvedInput;
     try {
       resolvedInput = await resolveFromRequest(mappings, req.params[0] || '');
@@ -1133,6 +1404,10 @@ function createApp(options = {}) {
     }
 
     const { repo, relativePath, rootPath, resolved } = resolvedInput;
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).type('text/plain').send('File not found.');
+      return;
+    }
     if (!relativePath) {
       res.status(400).type('text/plain').send('Edit requires a file path.');
       return;
@@ -1207,6 +1482,13 @@ function createApp(options = {}) {
       return;
     }
 
+    const requested = splitViewPath(req.params[0] || '');
+    if (requested && getManagedRepo(requested.repo)
+      && !canAccessPath(accessContext, 'write', requested.repo, requested.relativePath, 'file')) {
+      res.status(404).json({ ok: false, error: 'File not found.' });
+      return;
+    }
+
     let resolvedInput;
     try {
       resolvedInput = await resolveFromRequest(mappings, req.params[0] || '');
@@ -1222,6 +1504,10 @@ function createApp(options = {}) {
     }
 
     const { repo, relativePath, resolved } = resolvedInput;
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).json({ ok: false, error: 'File not found.' });
+      return;
+    }
     if (!relativePath) {
       res.status(400).json({ ok: false, error: 'Save requires a file path.' });
       return;
@@ -1346,6 +1632,13 @@ function createApp(options = {}) {
       return;
     }
 
+    const requested = splitViewPath(req.params[0] || '');
+    if (requested && getManagedRepo(requested.repo)
+      && !canAccessPath(accessContext, 'view', requested.repo, requested.relativePath, 'file')) {
+      res.status(404).json({ ok: false, error: 'File not found.' });
+      return;
+    }
+
     let resolvedInput;
     try {
       resolvedInput = await resolveFromRequest(mappings, req.params[0] || '');
@@ -1361,6 +1654,10 @@ function createApp(options = {}) {
     }
 
     const { repo, relativePath, rootPath, resolved } = resolvedInput;
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).json({ ok: false, error: 'File not found.' });
+      return;
+    }
     if (!relativePath) {
       res.status(400).json({ ok: false, error: 'Preview requires a file path.' });
       return;
@@ -1424,6 +1721,11 @@ function createApp(options = {}) {
     const rootPath = mappings[repo];
     const accessContext = resolveAccessContext(req);
 
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).json({ ok: false, error: 'File not found.' });
+      return;
+    }
+
     if (!rootPath) {
       res.status(404).json({ ok: false, error: `Unknown repository: ${repo}` });
       return;
@@ -1435,7 +1737,8 @@ function createApp(options = {}) {
     }
 
     if (!canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
-      sendAccessError(res, accessContext, true);
+      if (getManagedRepo(repo)) managedNotFound(res);
+      else sendAccessError(res, accessContext, true);
       return;
     }
 
@@ -1516,6 +1819,11 @@ function createApp(options = {}) {
     const rootPath = mappings[repo];
     const accessContext = resolveAccessContext(req);
 
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).json({ ok: false, error: 'File not found.' });
+      return;
+    }
+
     if (!rootPath) {
       res.status(404).json({ ok: false, error: `Unknown repository: ${repo}` });
       return;
@@ -1527,7 +1835,8 @@ function createApp(options = {}) {
     }
 
     if (!canAccessPath(accessContext, 'write', repo, relativePath, 'file')) {
-      sendAccessError(res, accessContext, true);
+      if (getManagedRepo(repo)) managedNotFound(res);
+      else sendAccessError(res, accessContext, true);
       return;
     }
 
@@ -1598,6 +1907,11 @@ function createApp(options = {}) {
     const rootPath = mappings[repo];
     const accessContext = resolveAccessContext(req);
 
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).json({ ok: false, error: 'File not found.' });
+      return;
+    }
+
     if (!rootPath) {
       res.status(404).json({ ok: false, error: `Unknown repository: ${repo}` });
       return;
@@ -1609,7 +1923,8 @@ function createApp(options = {}) {
     }
 
     if (!canAccessPath(accessContext, 'write', repo, relativePath, 'file')) {
-      sendAccessError(res, accessContext, true);
+      if (getManagedRepo(repo)) managedNotFound(res);
+      else sendAccessError(res, accessContext, true);
       return;
     }
 
@@ -1688,8 +2003,18 @@ function createApp(options = {}) {
     const relativePath = req.params[0] || '';
     const rootPath = mappings[repo];
 
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).type('text/plain').send('Asset not found.');
+      return;
+    }
+
     if (!rootPath) {
       res.status(404).type('text/plain').send(`Unknown repository: ${repo}`);
+      return;
+    }
+
+    if (getManagedRepo(repo) && !canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+      res.status(404).type('text/plain').send('Asset not found.');
       return;
     }
 
@@ -1770,8 +2095,18 @@ function createApp(options = {}) {
     const relativePath = req.params[0] || '';
     const rootPath = mappings[repo];
 
+    if (isManagedInternalPath(repo, relativePath)) {
+      res.status(404).type('text/plain').send('Raw HTML file not found.');
+      return;
+    }
+
     if (!rootPath) {
       res.status(404).type('text/plain').send(`Unknown repository: ${repo}`);
+      return;
+    }
+
+    if (getManagedRepo(repo) && !canAccessPath(accessContext, 'view', repo, relativePath, 'file')) {
+      res.status(404).type('text/plain').send('Raw HTML file not found.');
       return;
     }
 
@@ -1865,6 +2200,7 @@ function startServer() {
   const annotationsEnabled = getAnnotationsEnabled();
   const rawHtmlEnabled = getRawHtmlEnabled();
   const accessConfig = getAccessConfig();
+  const managedReposConfig = getManagedReposConfig();
 
   const customThemes = loadCustomThemes();
   const customThemeCss = generateCustomThemeCss(customThemes);
@@ -1876,7 +2212,7 @@ function startServer() {
   const allThemes = [...builtInThemes, ...customThemes.map((t) => ({ slug: t.slug, label: t.label }))];
   setThemeList(allThemes);
 
-  const app = createApp({ mappings, editingEnabled, annotationsEnabled, rawHtmlEnabled, customThemeCss, accessConfig });
+  const app = createApp({ mappings, editingEnabled, annotationsEnabled, rawHtmlEnabled, customThemeCss, accessConfig, managedReposConfig });
 
   app.listen(port, '0.0.0.0', () => {
     console.log(`Lookie Link listening on http://${hostname}:${port}`);

--- a/server.js
+++ b/server.js
@@ -33,6 +33,7 @@ const {
 } = require('./lib/grant-store');
 const { ApiKeyStore } = require('./lib/api-key-store');
 const { ManagedRepoStore } = require('./lib/managed-repo-store');
+const { searchManagedRepos, suggestManagedRepos } = require('./lib/managed-repo-search');
 const {
   safeResolve,
   toPosixPath,
@@ -850,6 +851,68 @@ function createApp(options = {}) {
     } catch (error) {
       const status = managedErrorStatus(error);
       res.status(status).json({ ok: false, error: status === 404 ? 'Not found.' : error.message });
+    }
+  });
+
+  app.get('/api/search', async (req, res) => {
+    if (!managedRepoStore || !managedRepoStore.isEnabled()) {
+      managedNotFound(res);
+      return;
+    }
+    const query = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    if (!query) {
+      res.status(400).json({ ok: false, error: 'q is required.' });
+      return;
+    }
+    if (query.length > 256) {
+      res.status(400).json({ ok: false, error: 'q must be at most 256 characters.' });
+      return;
+    }
+    const accessContext = resolveAccessContext(req);
+    try {
+      const result = await searchManagedRepos({
+        store: managedRepoStore,
+        repos: managedRepoStore.listRepos().repos,
+        query,
+        scope: req.query.scope,
+        limit: req.query.limit,
+        maxEntries: req.query.maxEntries,
+        canView: (repo, relativePath, type) => canAccessPath(accessContext, 'view', repo, relativePath, type),
+      });
+      res.status(200).json({ ok: true, ...result });
+    } catch (error) {
+      res.status(500).json({ ok: false, error: 'Search failed.' });
+    }
+  });
+
+  app.get('/api/search/suggest', async (req, res) => {
+    if (!managedRepoStore || !managedRepoStore.isEnabled()) {
+      managedNotFound(res);
+      return;
+    }
+    const query = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    if (!query) {
+      res.status(400).json({ ok: false, error: 'q is required.' });
+      return;
+    }
+    if (query.length > 256) {
+      res.status(400).json({ ok: false, error: 'q must be at most 256 characters.' });
+      return;
+    }
+    const accessContext = resolveAccessContext(req);
+    try {
+      const result = await suggestManagedRepos({
+        store: managedRepoStore,
+        repos: managedRepoStore.listRepos().repos,
+        query,
+        scope: req.query.scope,
+        limit: req.query.limit,
+        maxEntries: req.query.maxEntries,
+        canView: (repo, relativePath, type) => canAccessPath(accessContext, 'view', repo, relativePath, type),
+      });
+      res.status(200).json({ ok: true, ...result });
+    } catch (error) {
+      res.status(500).json({ ok: false, error: 'Suggestion lookup failed.' });
     }
   });
 

--- a/test/managed-repo-route-security.test.js
+++ b/test/managed-repo-route-security.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ManagedRepoStore } = require('../lib/managed-repo-store');
+const { createApp } = require('../server');
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-managed-route-security-'));
+  const allowed = path.join(root, 'allowed');
+  await fs.mkdir(allowed);
+  const store = new ManagedRepoStore({
+    storePath: path.join(root, 'registry.yaml'),
+    allowRoots: [allowed],
+  });
+  const repo = store.createRepo({
+    repoId: 'shared-notes',
+    rootPath: path.join(allowed, 'shared-notes'),
+  }).repo;
+  return { root, store, repo };
+}
+
+function getRouteHandler(app, method, routePath) {
+  const layer = app._router.stack.find((entry) => (
+    entry.route && entry.route.path === routePath && entry.route.methods[method]
+  ));
+  assert(layer, `Missing route ${method.toUpperCase()} ${routePath}`);
+  return layer.route.stack[0].handle;
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+function rootScopedViewer(repoId) {
+  return {
+    mode: 'scoped',
+    permissions: { view: true, write: false, edit: false, publish: false },
+    allRepos: false,
+    repos: { [repoId]: [{ type: 'all', path: '' }] },
+  };
+}
+
+test('tree route uniformly hides trash starts from a root-scoped viewer', async (t) => {
+  const setup = await fixture();
+  t.after(() => fs.rm(setup.root, { recursive: true, force: true }));
+  await setup.store.writeFile(setup.repo, 'notes/topic.md', '# Topic\n', null);
+  const deleted = await setup.store.deleteFile(setup.repo, 'notes/topic.md');
+
+  let listTreeCalls = 0;
+  setup.store.listTree = async () => {
+    listTreeCalls += 1;
+    throw new Error('The route guard must reject internal paths before listTree.');
+  };
+  const app = createApp({ managedRepoStore: setup.store, mappings: {} });
+  const handler = getRouteHandler(app, 'get', '/api/managed-repos/:repo/tree');
+
+  for (const relativePath of [
+    setup.repo.policy.trashDirName,
+    `${setup.repo.policy.trashDirName}/${deleted.trashId}`,
+  ]) {
+    const res = createMockRes();
+    await handler({
+      params: { repo: setup.repo.id },
+      query: { path: relativePath },
+      accessContext: rootScopedViewer(setup.repo.id),
+    }, res);
+    assert.equal(res.statusCode, 404);
+    assert.deepEqual(res.body, { ok: false, error: 'Not found.' });
+    assert.equal(JSON.stringify(res.body).includes(deleted.trashId), false);
+    assert.equal(JSON.stringify(res.body).includes('metadata'), false);
+  }
+  assert.equal(listTreeCalls, 0);
+});
+
+test('unauthorized trash mutations do not read metadata or reveal existence', async (t) => {
+  const setup = await fixture();
+  t.after(() => fs.rm(setup.root, { recursive: true, force: true }));
+  await setup.store.writeFile(setup.repo, 'notes/topic.md', '# Topic\n', null);
+  const deleted = await setup.store.deleteFile(setup.repo, 'notes/topic.md');
+
+  let metadataReads = 0;
+  const originalGetTrashMetadata = setup.store.getTrashMetadata.bind(setup.store);
+  setup.store.getTrashMetadata = async (...args) => {
+    metadataReads += 1;
+    return originalGetTrashMetadata(...args);
+  };
+  const app = createApp({ managedRepoStore: setup.store, mappings: {} });
+  const missingTrashId = '00000000-0000-4000-8000-000000000000';
+
+  for (const [method, routePath] of [
+    ['post', '/api/managed-repos/:repo/trash/:trashId/restore'],
+    ['delete', '/api/managed-repos/:repo/trash/:trashId'],
+  ]) {
+    const handler = getRouteHandler(app, method, routePath);
+    const responses = [];
+    for (const trashId of [deleted.trashId, missingTrashId]) {
+      const res = createMockRes();
+      await handler({
+        params: { repo: setup.repo.id, trashId },
+        accessContext: rootScopedViewer(setup.repo.id),
+      }, res);
+      responses.push(res);
+    }
+    assert.deepEqual(
+      responses.map((res) => ({ status: res.statusCode, body: res.body })),
+      [
+        { status: 404, body: { ok: false, error: 'Not found.' } },
+        { status: 404, body: { ok: false, error: 'Not found.' } },
+      ]
+    );
+  }
+  assert.equal(metadataReads, 0);
+});

--- a/test/managed-repo-store.test.js
+++ b/test/managed-repo-store.test.js
@@ -59,6 +59,11 @@ test('managed repo store provides atomic CRUD, mtime conflicts, recovery, and bo
   const softDeleted = await setup.store.deleteFile(repo, 'notes/topic.md');
   assert.equal(softDeleted.deleted, 'soft');
   await assert.rejects(setup.store.readFile(repo, 'notes/topic.md'), { code: 'ENOENT' });
+  await assert.rejects(setup.store.listTree(repo, repo.policy.trashDirName), { code: 'ENOENT' });
+  await assert.rejects(
+    setup.store.listTree(repo, `${repo.policy.trashDirName}/${softDeleted.trashId}`),
+    { code: 'ENOENT' }
+  );
   await assert.rejects(
     setup.store.readFile(repo, `${repo.policy.trashDirName}/${softDeleted.trashId}/payload`),
     { code: 'EACCES' }

--- a/test/managed-repo-store.test.js
+++ b/test/managed-repo-store.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ManagedRepoStore } = require('../lib/managed-repo-store');
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-managed-store-'));
+  const allowed = path.join(root, 'allowed');
+  await fs.mkdir(allowed);
+  const store = new ManagedRepoStore({
+    storePath: path.join(root, 'registry.yaml'),
+    allowRoots: [allowed],
+    adminTokens: { operator: { secret: 'registry-admin-placeholder' } },
+  });
+  return { root, allowed, store };
+}
+
+test('managed repo store provides atomic CRUD, mtime conflicts, recovery, and bounded trees', async (t) => {
+  const setup = await fixture();
+  t.after(() => fs.rm(setup.root, { recursive: true, force: true }));
+
+  const { repo } = setup.store.createRepo({
+    repoId: 'shared-notes',
+    rootPath: path.join(setup.allowed, 'shared-notes'),
+  }, { tokenName: 'operator' });
+  assert.equal(repo.id, 'shared-notes');
+  assert.equal(setup.store.listRepos().repos.length, 1);
+  assert.equal(setup.store.authenticateAdminToken('registry-admin-placeholder').tokenName, 'operator');
+
+  const created = await setup.store.writeFile(repo, 'notes/topic.md', '# Topic\n', null);
+  assert.equal(created.created, true);
+  assert.equal((await setup.store.readFile(repo, 'notes/topic.md')).content, '# Topic\n');
+
+  await assert.rejects(
+    setup.store.writeFile(repo, 'notes/topic.md', '# Stale\n', created.mtimeMs - 1),
+    (error) => error.code === 'ECONFLICT' && error.current.exists === true
+  );
+  const updated = await setup.store.writeFile(repo, 'notes/topic.md', '# Updated\n', created.mtimeMs);
+  assert.equal(updated.created, false);
+  assert.equal((await fs.readdir(path.join(repo.rootPath, 'notes'))).some((name) => name.endsWith('.tmp')), false);
+
+  const concurrent = await Promise.allSettled([
+    setup.store.writeFile(repo, 'notes/topic.md', '# Writer one\n', updated.mtimeMs),
+    setup.store.writeFile(repo, 'notes/topic.md', '# Writer two\n', updated.mtimeMs),
+  ]);
+  assert.equal(concurrent.filter((result) => result.status === 'fulfilled').length, 1);
+  assert.equal(concurrent.filter((result) => result.status === 'rejected' && result.reason.code === 'ECONFLICT').length, 1);
+
+  await setup.store.writeFile(repo, 'notes/second.md', 'second\n', null);
+  const bounded = await setup.store.listTree(repo, '', { maxDepth: 10, maxEntries: 1 });
+  assert.equal(bounded.entries.length, 1);
+  assert.equal(bounded.truncated, true);
+
+  const softDeleted = await setup.store.deleteFile(repo, 'notes/topic.md');
+  assert.equal(softDeleted.deleted, 'soft');
+  await assert.rejects(setup.store.readFile(repo, 'notes/topic.md'), { code: 'ENOENT' });
+  await assert.rejects(
+    setup.store.readFile(repo, `${repo.policy.trashDirName}/${softDeleted.trashId}/payload`),
+    { code: 'EACCES' }
+  );
+  assert.deepEqual(await setup.store.restoreTrash(repo, softDeleted.trashId), {
+    path: 'notes/topic.md',
+    restored: true,
+  });
+  assert.match((await setup.store.readFile(repo, 'notes/topic.md')).content, /^# Writer (?:one|two)\n$/);
+
+  const discarded = await setup.store.deleteFile(repo, 'notes/topic.md');
+  assert.equal((await setup.store.hardDeleteTrash(repo, discarded.trashId)).deleted, 'hard');
+  await assert.rejects(setup.store.getTrashMetadata(repo, discarded.trashId), { code: 'ENOENT' });
+});
+
+test('managed repo creation rejects a symlink ancestor that escapes the allow-root', async (t) => {
+  const setup = await fixture();
+  t.after(() => fs.rm(setup.root, { recursive: true, force: true }));
+  const outside = path.join(setup.root, 'outside');
+  await fs.mkdir(outside);
+  await fs.symlink(outside, path.join(setup.allowed, 'escape'));
+
+  assert.throws(
+    () => setup.store.createRepo({
+      repoId: 'escaped-repo',
+      rootPath: path.join(setup.allowed, 'escape', 'created-outside'),
+    }),
+    (error) => error.code === 'EACCES'
+  );
+  await assert.rejects(fs.stat(path.join(outside, 'created-outside')), { code: 'ENOENT' });
+});
+
+test('managed file resolution rejects symlink escapes for reads and missing descendants', async (t) => {
+  const setup = await fixture();
+  t.after(() => fs.rm(setup.root, { recursive: true, force: true }));
+  const { repo } = setup.store.createRepo({
+    repoId: 'safe-repo',
+    rootPath: path.join(setup.allowed, 'safe-repo'),
+  });
+  const outside = path.join(setup.root, 'outside-files');
+  await fs.mkdir(outside);
+  await fs.writeFile(path.join(outside, 'secret.md'), 'not visible\n');
+  await fs.symlink(outside, path.join(repo.rootPath, 'linked'));
+
+  await assert.rejects(setup.store.readFile(repo, 'linked/secret.md'), { code: 'EACCES' });
+  await assert.rejects(setup.store.writeFile(repo, 'linked/new.md', 'escape\n'), { code: 'EACCES' });
+  await assert.rejects(fs.stat(path.join(outside, 'new.md')), { code: 'ENOENT' });
+});

--- a/test/managed-repos.test.js
+++ b/test/managed-repos.test.js
@@ -32,6 +32,11 @@ async function startFixture() {
           repos: { 'shared-notes': { paths: ['notes/'] } },
           permissions: { view: true },
         },
+        rootReader: {
+          secret: 'root-reader-placeholder',
+          repos: ['shared-notes'],
+          permissions: { view: true },
+        },
         maintainer: {
           secret: 'maintainer-placeholder',
           repos: ['shared-notes'],
@@ -143,6 +148,28 @@ test('managed repo HTTP CRUD is scoped, conflict-aware, non-leaking, and recover
   const deleted = await softDelete.json();
   assert.equal(deleted.deleted, 'soft');
 
+  for (const trashPath of [
+    '.lookie-link-trash',
+    `.lookie-link-trash/${deleted.trashId}`,
+  ]) {
+    const hiddenTree = await fixture.request(
+      `/api/managed-repos/shared-notes/tree?path=${encodeURIComponent(trashPath)}`,
+      { headers: auth('root-reader-placeholder') }
+    );
+    assert.equal(hiddenTree.status, 404);
+    const hiddenTreeText = await hiddenTree.text();
+    assert.deepEqual(JSON.parse(hiddenTreeText), { ok: false, error: 'Not found.' });
+    assert.equal(hiddenTreeText.includes(deleted.trashId), false);
+    assert.equal(hiddenTreeText.includes('metadata'), false);
+  }
+
+  const pathScopedTrashTree = await fixture.request(
+    '/api/managed-repos/shared-notes/tree?path=.lookie-link-trash',
+    { headers: auth('reader-placeholder') }
+  );
+  assert.equal(pathScopedTrashTree.status, 404);
+  assert.deepEqual(await pathScopedTrashTree.json(), { ok: false, error: 'Not found.' });
+
   const hiddenTrash = await fixture.request(`/asset/shared-notes/.lookie-link-trash/${deleted.trashId}/payload`, {
     headers: auth('maintainer-placeholder'),
   });
@@ -160,6 +187,22 @@ test('managed repo HTTP CRUD is scoped, conflict-aware, non-leaking, and recover
     headers: auth('writer-placeholder'),
   });
   const discarded = await softDeleteAgain.json();
+
+  const missingTrashId = '00000000-0000-4000-8000-000000000000';
+  for (const [method, suffix] of [['POST', '/restore'], ['DELETE', '']]) {
+    const unauthorizedExisting = await fixture.request(
+      `/api/managed-repos/shared-notes/trash/${discarded.trashId}${suffix}`,
+      { method, headers: auth('root-reader-placeholder') }
+    );
+    const unauthorizedMissing = await fixture.request(
+      `/api/managed-repos/shared-notes/trash/${missingTrashId}${suffix}`,
+      { method, headers: auth('root-reader-placeholder') }
+    );
+    assert.equal(unauthorizedExisting.status, 404);
+    assert.equal(unauthorizedMissing.status, 404);
+    assert.deepEqual(await unauthorizedExisting.json(), await unauthorizedMissing.json());
+  }
+
   const hardDeleteTrash = await fixture.request(`/api/managed-repos/shared-notes/trash/${discarded.trashId}`, {
     method: 'DELETE',
     headers: auth('writer-placeholder'),

--- a/test/managed-repos.test.js
+++ b/test/managed-repos.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createApp } = require('../server');
+
+async function startFixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-managed-http-'));
+  const allowRoot = path.join(root, 'managed');
+  await fs.mkdir(allowRoot);
+  const app = createApp({
+    mappings: {},
+    managedReposConfig: {
+      storePath: path.join(root, 'registry.yaml'),
+      allowRoots: [allowRoot],
+      adminTokens: { operator: { secret: 'managed-admin-placeholder' } },
+    },
+    accessConfig: {
+      humanDefault: 'restricted',
+      tokens: {
+        writer: {
+          secret: 'writer-placeholder',
+          repos: { 'shared-notes': { paths: ['notes/'] } },
+          permissions: { view: true, write: true },
+        },
+        reader: {
+          secret: 'reader-placeholder',
+          repos: { 'shared-notes': { paths: ['notes/'] } },
+          permissions: { view: true },
+        },
+        maintainer: {
+          secret: 'maintainer-placeholder',
+          repos: ['shared-notes'],
+          permissions: { view: true, write: true },
+        },
+      },
+    },
+  });
+  const server = await new Promise((resolve) => {
+    const listener = app.listen(0, '127.0.0.1', () => resolve(listener));
+  });
+  const address = server.address();
+  return {
+    root,
+    allowRoot,
+    async request(route, init = {}) {
+      return fetch(`http://127.0.0.1:${address.port}${route}`, init);
+    },
+    async close() {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      await fs.rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function auth(token, extras = {}) {
+  return { Authorization: `Bearer ${token}`, ...extras };
+}
+
+test('managed repo HTTP CRUD is scoped, conflict-aware, non-leaking, and recoverable', async (t) => {
+  const fixture = await startFixture();
+  t.after(() => fixture.close());
+
+  const create = await fixture.request('/api/managed-repos', {
+    method: 'POST',
+    headers: auth('managed-admin-placeholder', { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ repoId: 'shared-notes', rootPath: path.join(fixture.allowRoot, 'shared-notes') }),
+  });
+  assert.equal(create.status, 201);
+  assert.equal(Object.hasOwn((await create.json()).repo, 'rootPath'), false);
+
+  const discovery = await fixture.request('/api/repos', { headers: auth('writer-placeholder') });
+  assert.equal(discovery.status, 200);
+  assert.equal(Object.hasOwn((await discovery.json()).repos[0], 'rootPath'), false);
+
+  const write = await fixture.request('/api/managed-repos/shared-notes/files/notes/topic.md', {
+    method: 'PUT',
+    headers: auth('writer-placeholder', { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ content: '# Shared topic\n', expectedMtimeMs: null }),
+  });
+  assert.equal(write.status, 201);
+  const written = await write.json();
+
+  const hiddenWrite = await fixture.request('/api/managed-repos/shared-notes/files/private/secret.md', {
+    method: 'PUT',
+    headers: auth('maintainer-placeholder', { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ content: 'private marker\n', expectedMtimeMs: null }),
+  });
+  assert.equal(hiddenWrite.status, 201);
+
+  const forbiddenExisting = await fixture.request('/api/managed-repos/shared-notes/files/private/secret.md', {
+    headers: auth('reader-placeholder'),
+  });
+  const absent = await fixture.request('/api/managed-repos/shared-notes/files/private/absent.md', {
+    headers: auth('reader-placeholder'),
+  });
+  assert.equal(forbiddenExisting.status, 404);
+  assert.equal(absent.status, 404);
+  assert.deepEqual(await forbiddenExisting.json(), await absent.json());
+
+  const hiddenAsset = await fixture.request('/asset/shared-notes/private/secret.md', {
+    headers: auth('reader-placeholder'),
+  });
+  const absentAsset = await fixture.request('/asset/shared-notes/private/absent.md', {
+    headers: auth('reader-placeholder'),
+  });
+  assert.equal(hiddenAsset.status, 404);
+  assert.equal(absentAsset.status, 404);
+  assert.equal(await hiddenAsset.text(), await absentAsset.text());
+
+  const viewOnlyMutation = await fixture.request('/api/managed-repos/shared-notes/files/notes/topic.md', {
+    method: 'PUT',
+    headers: auth('reader-placeholder', { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ content: 'not allowed\n' }),
+  });
+  assert.equal(viewOnlyMutation.status, 404);
+
+  const stale = await fixture.request('/api/managed-repos/shared-notes/files/notes/topic.md', {
+    method: 'PUT',
+    headers: auth('writer-placeholder', { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ content: 'stale\n', expectedMtimeMs: written.mtimeMs - 1 }),
+  });
+  assert.equal(stale.status, 409);
+  assert.equal((await stale.json()).current.exists, true);
+
+  const tree = await fixture.request('/api/managed-repos/shared-notes/tree?maxEntries=50', {
+    headers: auth('reader-placeholder'),
+  });
+  assert.equal(tree.status, 200);
+  const treePayload = await tree.json();
+  assert.ok(treePayload.entries.some((entry) => entry.path === 'notes/topic.md'));
+  assert.equal(treePayload.entries.some((entry) => entry.path.includes('private')), false);
+
+  const softDelete = await fixture.request('/api/managed-repos/shared-notes/files/notes/topic.md', {
+    method: 'DELETE',
+    headers: auth('writer-placeholder'),
+  });
+  assert.equal(softDelete.status, 200);
+  const deleted = await softDelete.json();
+  assert.equal(deleted.deleted, 'soft');
+
+  const hiddenTrash = await fixture.request(`/asset/shared-notes/.lookie-link-trash/${deleted.trashId}/payload`, {
+    headers: auth('maintainer-placeholder'),
+  });
+  assert.equal(hiddenTrash.status, 404);
+
+  const restore = await fixture.request(`/api/managed-repos/shared-notes/trash/${deleted.trashId}/restore`, {
+    method: 'POST',
+    headers: auth('writer-placeholder'),
+  });
+  assert.equal(restore.status, 200);
+  assert.equal((await restore.json()).path, 'notes/topic.md');
+
+  const softDeleteAgain = await fixture.request('/api/managed-repos/shared-notes/files/notes/topic.md', {
+    method: 'DELETE',
+    headers: auth('writer-placeholder'),
+  });
+  const discarded = await softDeleteAgain.json();
+  const hardDeleteTrash = await fixture.request(`/api/managed-repos/shared-notes/trash/${discarded.trashId}`, {
+    method: 'DELETE',
+    headers: auth('writer-placeholder'),
+  });
+  assert.equal(hardDeleteTrash.status, 200);
+  assert.equal((await hardDeleteTrash.json()).deleted, 'hard');
+});

--- a/test/managed-repos.test.js
+++ b/test/managed-repos.test.js
@@ -167,3 +167,50 @@ test('managed repo HTTP CRUD is scoped, conflict-aware, non-leaking, and recover
   assert.equal(hardDeleteTrash.status, 200);
   assert.equal((await hardDeleteTrash.json()).deleted, 'hard');
 });
+
+test('search and suggest responses contain only caller-visible managed paths', async (t) => {
+  const fixture = await startFixture();
+  t.after(() => fixture.close());
+  const create = await fixture.request('/api/managed-repos', {
+    method: 'POST',
+    headers: auth('managed-admin-placeholder', { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ repoId: 'shared-notes', rootPath: path.join(fixture.allowRoot, 'shared-notes') }),
+  });
+  assert.equal(create.status, 201);
+
+  for (const [filePath, content] of [
+    ['notes/visible-topic.md', 'common scope marker in visible content\n'],
+    ['private/hidden-topic.md', 'common scope marker in private content\n'],
+  ]) {
+    const write = await fixture.request(`/api/managed-repos/shared-notes/files/${filePath}`, {
+      method: 'PUT',
+      headers: auth('maintainer-placeholder', { 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ content, expectedMtimeMs: null }),
+    });
+    assert.equal(write.status, 201);
+  }
+
+  const search = await fixture.request('/api/search?q=common%20scope%20marker&limit=10&maxEntries=50', {
+    headers: auth('reader-placeholder'),
+  });
+  assert.equal(search.status, 200);
+  const searchText = await search.text();
+  const searchPayload = JSON.parse(searchText);
+  assert.deepEqual(searchPayload.results.map((entry) => entry.path), ['notes/visible-topic.md']);
+  assert.equal(searchText.includes('hidden-topic'), false);
+  assert.equal(searchText.includes('private content'), false);
+
+  const suggest = await fixture.request('/api/search/suggest?q=topic&limit=10', {
+    headers: auth('reader-placeholder'),
+  });
+  assert.equal(suggest.status, 200);
+  const suggestText = await suggest.text();
+  assert.deepEqual(JSON.parse(suggestText).suggestions.map((entry) => entry.path), ['notes/visible-topic.md']);
+  assert.equal(suggestText.includes('hidden-topic'), false);
+
+  const excludedScope = await fixture.request('/api/search?q=common&scope=unknown-repo', {
+    headers: auth('reader-placeholder'),
+  });
+  assert.equal(excludedScope.status, 200);
+  assert.deepEqual((await excludedScope.json()).results, []);
+});

--- a/test/managed-search.test.js
+++ b/test/managed-search.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ManagedRepoStore } = require('../lib/managed-repo-store');
+const { searchManagedRepos, suggestManagedRepos } = require('../lib/managed-repo-search');
+
+test('managed search and suggestions never return out-of-scope repos or paths', async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-managed-search-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const allowed = path.join(root, 'allowed');
+  await fs.mkdir(allowed);
+  const store = new ManagedRepoStore({ storePath: path.join(root, 'registry.json'), allowRoots: [allowed] });
+  const visibleRepo = store.createRepo({ repoId: 'visible-repo', rootPath: path.join(allowed, 'visible-repo') }).repo;
+  const hiddenRepo = store.createRepo({ repoId: 'hidden-repo', rootPath: path.join(allowed, 'hidden-repo') }).repo;
+
+  await store.writeFile(visibleRepo, 'notes/shared-topic.md', 'scope marker in visible notes\n', null);
+  await store.writeFile(visibleRepo, 'private/hidden-topic.md', 'scope marker in hidden path\n', null);
+  await store.writeFile(hiddenRepo, 'notes/other-topic.md', 'scope marker in hidden repo\n', null);
+
+  const canView = (repo, relativePath, type) => {
+    if (repo !== 'visible-repo') return false;
+    if (type === 'directory') return relativePath === '' || relativePath === 'notes';
+    return relativePath.startsWith('notes/');
+  };
+  const search = await searchManagedRepos({
+    store,
+    repos: store.listRepos().repos,
+    query: 'scope marker',
+    canView,
+  });
+  assert.deepEqual(search.results.map((entry) => [entry.repo, entry.path]), [
+    ['visible-repo', 'notes/shared-topic.md'],
+  ]);
+  assert.equal(JSON.stringify(search).includes('hidden-topic'), false);
+  assert.equal(JSON.stringify(search).includes('hidden-repo'), false);
+
+  const suggestions = await suggestManagedRepos({
+    store,
+    repos: store.listRepos().repos,
+    query: 'topic',
+    canView,
+  });
+  assert.deepEqual(suggestions.suggestions.map((entry) => [entry.repo, entry.path]), [
+    ['visible-repo', 'notes/shared-topic.md'],
+  ]);
+  assert.equal(JSON.stringify(suggestions).includes('hidden-topic'), false);
+  assert.equal(JSON.stringify(suggestions).includes('hidden-repo'), false);
+});
+
+test('managed search caps results and traversal work', async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-managed-search-bounds-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const allowed = path.join(root, 'allowed');
+  await fs.mkdir(allowed);
+  const store = new ManagedRepoStore({ storePath: path.join(root, 'registry.json'), allowRoots: [allowed] });
+  const repo = store.createRepo({ repoId: 'bounded-repo', rootPath: path.join(allowed, 'bounded-repo') }).repo;
+  for (let index = 0; index < 5; index += 1) {
+    await store.writeFile(repo, `notes/match-${index}.md`, 'bounded marker\n', null);
+  }
+  const result = await searchManagedRepos({
+    store,
+    repos: [repo],
+    query: 'bounded marker',
+    limit: 2,
+    maxEntries: 3,
+    canView: () => true,
+  });
+  assert.ok(result.results.length <= 2);
+  assert.equal(result.limits.results, 2);
+  assert.equal(result.limits.entries, 3);
+  assert.equal(result.truncated, true);
+});


### PR DESCRIPTION
Part of #91 (reconciliation Step 8 — the highest-risk security port). Builds on the auth foundations (#150).

1. **File-backed managed-repo registry + CRUD**: atomic registry writes, bounded registry size, admin-header bootstrap, fail-closed validation of stored roots; managed file read + atomic create/update with per-path mutation serialization and optimistic `expectedMtimeMs` conflicts; bounded tree/change enumeration; soft delete → restore → hard delete (trash excluded from tree/search/view/asset/raw and returns uniform not-found).
2. **Scoped search + suggest**: limited to caller-visible managed repos, caller-scope traversal pruning, capped query/result/entry/per-file/aggregate work with explicit truncation metadata.

**Security** (binding, per the plan): realpath-based allow-root checks; safe creation only beneath a real existing in-policy ancestor; symlink-ancestor escape rejected (test: an allow-root child symlink to an outside dir → registering a repo below it is refused, no outside dir created); managed mutations require write capability; missing/out-of-scope paths return uniform not-found (no existence leak); search never returns out-of-scope repos/paths.

**Contract note**: `/api/repos` keeps `rootPath` for static config repos (preserving lookie-read's local-read optimization from #149) and omits it only for managed repos, whose operator-controlled host paths shouldn't leak.

Merged with current main (incl. /embed and the validator canary fix #155). Verification: 67/67 tests + `validate:raw-html` (exit 0) + `validate:editable`; added-line scan clean. **Independent security review requested before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)