### PR TITLE
security: sandbox scriptable asset MIME types on /asset (SVG write primitive)

### DIFF
--- a/server.js
+++ b/server.js
@@ -307,6 +307,16 @@ function sendAccessError(res, accessContext, asJson = false) {
 // origin; allow-same-origin must never be added (ADR-92 B1 + operator decision).
 const ARTIFACT_SANDBOX = 'sandbox allow-scripts allow-forms allow-popups';
 
+// Asset MIME types a browser will execute as a document when navigated to
+// directly (SVG carries <script>; HTML/XHTML/XML can execute inline or via
+// XSLT). Served same-origin these are the same write primitive as /embed was,
+// so they get the identical opaque-origin sandbox.
+const SCRIPTABLE_ASSET_TYPES = /^(?:image\/svg\+xml|text\/html|application\/xhtml\+xml|(?:text|application)\/xml)\b/i;
+
+function isScriptableAssetType(mimeType) {
+  return typeof mimeType === 'string' && SCRIPTABLE_ASSET_TYPES.test(mimeType);
+}
+
 function sendRawHtmlResponse(res, sourceBuffer) {
   res.set('Content-Security-Policy', ARTIFACT_SANDBOX);
   res.status(200).type(RAW_HTML_MIME_TYPE).send(sourceBuffer);
@@ -2412,6 +2422,10 @@ function createApp(options = {}) {
       return;
     }
 
+    res.set('X-Content-Type-Options', 'nosniff');
+    if (isScriptableAssetType(mimeType)) {
+      res.set('Content-Security-Policy', ARTIFACT_SANDBOX);
+    }
     res.type(mimeType).sendFile(resolved, (error) => {
       if (!error) {
         return;

--- a/test/artifact-sandbox.test.js
+++ b/test/artifact-sandbox.test.js
@@ -58,3 +58,34 @@ test('the /view wrapper frames the embedded artifact with a sandbox attribute', 
     assert.ok(!/allow-same-origin/.test(iframe[0]), 'iframe must never grant allow-same-origin');
   });
 });
+
+test('scriptable asset MIME types are sandboxed on /asset; ordinary files are not', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-asset-'));
+  const repo = path.join(root, 'docs');
+  fs.mkdirSync(repo, { recursive: true });
+  // SVG can carry <script>; served same-origin it is the same write primitive
+  // as unsandboxed /embed was (proven exploitable in a real browser).
+  fs.writeFileSync(path.join(repo, 'diagram.svg'), '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg>');
+  fs.writeFileSync(path.join(repo, 'notes.md'), '# plain\n');
+  const app = createApp({
+    mappings: { docs: repo },
+    accessConfig: { humanDefault: 'full' },
+    editingEnabled: true,
+  });
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const svg = await fetch(`${origin}/asset/docs/diagram.svg`);
+    assert.equal(svg.headers.get('content-security-policy'), EXPECTED, 'SVG must be sandboxed');
+    assert.ok(!/allow-same-origin/.test(svg.headers.get('content-security-policy')));
+    assert.equal(svg.headers.get('x-content-type-options'), 'nosniff');
+
+    const md = await fetch(`${origin}/asset/docs/notes.md`);
+    assert.equal(md.headers.get('content-security-policy'), null, 'non-scriptable assets need no sandbox');
+    assert.equal(md.headers.get('x-content-type-options'), 'nosniff', 'but must still refuse MIME sniffing');
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/video-routes.test.js
+++ b/test/video-routes.test.js
@@ -37,6 +37,11 @@ function invokeHandler(handler, req) {
       contentType: null,
       body: null,
       filePath: null,
+      headers: {},
+      set(name, value) {
+        this.headers[String(name).toLowerCase()] = value;
+        return this;
+      },
       status(code) {
         this.statusCode = code;
         return this;


### PR DESCRIPTION
Second live write primitive, same class as #164, different MIME. `/asset/:repo/*.svg` served author SVG as `image/svg+xml` same-origin with no CSP; SVG executes `<script>` when navigated to directly.

Proof (real headless Chrome, unmodified main): an SVG script called `/api/save` and overwrote a repository file (`note.md` -> `PWNED-BY-SVG`), with raw-HTML serving disabled. Found by independent re-review of #163 after #164 closed the HTML path.

Fix: identical opaque-origin sandbox (`sandbox allow-scripts allow-forms allow-popups`, never `allow-same-origin`) on asset responses a browser executes as a document (SVG, HTML, XHTML, XML/XSLT), plus `X-Content-Type-Options: nosniff` on all asset responses so a sniffed type cannot dodge the check. `<img>`-embedded SVG still renders (sandbox applies only to document navigation).

Verified after fix: attack blocked, victim file intact; svg/xml carry the sandbox, markdown does not (but does carry nosniff). Regression test added. Also completes the video-routes response double which lacked `res.set()`.

122/122 tests; both validators exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)