### PR TITLE
fix: stop tracking node_modules symlink; harden gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 
 # Runtime / local-only artifacts
 .cache/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/tmp/claude-1000/-home-chrisfonte-operations-system/d7f48fe8-f96b-4abd-bba7-590bd54f8d96/scratchpad/lookie-forms-wave0/gh-main/node_modules


### PR DESCRIPTION
A `node_modules` **symlink** (mode 120000) pointing at an orchestrator scratch path was accidentally committed in 3ccdbe2 (a worktree `git add -A` caught it). The `.gitignore` rule `node_modules/` (trailing slash) matches only directories, so it never caught the symlink.

Impact: on any machine other than the one that authored it — a fresh clone, CI, the mac-mini-2 deployment — the symlink is broken and `require()` fails. (Tests passed on the authoring machine because the symlink target resolved there.)

Fix: `git rm --cached node_modules` + change the ignore rule to bare `node_modules` (matches dir, file, or symlink). Verified: a fresh `git clone` has zero tracked node_modules, no symlink, and passes 95/95 after a normal `npm install`. Surfaced while deploying the reconciled baseline to the live instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)