### PR TITLE
feat(forms): schema validator + canonical serializer with reproducible digest

### DIFF
--- a/lib/forms/canonical.js
+++ b/lib/forms/canonical.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const crypto = require('node:crypto');
+
+function compareCodePoints(left, right) {
+  const leftPoints = [...left].map((character) => character.codePointAt(0));
+  const rightPoints = [...right].map((character) => character.codePointAt(0));
+  const length = Math.min(leftPoints.length, rightPoints.length);
+  for (let index = 0; index < length; index += 1) {
+    if (leftPoints[index] !== rightPoints[index]) return leftPoints[index] - rightPoints[index];
+  }
+  return leftPoints.length - rightPoints.length;
+}
+
+function normalizeString(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) throw new TypeError('unpaired Unicode surrogate');
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new TypeError('unpaired Unicode surrogate');
+    }
+  }
+  return value.normalize('NFC');
+}
+
+function quoteString(value) {
+  let result = '"';
+  for (const character of normalizeString(value)) {
+    const codePoint = character.codePointAt(0);
+    if (character === '"') result += '\\"';
+    else if (character === '\\') result += '\\\\';
+    else if (character === '\b') result += '\\b';
+    else if (character === '\t') result += '\\t';
+    else if (character === '\n') result += '\\n';
+    else if (character === '\f') result += '\\f';
+    else if (character === '\r') result += '\\r';
+    else if (codePoint <= 0x1f) result += `\\u${codePoint.toString(16).padStart(4, '0')}`;
+    else result += character;
+  }
+  return `${result}"`;
+}
+
+function serialize(value, ancestors) {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return quoteString(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('canonical numbers must be finite');
+    if (Object.is(value, -0)) throw new TypeError('canonical numbers must not be negative zero');
+    return String(value);
+  }
+  if (typeof value !== 'object') throw new TypeError(`unsupported canonical value type: ${typeof value}`);
+  if (ancestors.has(value)) throw new TypeError('canonical values must not contain cycles');
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index += 1) {
+        if (!Object.prototype.hasOwnProperty.call(value, index)) throw new TypeError('canonical arrays must not be sparse');
+      }
+      return `[${value.map((entry) => serialize(entry, ancestors)).join(',')}]`;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) throw new TypeError('canonical objects must be plain objects');
+    if (Object.getOwnPropertySymbols(value).length > 0) throw new TypeError('canonical objects must not have symbol keys');
+    const entries = [];
+    const normalizedKeys = new Set();
+    for (const key of Object.keys(value)) {
+      const normalizedKey = normalizeString(key);
+      if (normalizedKeys.has(normalizedKey)) throw new TypeError('object keys must be unique after normalization');
+      normalizedKeys.add(normalizedKey);
+      entries.push([normalizedKey, value[key]]);
+    }
+    entries.sort(([left], [right]) => compareCodePoints(left, right));
+    return `{${entries.map(([key, entry]) => `${quoteString(key)}:${serialize(entry, ancestors)}`).join(',')}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function canonicalize(value) {
+  return `${serialize(value, new Set())}\n`;
+}
+
+function schemaDigest(template) {
+  if (template === null || typeof template !== 'object' || Array.isArray(template)) {
+    throw new TypeError('template must be an object');
+  }
+  const schema = {
+    grammarVersion: template.grammarVersion,
+    fields: template.fields,
+  };
+  return crypto.createHash('sha256').update(canonicalize(schema), 'utf8').digest('hex');
+}
+
+module.exports = {
+  canonicalize,
+  schemaDigest,
+};

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -1,0 +1,445 @@
+'use strict';
+
+const FIELD_TYPES = new Set([
+  'short-text',
+  'long-text',
+  'number',
+  'checkbox',
+  'date',
+  'time',
+  'datetime',
+  'select',
+  'multi-select',
+]);
+
+const DEFINITION_ID = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const TIME = /^(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/;
+const DATETIME = /^(\d{4})-(\d{2})-(\d{2})T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
+const CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/u;
+
+const TEMPLATE_KEYS = new Set([
+  'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision',
+  'grammarVersion', 'title', 'description', 'tags', 'lineage',
+  'presentation', 'fields',
+]);
+const FIELD_KEYS = new Set([
+  'id', 'type', 'label', 'help', 'required', 'default', 'component',
+  'constraints', 'options', 'providerSlot',
+]);
+const OPTION_KEYS = new Set(['id', 'label', 'disabled']);
+const CONSTRAINT_KEYS = {
+  'short-text': new Set(['minLength', 'maxLength']),
+  'long-text': new Set(['minLength', 'maxLength']),
+  number: new Set(['minimum', 'maximum', 'integer']),
+  checkbox: new Set(),
+  date: new Set(['minimum', 'maximum']),
+  time: new Set(),
+  datetime: new Set(['minimum', 'maximum']),
+  select: new Set(),
+  'multi-select': new Set(['minSelections', 'maxSelections']),
+};
+
+function isRecord(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function own(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function addError(errors, path, message) {
+  errors.push({path, message});
+}
+
+function rejectUnknownKeys(value, allowed, path, errors) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) addError(errors, path ? `${path}.${key}` : key, 'unknown property');
+  }
+}
+
+function normalizedText(value) {
+  return value.replace(/\r\n?/g, '\n').normalize('NFC');
+}
+
+function hasUnpairedSurrogate(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return true;
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function validateText(value, path, errors, {minimum = 0, maximum, requiredContent = false} = {}) {
+  if (typeof value !== 'string') {
+    addError(errors, path, 'must be a string');
+    return null;
+  }
+  if (hasUnpairedSurrogate(value)) addError(errors, path, 'contains an unpaired Unicode surrogate');
+  const normalized = normalizedText(value);
+  if (CONTROL_CHARACTER.test(normalized)) addError(errors, path, 'contains a prohibited control character');
+  const length = [...normalized].length;
+  if (length < minimum) addError(errors, path, `must contain at least ${minimum} Unicode code points`);
+  if (length > maximum) addError(errors, path, `must contain at most ${maximum} Unicode code points`);
+  if (requiredContent && !/\S/u.test(normalized)) addError(errors, path, 'must contain a non-whitespace character');
+  return normalized;
+}
+
+function validateId(value, path, errors) {
+  if (typeof value !== 'string' || value.length > 64 || !DEFINITION_ID.test(value)) {
+    addError(errors, path, 'must be a definition ID');
+    return false;
+  }
+  return true;
+}
+
+function validateInteger(value, path, errors, minimum, maximum) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    addError(errors, path, `must be an integer from ${minimum} through ${maximum}`);
+    return false;
+  }
+  return true;
+}
+
+function validateDate(value, path, errors) {
+  if (typeof value !== 'string') {
+    addError(errors, path, 'must be a date string');
+    return false;
+  }
+  const match = DATE.exec(value);
+  if (!match) {
+    addError(errors, path, 'must use YYYY-MM-DD format');
+    return false;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const probe = new Date(0);
+  probe.setUTCFullYear(year, month - 1, day);
+  probe.setUTCHours(0, 0, 0, 0);
+  if (probe.getUTCFullYear() !== year || probe.getUTCMonth() !== month - 1 || probe.getUTCDate() !== day) {
+    addError(errors, path, 'must represent a real calendar date');
+    return false;
+  }
+  return true;
+}
+
+function validateDatetime(value, path, errors) {
+  if (typeof value !== 'string' || !DATETIME.test(value)) {
+    addError(errors, path, 'must be an RFC 3339 timestamp with an explicit offset');
+    return false;
+  }
+  const datePart = value.slice(0, 10);
+  if (!validateDate(datePart, path, errors)) return false;
+  if (!Number.isFinite(Date.parse(value))) {
+    addError(errors, path, 'must represent a valid RFC 3339 instant');
+    return false;
+  }
+  return true;
+}
+
+function validateConstraintBoundPair(constraints, path, errors, compare = (a, b) => a > b) {
+  if (own(constraints, 'minimum') && own(constraints, 'maximum') &&
+      compare(constraints.minimum, constraints.maximum)) {
+    addError(errors, `${path}.minimum`, 'must not exceed maximum');
+  }
+}
+
+function validateConstraints(field, path, errors) {
+  if (!own(field, 'constraints')) return;
+  const constraintsPath = `${path}.constraints`;
+  if (!isRecord(field.constraints)) {
+    addError(errors, constraintsPath, 'must be an object');
+    return;
+  }
+  const allowed = CONSTRAINT_KEYS[field.type] || new Set();
+  rejectUnknownKeys(field.constraints, allowed, constraintsPath, errors);
+  const constraints = field.constraints;
+
+  if (field.type === 'short-text' || field.type === 'long-text') {
+    const ceiling = field.type === 'short-text' ? 256 : 10000;
+    if (own(constraints, 'minLength')) validateInteger(constraints.minLength, `${constraintsPath}.minLength`, errors, 0, ceiling);
+    if (own(constraints, 'maxLength')) validateInteger(constraints.maxLength, `${constraintsPath}.maxLength`, errors, 1, ceiling);
+    if (Number.isInteger(constraints.minLength) && Number.isInteger(constraints.maxLength) &&
+        constraints.minLength > constraints.maxLength) {
+      addError(errors, `${constraintsPath}.minLength`, 'must not exceed maxLength');
+    }
+  } else if (field.type === 'number') {
+    for (const key of ['minimum', 'maximum']) {
+      if (own(constraints, key) && (typeof constraints[key] !== 'number' || !Number.isFinite(constraints[key]) || Object.is(constraints[key], -0))) {
+        addError(errors, `${constraintsPath}.${key}`, 'must be a finite JSON number other than negative zero');
+      }
+    }
+    if (own(constraints, 'integer') && typeof constraints.integer !== 'boolean') {
+      addError(errors, `${constraintsPath}.integer`, 'must be a boolean');
+    }
+    if (Number.isFinite(constraints.minimum) && Number.isFinite(constraints.maximum)) {
+      validateConstraintBoundPair(constraints, constraintsPath, errors);
+    }
+  } else if (field.type === 'date') {
+    for (const key of ['minimum', 'maximum']) {
+      if (own(constraints, key)) validateDate(constraints[key], `${constraintsPath}.${key}`, errors);
+    }
+    if (DATE.test(constraints.minimum || '') && DATE.test(constraints.maximum || '')) {
+      validateConstraintBoundPair(constraints, constraintsPath, errors);
+    }
+  } else if (field.type === 'datetime') {
+    for (const key of ['minimum', 'maximum']) {
+      if (own(constraints, key)) validateDatetime(constraints[key], `${constraintsPath}.${key}`, errors);
+    }
+    if (DATETIME.test(constraints.minimum || '') && DATETIME.test(constraints.maximum || '')) {
+      validateConstraintBoundPair(constraints, constraintsPath, errors, (a, b) => Date.parse(a) > Date.parse(b));
+    }
+  } else if (field.type === 'multi-select') {
+    for (const key of ['minSelections', 'maxSelections']) {
+      if (own(constraints, key)) validateInteger(constraints[key], `${constraintsPath}.${key}`, errors, 0, 1000);
+    }
+    if (Number.isInteger(constraints.minSelections) && Number.isInteger(constraints.maxSelections) &&
+        constraints.minSelections > constraints.maxSelections) {
+      addError(errors, `${constraintsPath}.minSelections`, 'must not exceed maxSelections');
+    }
+  }
+}
+
+function validateOptions(field, path, errors) {
+  const isSelection = field.type === 'select' || field.type === 'multi-select';
+  const hasOptions = own(field, 'options');
+  const hasProvider = own(field, 'providerSlot');
+  if (!isSelection) {
+    if (hasOptions) addError(errors, `${path}.options`, 'is allowed only for selection fields');
+    if (hasProvider) addError(errors, `${path}.providerSlot`, 'is allowed only for selection fields');
+    return;
+  }
+  if (hasOptions === hasProvider) {
+    addError(errors, hasOptions ? `${path}.providerSlot` : `${path}.options`, 'exactly one option source is required');
+  }
+  if (hasProvider) validateId(field.providerSlot, `${path}.providerSlot`, errors);
+  if (!hasOptions) return;
+  if (!Array.isArray(field.options) || field.options.length < 1 || field.options.length > 1000) {
+    addError(errors, `${path}.options`, 'must be an array containing 1 through 1000 options');
+    return;
+  }
+  const ids = new Set();
+  field.options.forEach((option, index) => {
+    const optionPath = `${path}.options[${index}]`;
+    if (!isRecord(option)) {
+      addError(errors, optionPath, 'must be an object');
+      return;
+    }
+    rejectUnknownKeys(option, OPTION_KEYS, optionPath, errors);
+    if (!own(option, 'id')) addError(errors, `${optionPath}.id`, 'is required');
+    else if (validateId(option.id, `${optionPath}.id`, errors)) {
+      if (ids.has(option.id)) addError(errors, `${optionPath}.id`, 'must be unique within the field');
+      ids.add(option.id);
+    }
+    if (!own(option, 'label')) addError(errors, `${optionPath}.label`, 'is required');
+    else validateText(option.label, `${optionPath}.label`, errors, {minimum: 1, maximum: 200});
+    if (own(option, 'disabled') && typeof option.disabled !== 'boolean') {
+      addError(errors, `${optionPath}.disabled`, 'must be a boolean');
+    }
+  });
+}
+
+function valueForField(field, value, path, errors) {
+  const constraints = isRecord(field.constraints) ? field.constraints : {};
+  if (field.type === 'short-text' || field.type === 'long-text') {
+    const ceiling = field.type === 'short-text' ? 256 : 10000;
+    const normalized = validateText(value, path, errors, {
+      minimum: constraints.minLength ?? 0,
+      maximum: constraints.maxLength ?? ceiling,
+      requiredContent: field.required,
+    });
+    return normalized;
+  }
+  if (field.type === 'number') {
+    if (typeof value !== 'number' || !Number.isFinite(value) || Object.is(value, -0)) {
+      addError(errors, path, 'must be a finite JSON number other than negative zero');
+      return value;
+    }
+    if (constraints.integer && (!Number.isSafeInteger(value))) addError(errors, path, 'must be a safe integer');
+    if (typeof constraints.minimum === 'number' && value < constraints.minimum) addError(errors, path, 'must be at least minimum');
+    if (typeof constraints.maximum === 'number' && value > constraints.maximum) addError(errors, path, 'must be at most maximum');
+    return value;
+  }
+  if (field.type === 'checkbox') {
+    if (typeof value !== 'boolean') addError(errors, path, 'must be a boolean');
+    return value;
+  }
+  if (field.type === 'date') {
+    if (validateDate(value, path, errors)) {
+      if (typeof constraints.minimum === 'string' && value < constraints.minimum) addError(errors, path, 'must be on or after minimum');
+      if (typeof constraints.maximum === 'string' && value > constraints.maximum) addError(errors, path, 'must be on or before maximum');
+    }
+    return value;
+  }
+  if (field.type === 'time') {
+    if (typeof value !== 'string' || !TIME.test(value)) addError(errors, path, 'must be HH:MM or HH:MM:SS in 24-hour time');
+    return value;
+  }
+  if (field.type === 'datetime') {
+    if (validateDatetime(value, path, errors)) {
+      const instant = Date.parse(value);
+      if (typeof constraints.minimum === 'string' && instant < Date.parse(constraints.minimum)) addError(errors, path, 'must be at or after minimum');
+      if (typeof constraints.maximum === 'string' && instant > Date.parse(constraints.maximum)) addError(errors, path, 'must be at or before maximum');
+    }
+    return value;
+  }
+  if (field.type === 'select') {
+    if (!validateId(value, path, errors)) return value;
+    if (Array.isArray(field.options)) {
+      const option = field.options.find((entry) => isRecord(entry) && entry.id === value);
+      if (!option) addError(errors, path, 'must identify one declared option');
+      else if (option.disabled) addError(errors, path, 'must not identify a disabled option');
+    }
+    return value;
+  }
+  if (field.type === 'multi-select') {
+    if (!Array.isArray(value)) {
+      addError(errors, path, 'must be an ordered option-ID array');
+      return value;
+    }
+    const seen = new Set();
+    const optionMap = new Map(Array.isArray(field.options) ? field.options.map((option) => [option.id, option]) : []);
+    value.forEach((id, index) => {
+      const itemPath = `${path}[${index}]`;
+      if (!validateId(id, itemPath, errors)) return;
+      if (seen.has(id)) addError(errors, itemPath, 'must not duplicate a selection');
+      seen.add(id);
+      if (Array.isArray(field.options)) {
+        const option = optionMap.get(id);
+        if (!option) addError(errors, itemPath, 'must identify a declared option');
+        else if (option.disabled) addError(errors, itemPath, 'must not identify a disabled option');
+      }
+    });
+    if (Number.isInteger(constraints.minSelections) && value.length < constraints.minSelections) addError(errors, path, 'contains fewer than minSelections');
+    if (Number.isInteger(constraints.maxSelections) && value.length > constraints.maxSelections) addError(errors, path, 'contains more than maxSelections');
+    return value.slice();
+  }
+  return value;
+}
+
+function validateField(field, index, errors) {
+  const path = `fields[${index}]`;
+  if (!isRecord(field)) {
+    addError(errors, path, 'must be an object');
+    return;
+  }
+  rejectUnknownKeys(field, FIELD_KEYS, path, errors);
+  for (const key of ['id', 'type', 'label', 'required']) {
+    if (!own(field, key)) addError(errors, `${path}.${key}`, 'is required');
+  }
+  if (own(field, 'id')) validateId(field.id, `${path}.id`, errors);
+  if (own(field, 'type') && !FIELD_TYPES.has(field.type)) addError(errors, `${path}.type`, 'is not a supported field type');
+  if (own(field, 'label')) validateText(field.label, `${path}.label`, errors, {minimum: 1, maximum: 200});
+  if (own(field, 'help')) validateText(field.help, `${path}.help`, errors, {minimum: 1, maximum: 1000});
+  if (own(field, 'required') && typeof field.required !== 'boolean') addError(errors, `${path}.required`, 'must be a boolean');
+  if (own(field, 'component')) validateId(field.component, `${path}.component`, errors);
+  validateConstraints(field, path, errors);
+  validateOptions(field, path, errors);
+  if (own(field, 'default')) {
+    if (own(field, 'providerSlot')) addError(errors, `${path}.default`, 'is prohibited with a dynamic option provider');
+    if (FIELD_TYPES.has(field.type)) valueForField(field, field.default, `${path}.default`, errors);
+  }
+}
+
+function validateLineage(lineage, errors) {
+  if (!isRecord(lineage)) {
+    addError(errors, 'lineage', 'must be an object');
+    return;
+  }
+  rejectUnknownKeys(lineage, new Set(['relation', 'templateId', 'templateVersion']), 'lineage', errors);
+  if (lineage.relation !== 'clone' && lineage.relation !== 'fork') addError(errors, 'lineage.relation', 'must be clone or fork');
+  if (!own(lineage, 'templateId')) addError(errors, 'lineage.templateId', 'is required');
+  else validateId(lineage.templateId, 'lineage.templateId', errors);
+  if (own(lineage, 'templateVersion')) validateInteger(lineage.templateVersion, 'lineage.templateVersion', errors, 1, Number.MAX_SAFE_INTEGER);
+}
+
+function validatePresentation(presentation, errors) {
+  if (!isRecord(presentation)) {
+    addError(errors, 'presentation', 'must be an object');
+    return;
+  }
+  rejectUnknownKeys(presentation, new Set(['submitLabel', 'component']), 'presentation', errors);
+  if (own(presentation, 'submitLabel')) validateText(presentation.submitLabel, 'presentation.submitLabel', errors, {minimum: 1, maximum: 80});
+  if (own(presentation, 'component')) validateId(presentation.component, 'presentation.component', errors);
+}
+
+function validateTemplate(doc) {
+  const errors = [];
+  if (!isRecord(doc)) return {valid: false, errors: [{path: '', message: 'template must be an object'}]};
+  rejectUnknownKeys(doc, TEMPLATE_KEYS, '', errors);
+  const required = ['contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision', 'grammarVersion', 'title', 'fields'];
+  for (const key of required) if (!own(doc, key)) addError(errors, key, 'is required');
+  if (own(doc, 'contractVersion') && doc.contractVersion !== 1) addError(errors, 'contractVersion', 'must equal 1');
+  if (own(doc, 'resourceKind') && doc.resourceKind !== 'form-template') addError(errors, 'resourceKind', 'must equal form-template');
+  if (own(doc, 'templateId')) validateId(doc.templateId, 'templateId', errors);
+  if (own(doc, 'ownerId')) validateId(doc.ownerId, 'ownerId', errors);
+  if (own(doc, 'revision')) validateInteger(doc.revision, 'revision', errors, 1, Number.MAX_SAFE_INTEGER);
+  if (own(doc, 'grammarVersion') && doc.grammarVersion !== 1) addError(errors, 'grammarVersion', 'must equal 1');
+  if (own(doc, 'title')) validateText(doc.title, 'title', errors, {minimum: 1, maximum: 200});
+  if (own(doc, 'description')) validateText(doc.description, 'description', errors, {maximum: 2000});
+  if (own(doc, 'tags')) {
+    if (!Array.isArray(doc.tags) || doc.tags.length > 32) addError(errors, 'tags', 'must be an array of at most 32 definition IDs');
+    else {
+      doc.tags.forEach((tag, index) => validateId(tag, `tags[${index}]`, errors));
+      for (let index = 1; index < doc.tags.length; index += 1) {
+        if (doc.tags[index - 1] >= doc.tags[index]) addError(errors, `tags[${index}]`, 'must be unique and lexicographically sorted');
+      }
+    }
+  }
+  if (own(doc, 'lineage')) validateLineage(doc.lineage, errors);
+  if (own(doc, 'presentation')) validatePresentation(doc.presentation, errors);
+  if (!Array.isArray(doc.fields) || doc.fields.length < 1 || doc.fields.length > 200) {
+    if (own(doc, 'fields')) addError(errors, 'fields', 'must be an array containing 1 through 200 fields');
+  } else {
+    const ids = new Set();
+    doc.fields.forEach((field, index) => {
+      validateField(field, index, errors);
+      if (isRecord(field) && typeof field.id === 'string') {
+        if (ids.has(field.id)) addError(errors, `fields[${index}].id`, 'must be unique within the template');
+        ids.add(field.id);
+      }
+    });
+  }
+  return {valid: errors.length === 0, errors};
+}
+
+function validateSubmissionValues(template, values) {
+  const errors = [];
+  const normalized = {};
+  const templateResult = validateTemplate(template);
+  if (!templateResult.valid) {
+    return {
+      valid: false,
+      errors: templateResult.errors.map((error) => ({path: `template${error.path ? `.${error.path}` : ''}`, message: error.message})),
+      normalized,
+    };
+  }
+  if (!isRecord(values)) return {valid: false, errors: [{path: 'values', message: 'must be an object'}], normalized};
+  const fields = new Map(template.fields.map((field) => [field.id, field]));
+  for (const key of Object.keys(values)) {
+    if (!fields.has(key)) addError(errors, `values.${key}`, 'does not identify a template field');
+  }
+  for (const field of template.fields) {
+    const path = `values.${field.id}`;
+    if (!own(values, field.id)) {
+      if (field.required) addError(errors, path, 'is required');
+      continue;
+    }
+    normalized[field.id] = valueForField(field, values[field.id], path, errors);
+  }
+  return {valid: errors.length === 0, errors, normalized};
+}
+
+module.exports = {
+  validateTemplate,
+  validateSubmissionValues,
+};

--- a/test/forms-canonical.test.js
+++ b/test/forms-canonical.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const yaml = require('js-yaml');
+
+const {canonicalize, schemaDigest} = require('../lib/forms/canonical');
+
+test('canonical JSON has code-point key order, exact escaping, NFC, LF, and one final newline', () => {
+  const value = {
+    '\ue000': 'private',
+    '\ud83d\ude00': 'astral',
+    z: 'Cafe\u0301\r\n\b\t\f\u0001/\\"',
+    a: true,
+  };
+  assert.equal(
+    canonicalize(value),
+    '{"a":true,"z":"Caf\u00e9\\r\\n\\b\\t\\f\\u0001/\\\\\\"","\ue000":"private","\ud83d\ude00":"astral"}\n',
+  );
+});
+
+test('canonical numbers use binary64 shortest-round-trip spellings', () => {
+  assert.equal(
+    canonicalize([1, 1e-7, 1e-6, 1e20, 1e21, 333333333.33333329]),
+    '[1,1e-7,0.000001,100000000000000000000,1e+21,333333333.3333333]\n',
+  );
+});
+
+test('canonicalization rejects non-finite numbers, negative zero, invalid Unicode, and non-JSON structures', () => {
+  for (const value of [NaN, Infinity, -Infinity, -0]) {
+    assert.throws(() => canonicalize(value), TypeError);
+  }
+  assert.throws(() => canonicalize('\ud800'), /surrogate/);
+  assert.throws(() => canonicalize({a: undefined}), /unsupported/);
+  assert.throws(() => canonicalize(new Date()), /plain objects/);
+  const sparse = [];
+  sparse[1] = true;
+  assert.throws(() => canonicalize(sparse), /sparse/);
+});
+
+test('object keys that collide after Unicode normalization are rejected', () => {
+  assert.throws(() => canonicalize({'\u00e9': 1, 'e\u0301': 2}), /unique after normalization/);
+});
+
+test('equivalent YAML and JSON templates have the same schema digest', () => {
+  const yamlTemplate = yaml.load(`
+contractVersion: 1
+resourceKind: form-template
+templateId: example
+ownerId: operator
+revision: 1
+grammarVersion: 1
+title: Example
+fields:
+  - id: count
+    type: number
+    label: Count
+    required: true
+    constraints:
+      integer: true
+      minimum: 1.0
+      maximum: 1e2
+  - id: mood
+    type: select
+    label: Mood
+    required: false
+    options:
+      - id: calm
+        label: Calm
+      - id: energized
+        label: Energized
+`, {schema: yaml.JSON_SCHEMA});
+  const jsonTemplate = JSON.parse(`{
+    "fields": [
+      {"constraints":{"maximum":100,"minimum":1,"integer":true},"required":true,"label":"Count","type":"number","id":"count"},
+      {"options":[{"label":"Calm","id":"calm"},{"label":"Energized","id":"energized"}],"required":false,"label":"Mood","type":"select","id":"mood"}
+    ],
+    "title":"Different human title does not affect the schema",
+    "grammarVersion":1,
+    "revision":9,
+    "ownerId":"operator",
+    "templateId":"example",
+    "resourceKind":"form-template",
+    "contractVersion":1
+  }`);
+  const yamlDigest = schemaDigest(yamlTemplate);
+  assert.match(yamlDigest, /^[0-9a-f]{64}$/);
+  assert.equal(yamlDigest, schemaDigest(jsonTemplate));
+
+  const changed = structuredClone(jsonTemplate);
+  changed.fields[0].constraints.maximum = 101;
+  assert.notEqual(schemaDigest(changed), yamlDigest);
+});
+
+test('schema digest includes the canonical terminal newline and only grammarVersion plus fields', () => {
+  const template = {grammarVersion: 1, fields: []};
+  const crypto = require('node:crypto');
+  const expected = crypto.createHash('sha256')
+    .update('{"fields":[],"grammarVersion":1}\n', 'utf8')
+    .digest('hex');
+  assert.equal(schemaDigest(template), expected);
+  assert.equal(schemaDigest({...template, title: 'Ignored'}), expected);
+});

--- a/test/forms-schema.test.js
+++ b/test/forms-schema.test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {validateTemplate, validateSubmissionValues} = require('../lib/forms/schema');
+
+function templateWith(fields) {
+  return {
+    contractVersion: 1,
+    resourceKind: 'form-template',
+    templateId: 'activity-log',
+    ownerId: 'operator',
+    revision: 1,
+    grammarVersion: 1,
+    title: 'Activity log',
+    fields,
+  };
+}
+
+function field(id, type, extra = {}) {
+  return {id, type, label: id, required: true, ...extra};
+}
+
+function paths(result) {
+  return result.errors.map((error) => error.path);
+}
+
+const everyTypeTemplate = templateWith([
+  field('summary', 'short-text', {constraints: {minLength: 2, maxLength: 40}, default: 'Warm up'}),
+  field('notes', 'long-text', {required: false, constraints: {minLength: 0, maxLength: 1000}}),
+  field('repetitions', 'number', {constraints: {minimum: 1, maximum: 100, integer: true}, default: 8}),
+  field('completed', 'checkbox', {default: false}),
+  field('activity-date', 'date', {constraints: {minimum: '2020-01-01', maximum: '2030-12-31'}}),
+  field('activity-time', 'time'),
+  field('recorded-at', 'datetime', {constraints: {minimum: '2020-01-01T00:00:00Z', maximum: '2030-12-31T23:59:59+00:00'}}),
+  field('effort', 'select', {options: [{id: 'easy', label: 'Easy'}, {id: 'hard', label: 'Hard'}]}),
+  field('muscles', 'multi-select', {
+    constraints: {minSelections: 1, maxSelections: 2},
+    options: [{id: 'legs', label: 'Legs'}, {id: 'core', label: 'Core'}, {id: 'arms', label: 'Arms'}],
+  }),
+]);
+
+test('a template and submission covering every field type validate', () => {
+  assert.deepEqual(validateTemplate(everyTypeTemplate), {valid: true, errors: []});
+  const result = validateSubmissionValues(everyTypeTemplate, {
+    summary: 'Cafe\u0301\r\nwork',
+    notes: 'steady',
+    repetitions: 12,
+    completed: false,
+    'activity-date': '2026-07-20',
+    'activity-time': '08:15:30',
+    'recorded-at': '2026-07-20T08:15:30-04:00',
+    effort: 'hard',
+    muscles: ['legs', 'core'],
+  });
+  assert.equal(result.valid, true);
+  assert.equal(result.normalized.summary, 'Caf\u00e9\nwork');
+  assert.deepEqual(result.normalized.muscles, ['legs', 'core']);
+});
+
+test('unknown template and field keys report their exact paths', () => {
+  const unknownRoot = {...everyTypeTemplate, surprise: true};
+  assert.ok(paths(validateTemplate(unknownRoot)).includes('surprise'));
+
+  const fields = structuredClone(everyTypeTemplate.fields);
+  fields[2].surprise = true;
+  assert.ok(paths(validateTemplate(templateWith(fields))).includes('fields[2].surprise'));
+});
+
+test('unknown field types and duplicate field and option IDs are rejected', () => {
+  const fields = [
+    field('same', 'mystery'),
+    field('same', 'select', {options: [{id: 'one', label: 'One'}, {id: 'one', label: 'Again'}]}),
+  ];
+  const result = validateTemplate(templateWith(fields));
+  assert.ok(paths(result).includes('fields[0].type'));
+  assert.ok(paths(result).includes('fields[1].id'));
+  assert.ok(paths(result).includes('fields[1].options[1].id'));
+});
+
+test('field and constraint allowlists are type-specific', () => {
+  const fields = [field('enabled', 'checkbox', {constraints: {minimum: 1}})];
+  const result = validateTemplate(templateWith(fields));
+  assert.ok(paths(result).includes('fields[0].constraints.minimum'));
+});
+
+test('invalid constraint declarations report the individual constraint paths', () => {
+  const cases = [
+    [field('text', 'short-text', {constraints: {minLength: -1}}), 'fields[0].constraints.minLength'],
+    [field('text', 'long-text', {constraints: {maxLength: 10001}}), 'fields[0].constraints.maxLength'],
+    [field('text', 'short-text', {constraints: {minLength: 3, maxLength: 2}}), 'fields[0].constraints.minLength'],
+    [field('count', 'number', {constraints: {minimum: NaN}}), 'fields[0].constraints.minimum'],
+    [field('count', 'number', {constraints: {maximum: Infinity}}), 'fields[0].constraints.maximum'],
+    [field('count', 'number', {constraints: {integer: 'yes'}}), 'fields[0].constraints.integer'],
+    [field('day', 'date', {constraints: {minimum: '2026-02-30'}}), 'fields[0].constraints.minimum'],
+    [field('day', 'date', {constraints: {minimum: '2027-01-01', maximum: '2026-01-01'}}), 'fields[0].constraints.minimum'],
+    [field('instant', 'datetime', {constraints: {minimum: '2026-01-01T00:00:00'}}), 'fields[0].constraints.minimum'],
+    [field('items', 'multi-select', {constraints: {minSelections: -1}, options: [{id: 'one', label: 'One'}]}), 'fields[0].constraints.minSelections'],
+    [field('items', 'multi-select', {constraints: {maxSelections: 1001}, options: [{id: 'one', label: 'One'}]}), 'fields[0].constraints.maxSelections'],
+    [field('items', 'multi-select', {constraints: {minSelections: 2, maxSelections: 1}, options: [{id: 'one', label: 'One'}]}), 'fields[0].constraints.minSelections'],
+  ];
+  for (const [candidate, expectedPath] of cases) {
+    assert.ok(paths(validateTemplate(templateWith([candidate]))).includes(expectedPath), expectedPath);
+  }
+});
+
+test('defaults use submission validation and dynamic selection defaults are prohibited', () => {
+  const invalidNumber = validateTemplate(templateWith([
+    field('count', 'number', {constraints: {integer: true}, default: 1.5}),
+  ]));
+  assert.ok(paths(invalidNumber).includes('fields[0].default'));
+
+  const dynamic = validateTemplate(templateWith([
+    field('choice', 'select', {providerSlot: 'catalog', default: 'one'}),
+  ]));
+  assert.ok(paths(dynamic).includes('fields[0].default'));
+});
+
+test('submission values reject every type constraint with exact value paths', () => {
+  const valid = {
+    summary: 'okay',
+    repetitions: 2,
+    completed: true,
+    'activity-date': '2026-01-01',
+    'activity-time': '10:30',
+    'recorded-at': '2026-01-01T10:30:00Z',
+    effort: 'easy',
+    muscles: ['legs'],
+  };
+  const cases = [
+    [{...valid, summary: 'x'}, 'values.summary'],
+    [{...valid, summary: 'x'.repeat(41)}, 'values.summary'],
+    [{...valid, repetitions: 0}, 'values.repetitions'],
+    [{...valid, repetitions: 101}, 'values.repetitions'],
+    [{...valid, repetitions: 1.5}, 'values.repetitions'],
+    [{...valid, completed: 1}, 'values.completed'],
+    [{...valid, 'activity-date': '2026-02-30'}, 'values.activity-date'],
+    [{...valid, 'activity-time': '24:00'}, 'values.activity-time'],
+    [{...valid, 'recorded-at': '2026-01-01T10:30:00'}, 'values.recorded-at'],
+    [{...valid, effort: 'unknown'}, 'values.effort'],
+    [{...valid, muscles: []}, 'values.muscles'],
+    [{...valid, muscles: ['legs', 'core', 'arms']}, 'values.muscles'],
+  ];
+  for (const [values, expectedPath] of cases) {
+    assert.ok(paths(validateSubmissionValues(everyTypeTemplate, values)).includes(expectedPath), expectedPath);
+  }
+});
+
+test('negative number and multi-select canaries are rejected', () => {
+  for (const invalid of [NaN, Infinity, -Infinity]) {
+    const result = validateSubmissionValues(everyTypeTemplate, {
+      summary: 'okay', repetitions: invalid, completed: true,
+      'activity-date': '2026-01-01', 'activity-time': '10:30',
+      'recorded-at': '2026-01-01T10:30:00Z', effort: 'easy', muscles: ['legs'],
+    });
+    assert.ok(paths(result).includes('values.repetitions'));
+  }
+  const duplicate = validateSubmissionValues(everyTypeTemplate, {
+    summary: 'okay', repetitions: 2, completed: true,
+    'activity-date': '2026-01-01', 'activity-time': '10:30',
+    'recorded-at': '2026-01-01T10:30:00Z', effort: 'easy', muscles: ['legs', 'legs'],
+  });
+  assert.ok(paths(duplicate).includes('values.muscles[1]'));
+});
+
+test('missing required and unknown submitted values are rejected without applying defaults', () => {
+  const result = validateSubmissionValues(everyTypeTemplate, {unknown: true});
+  assert.ok(paths(result).includes('values.unknown'));
+  assert.ok(paths(result).includes('values.summary'));
+  assert.equal(Object.hasOwn(result.normalized, 'summary'), false);
+});
+
+test('selection fields require exactly one option source and non-selection fields prohibit one', () => {
+  const missing = validateTemplate(templateWith([field('choice', 'select')]));
+  assert.ok(paths(missing).includes('fields[0].options'));
+  const extra = validateTemplate(templateWith([field('text', 'short-text', {options: [{id: 'one', label: 'One'}]})]));
+  assert.ok(paths(extra).includes('fields[0].options'));
+});


### PR DESCRIPTION
First half of the Phase-1 forms vertical slice (#90 epic; unblocked by #91).

- `lib/forms/schema.js` — strict template validator for the full ADR-93 field grammar (`short-text`, `long-text`, `number`, `checkbox`, `date`, `time`, `datetime`, `select`, `multi-select`), inline static options with stable IDs, per-type constraints (number min/max/integer rejecting NaN/Infinity; datetime requiring explicit offset; multi-select ordered + duplicate-free with min/maxSelections), strict unknown-key rejection with exact error paths.
- `lib/forms/canonical.js` — deterministic canonical JSON (NFC, code-point key ordering, RFC 8785 number spellings, rejects non-finite/negative-zero/unpaired-surrogates/cycles) + `schemaDigest` (SHA-256 over canonical bytes incl. pinned trailing LF).

Verified independently against a real gym template: template validates, a genuine submission (squat/315/3 reps/RPE 8) is accepted, and every negative canary rejects (bogus option, non-integer reps, RPE out of range, missing required field). Digest is reproducible across key ordering and changes when the template changes.

111/111 tests; `validate-raw-html` and `validate-editable-mode` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)