### PR TITLE
security: sandbox artifact HTML on /raw and /embed (proven write primitive)

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1595,6 +1595,7 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
         class="embedded-html-frame"
         title="${escapeHtml(relativePath)}"
         data-embedded-html
+        sandbox="allow-scripts allow-forms allow-popups"
         src="${escapeHtml(embedHtmlHref)}"
         loading="lazy"
       ></iframe>

--- a/server.js
+++ b/server.js
@@ -301,7 +301,14 @@ function sendAccessError(res, accessContext, asJson = false) {
   res.status(accessContext.denialStatus).type('text/plain').send(accessContext.denialMessage);
 }
 
+// Artifact HTML (/raw, /embed) executes author-supplied scripts. Serving it
+// same-origin lets those scripts drive first-party mutations (save, annotations,
+// forms) with the viewer's own credentials. The CSP sandbox forces an opaque
+// origin; allow-same-origin must never be added (ADR-92 B1 + operator decision).
+const ARTIFACT_SANDBOX = 'sandbox allow-scripts allow-forms allow-popups';
+
 function sendRawHtmlResponse(res, sourceBuffer) {
+  res.set('Content-Security-Policy', ARTIFACT_SANDBOX);
   res.status(200).type(RAW_HTML_MIME_TYPE).send(sourceBuffer);
 }
 
@@ -2520,6 +2527,7 @@ function createApp(options = {}) {
         ),
       });
       res.set('X-Lookie-Content-Mode', 'transformed-embed');
+      res.set('Content-Security-Policy', ARTIFACT_SANDBOX);
       res.status(200).type(RAW_HTML_MIME_TYPE).send(html);
     } catch (error) {
       console.error('Failed to transform embed HTML', { repo, relativePath, error });

--- a/test/artifact-sandbox.test.js
+++ b/test/artifact-sandbox.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+
+const { createApp } = require('../server.js');
+
+// Artifact HTML executes author-supplied scripts. If it is served same-origin,
+// those scripts can drive first-party mutations (/api/save, annotations, forms)
+// using the viewer's own credentials — proven exploitable before this guard.
+// The CSP sandbox forces an opaque origin. allow-same-origin must NEVER appear.
+const EXPECTED = 'sandbox allow-scripts allow-forms allow-popups';
+
+async function withServer(run) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-sandbox-'));
+  const repo = path.join(root, 'docs');
+  fs.mkdirSync(repo, { recursive: true });
+  fs.writeFileSync(path.join(repo, 'artifact.html'), '<!doctype html><html><body><h1 id="t">a</h1></body></html>');
+  const app = createApp({
+    mappings: { docs: repo },
+    accessConfig: { humanDefault: 'full' },
+    rawHtmlEnabled: true,
+    editingEnabled: true,
+  });
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await run(origin);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('artifact HTML is served with an opaque-origin CSP sandbox on /raw and /embed', async () => {
+  await withServer(async (origin) => {
+    for (const route of ['raw', 'embed']) {
+      const response = await fetch(`${origin}/${route}/docs/artifact.html`);
+      assert.equal(response.status, 200, `${route} should serve the artifact`);
+      const csp = response.headers.get('content-security-policy');
+      assert.equal(csp, EXPECTED, `${route} must carry the exact artifact sandbox`);
+      assert.ok(!/allow-same-origin/.test(csp), `${route} must never grant allow-same-origin`);
+    }
+  });
+});
+
+test('the /view wrapper frames the embedded artifact with a sandbox attribute', async () => {
+  await withServer(async (origin) => {
+    const html = await (await fetch(`${origin}/view/docs/artifact.html`)).text();
+    const iframe = html.match(/<iframe[^>]*data-embedded-html[^>]*>/);
+    assert.ok(iframe, '/view should frame the artifact');
+    assert.match(iframe[0], /sandbox="allow-scripts allow-forms allow-popups"/);
+    assert.ok(!/allow-same-origin/.test(iframe[0]), 'iframe must never grant allow-same-origin');
+  });
+});


### PR DESCRIPTION
**Verified live vulnerability on current main.** `/embed` served author-supplied artifact HTML **same-origin with no CSP**, and `/view` framed it with no `sandbox` attribute. A script inside any HTML artifact you view could therefore issue first-party mutations with your own credentials.

Proof (real headless Chrome, against unmodified main): an artifact script called `/api/save` and silently overwrote a repository file — the victim document's contents became `PWNED BY ARTIFACT SCRIPT`. This needs no forms; `/api/save` and annotations are already mutable surfaces on the deployed instance.

**Fix**: apply the ADR-92 B1 opaque-origin boundary to both artifact routes and the `/view` iframe — `sandbox allow-scripts allow-forms allow-popups`, never `allow-same-origin` (identical to the recorded operator decision for `/raw`). Artifact scripts, forms, and popups still function; ambient same-origin authority does not.

**Verified after the fix** (same real-browser attack): blocked through both `/embed` and `/view`, victim file intact. Regression test added asserting the exact CSP on both routes and the iframe attribute, with explicit `allow-same-origin` absence checks.

**Known cost (deliberate)**: annotation mounting and theme sync inside `/embed` depend on same-origin access and are degraded by this boundary. Closing a proven write primitive takes precedence; the durable fix (serving artifacts from a separate origin — ADR-92's deferred option) should be tracked as follow-up.

121/121 tests; validate-raw-html and validate-editable-mode exit 0. Minimal diff: no forms code, no unrelated hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)