### PR TITLE
feat(forms): session time, immutable corrections, submissions list API

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -248,6 +248,9 @@ function getFormsConfig() {
     submissionsPath: typeof config.forms.submissionsPath === 'string'
       ? path.resolve(expandHome(config.forms.submissionsPath))
       : undefined,
+    timezone: typeof config.forms.timezone === 'string'
+      ? config.forms.timezone
+      : undefined,
     publicOrigins: Array.isArray(config.forms.publicOrigins)
       ? config.forms.publicOrigins.filter((origin) => typeof origin === 'string')
       : typeof config.forms.publicOrigin === 'string'

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -153,7 +153,33 @@ function renderControl(field, values) {
     time: 'time',
     datetime: 'datetime-local',
   };
-  return `<input ${common} type="${inputTypes[field.type]}" value="${escapeHtml(value)}"${field.type === 'number' || field.type === 'date' ? constraintAttributes(field) : ''}>`;
+  const datetimeCapture = field.type === 'datetime'
+    ? ` data-datetime-local data-offset-field="${escapeHtml(field.id)}__offset" data-timezone-field="${escapeHtml(field.id)}__timezone"><input type="hidden" name="${escapeHtml(field.id)}__offset"><input type="hidden" name="${escapeHtml(field.id)}__timezone"`
+    : '';
+  return `<input ${common} type="${inputTypes[field.type]}" value="${escapeHtml(value)}"${field.type === 'number' || field.type === 'date' ? constraintAttributes(field) : ''}${datetimeCapture}>`;
+}
+
+function datetimeCaptureScript(cspNonce) {
+  return `<script nonce="${escapeHtml(cspNonce)}">
+(() => {
+  const pad = (value) => String(value).padStart(2, '0');
+  const localValue = (date) => date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate()) + 'T' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+  const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  for (const input of document.querySelectorAll('input[data-datetime-local]')) {
+    const offset = input.form.elements[input.dataset.offsetField];
+    const timezone = input.form.elements[input.dataset.timezoneField];
+    const sync = () => {
+      const instant = new Date(input.value);
+      if (offset && Number.isFinite(instant.getTime())) offset.value = String(-instant.getTimezoneOffset());
+      if (timezone && zone) timezone.value = zone;
+    };
+    if (!input.value) input.value = localValue(new Date());
+    input.addEventListener('input', sync);
+    input.form.addEventListener('submit', sync);
+    sync();
+  }
+})();
+</script>`;
 }
 
 function renderFormPage(template, csrfToken, values = {}, errors = [], options = {}) {
@@ -189,6 +215,7 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
       </form>
     </section>
   </main>
+  ${datetimeCaptureScript(options.cspNonce)}
   ${themeScript(options.cspNonce)}`;
 
   return baseHtml({
@@ -237,9 +264,68 @@ function renderReceiptPage(template, record, options = {}) {
   });
 }
 
-function nativeValues(template, body) {
+function timeZoneOffset(timestamp, timeZone) {
+  const part = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    timeZoneName: 'longOffset',
+    year: 'numeric',
+  }).formatToParts(new Date(timestamp)).find((entry) => entry.type === 'timeZoneName');
+  if (!part || part.value === 'GMT') return 0;
+  const match = /^GMT([+-])(\d{2}):(\d{2})$/.exec(part.value);
+  if (!match) throw new Error('Configured forms timezone has an unsupported offset.');
+  const minutes = Number(match[2]) * 60 + Number(match[3]);
+  return match[1] === '-' ? -minutes : minutes;
+}
+
+function offsetSuffix(minutes) {
+  const absolute = Math.abs(minutes);
+  return `${minutes < 0 ? '-' : '+'}${String(Math.floor(absolute / 60)).padStart(2, '0')}:${String(absolute % 60).padStart(2, '0')}`;
+}
+
+function localDateTimeParts(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(value);
+  if (!match) return null;
+  return {
+    year: Number(match[1]), month: Number(match[2]), day: Number(match[3]),
+    hour: Number(match[4]), minute: Number(match[5]), second: Number(match[6] || 0),
+  };
+}
+
+function zonedParts(timestamp, timeZone) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  }).formatToParts(new Date(timestamp));
+  return Object.fromEntries(parts.filter((part) => part.type !== 'literal').map((part) => [part.type, Number(part.value)]));
+}
+
+function normalizeNativeDatetime(value, offsetValue, timezoneValue, serverTimezone) {
+  const parts = localDateTimeParts(value);
+  if (!parts) return null;
+  let offset = /^-?\d+$/.test(String(offsetValue ?? '')) ? Number(offsetValue) : null;
+  let timezone = typeof timezoneValue === 'string' && timezoneValue ? timezoneValue : serverTimezone;
+  if (offset === null) {
+    timezone = serverTimezone;
+    const wallAsUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+    let instant = wallAsUtc;
+    for (let iteration = 0; iteration < 3; iteration += 1) {
+      offset = timeZoneOffset(instant, timezone);
+      instant = wallAsUtc - offset * 60000;
+    }
+    const actual = zonedParts(instant, timezone);
+    if (Object.keys(parts).some((key) => actual[key] !== parts[key])) return null;
+  }
+  if (!Number.isInteger(offset) || offset < -840 || offset > 840) return null;
+  const seconds = `${value.length === 16 ? `${value}:00` : value}${offsetSuffix(offset)}`;
+  return { value: seconds, eventAt: seconds, timezone, clientOffsetMinutes: offset };
+}
+
+function nativeValues(template, body, serverTimezone) {
   const values = {};
   const raw = {};
+  let eventTime;
   for (const field of template.fields) {
     const supplied = body[field.id];
     if (field.type === 'checkbox') {
@@ -254,13 +340,26 @@ function nativeValues(template, body) {
       values[field.id] = Number.isNaN(parsed) ? supplied : parsed;
     } else if (field.type === 'multi-select') {
       values[field.id] = Array.isArray(supplied) ? supplied : [supplied];
-    } else if (field.type === 'datetime' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?$/.test(supplied)) {
-      values[field.id] = `${supplied.length === 16 ? `${supplied}:00` : supplied}Z`;
+    } else if (field.type === 'datetime') {
+      const normalized = normalizeNativeDatetime(
+        supplied,
+        body[`${field.id}__offset`],
+        body[`${field.id}__timezone`],
+        serverTimezone
+      );
+      values[field.id] = normalized ? normalized.value : supplied;
+      if (!eventTime && normalized) {
+        eventTime = {
+          eventAt: normalized.eventAt,
+          timezone: normalized.timezone,
+          clientOffsetMinutes: normalized.clientOffsetMinutes,
+        };
+      }
     } else {
       values[field.id] = supplied;
     }
   }
-  return { values, raw };
+  return { values, raw, eventTime };
 }
 
 function exactOrigin(value) {
@@ -308,6 +407,12 @@ function createFormsRouter(options) {
   const logger = options.logger || console;
   const customThemeCss = options.customThemeCss || '';
   const publicOrigins = configuredOrigins(options.publicOrigin);
+  const serverTimezone = options.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: serverTimezone }).format(new Date());
+  } catch (_error) {
+    throw new Error('forms.timezone must be a valid IANA timezone.');
+  }
   const router = express.Router();
   const formParser = express.urlencoded({ extended: false, limit: '256kb', parameterLimit: 500 });
   const apiParser = express.json({ limit: '2mb' });
@@ -412,9 +517,9 @@ function createFormsRouter(options) {
     return false;
   }
 
-  function apiAuthenticated(req, res) {
+  function apiAuthenticated(req, res, type = 'form.submit') {
     if (principalFor(req)) return true;
-    emitAudit(req, 'form.submit', 'rejected_authn');
+    emitAudit(req, type, 'rejected_authn');
     res.status(401).json({ ok: false, error: 'Authentication required.' });
     return false;
   }
@@ -484,14 +589,24 @@ function createFormsRouter(options) {
       if (!template || !await allowed(req, 'forms.submit', template)) return formNotFound(req, res, 'form.submit');
       const actor = principalFor(req);
       if (!actor) return formNotFound(req, res, 'form.submit');
-      const allowedKeys = new Set(['_csrf', ...template.fields.map((field) => field.id)]);
+      const allowedKeys = new Set([
+        '_csrf',
+        ...template.fields.flatMap((field) => field.type === 'datetime'
+          ? [field.id, `${field.id}__offset`, `${field.id}__timezone`]
+          : [field.id]),
+      ]);
       if (Object.keys(req.body || {}).some((key) => !allowedKeys.has(key))) {
         emitAudit(req, 'form.submit', 'rejected_validation', template);
         res.status(400).type('text/plain').send('Invalid form body.');
         return;
       }
-      const submitted = nativeValues(template, req.body || {});
-      const result = await service.submit({ templateId: template.templateId, values: submitted.values, actor });
+      const submitted = nativeValues(template, req.body || {}, serverTimezone);
+      const result = await service.submit({
+        templateId: template.templateId,
+        values: submitted.values,
+        actor,
+        ...(submitted.eventTime || {}),
+      });
       if (result.error) {
         if (result.error.code === 'not_found') return formNotFound(req, res, 'form.submit');
         emitAudit(req, 'form.submit', result.error.code === 'idempotency_conflict'
@@ -546,7 +661,9 @@ function createFormsRouter(options) {
       const actor = principalFor(req);
       if (!actor) return apiNotFound(req, res);
       const body = req.body && typeof req.body === 'object' && !Array.isArray(req.body) ? req.body : {};
-      const allowedKeys = new Set(['values', 'eventAt', 'timezone', 'clientOffsetMinutes', 'idempotencyKey']);
+      const allowedKeys = new Set([
+        'values', 'eventAt', 'timezone', 'clientOffsetMinutes', 'idempotencyKey', 'supersedesRecord',
+      ]);
       if (Object.keys(body).some((key) => !allowedKeys.has(key))) {
         emitAudit(req, 'form.submit', 'rejected_validation', template);
         res.status(400).json({ ok: false, error: 'Unknown or server-derived submission field.' });
@@ -554,6 +671,23 @@ function createFormsRouter(options) {
       }
       const hasEventField = ['eventAt', 'timezone', 'clientOffsetMinutes']
         .some((key) => Object.prototype.hasOwnProperty.call(body, key));
+      let correctionAuthorized = false;
+      if (body.supersedesRecord !== undefined) {
+        const reference = body.supersedesRecord;
+        const predecessor = reference && reference.resourceKind === 'form-submission'
+          ? await store.getSubmission(reference.id).catch((error) => {
+            if (error && error.code === 'EVALIDATION') return null;
+            throw error;
+          })
+          : null;
+        const own = predecessor && predecessor.actor
+          && predecessor.actor.id === actor.id && predecessor.actor.type === actor.type;
+        if (!predecessor || predecessor.templateId !== template.templateId) return apiNotFound(req, res);
+        correctionAuthorized = Boolean(own
+          || await allowed(req, 'forms.read_submissions', predecessor)
+          || await allowed(req, 'forms.manage', predecessor));
+        if (!correctionAuthorized) return apiNotFound(req, res);
+      }
       const result = await service.submit({
         templateId: template.templateId,
         values: body.values,
@@ -566,11 +700,17 @@ function createFormsRouter(options) {
         ...(body.idempotencyKey === undefined && req.get('idempotency-key') === undefined ? {} : {
           idempotencyKey: req.get('idempotency-key') || body.idempotencyKey,
         }),
-      });
+        ...(body.supersedesRecord === undefined ? {} : {
+          supersedesRecord: body.supersedesRecord,
+        }),
+      }, { correctionAuthorized });
       if (result.error) {
         if (result.error.code === 'not_found') return apiNotFound(req, res);
-        const conflict = result.error.code === 'idempotency_conflict';
-        emitAudit(req, 'form.submit', conflict ? 'rejected_idempotency' : 'rejected_validation', template);
+        const conflict = result.error.code === 'idempotency_conflict'
+          || result.error.code === 'correction_conflict';
+        emitAudit(req, 'form.submit', result.error.code === 'idempotency_conflict'
+          ? 'rejected_idempotency'
+          : 'rejected_validation', template);
         res.status(conflict ? 409 : result.error.code === 'invalid_request' ? 400 : 422).json({ ok: false, error: result.error });
         return;
       }
@@ -580,6 +720,76 @@ function createFormsRouter(options) {
         submissionId: result.submissionId,
         receipt: result.receipt,
         receiptUrl: `/forms/${encodeURIComponent(template.templateId)}/receipts/${encodeURIComponent(result.submissionId)}`,
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/api/forms/:templateId/submissions', async (req, res, next) => {
+    try {
+      const bearer = bearerPresented(req);
+      if (bearer && cookieValue(req, CONTEXT_COOKIE)) {
+        emitAudit(req, 'form.submissions.list', 'rejected_authn');
+        res.status(400).json({ ok: false, error: 'Ambiguous credentials are not accepted.' });
+        return;
+      }
+      if (!apiAuthenticated(req, res, 'form.submissions.list')) return;
+      if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, 'form.submissions.list');
+      const template = await registry.getTemplate(req.params.templateId);
+      if (!template) return apiNotFound(req, res, 'form.submissions.list');
+      const visible = await allowed(req, 'forms.submit', template)
+        || await allowed(req, 'forms.read_submissions', template);
+      const actor = principalFor(req);
+      if (!visible || !actor) return apiNotFound(req, res, 'form.submissions.list');
+      const parsedLimit = req.query.limit === undefined ? 50 : Number(req.query.limit);
+      if (!Number.isSafeInteger(parsedLimit) || parsedLimit < 1) {
+        emitAudit(req, 'form.submissions.list', 'rejected_validation', template);
+        res.status(400).json({ ok: false, error: 'limit must be a positive integer.' });
+        return;
+      }
+      const submissions = await store.listSubmissions({
+        templateId: template.templateId,
+        actor,
+        limit: Math.min(parsedLimit, 100),
+      });
+      emitAudit(req, 'form.submissions.list', 'accepted', template);
+      res.status(200).json({ ok: true, submissions, limit: Math.min(parsedLimit, 100) });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/api/forms/:templateId/submissions/:submissionId/history', async (req, res, next) => {
+    try {
+      if (bearerPresented(req) && cookieValue(req, CONTEXT_COOKIE)) {
+        emitAudit(req, 'form.submission.history', 'rejected_authn');
+        res.status(400).json({ ok: false, error: 'Ambiguous credentials are not accepted.' });
+        return;
+      }
+      if (!apiAuthenticated(req, res, 'form.submission.history')) return;
+      if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, 'form.submission.history');
+      const history = await store.getSubmissionHistory(req.params.submissionId).catch((error) => {
+        if (error && error.code === 'EVALIDATION') return null;
+        throw error;
+      });
+      if (!history || history.latest.templateId !== req.params.templateId) {
+        return apiNotFound(req, res, 'form.submission.history');
+      }
+      const canRead = await allowed(req, 'forms.read_submissions', history.latest);
+      const canManage = canRead ? false : await allowed(req, 'forms.manage', history.latest);
+      const principal = principalFor(req);
+      const own = principal && history.latest.actor
+        && principal.id === history.latest.actor.id && principal.type === history.latest.actor.type;
+      if (!own && !canRead && !canManage) {
+        return apiNotFound(req, res, 'form.submission.history');
+      }
+      emitAudit(req, 'form.submission.history', 'accepted', history.latest);
+      res.status(200).json({
+        ok: true,
+        requestedSubmissionId: req.params.submissionId,
+        latestSubmissionId: history.latest.submissionId,
+        submissions: [history.latest, ...history.predecessors],
       });
     } catch (error) {
       next(error);

--- a/lib/forms/submission-service.js
+++ b/lib/forms/submission-service.js
@@ -40,7 +40,7 @@ class SubmissionService {
     this.store = store;
   }
 
-  async submit(input) {
+  async submit(input, options = {}) {
     const temporalFields = ['eventAt', 'timezone', 'clientOffsetMinutes']
       .filter((key) => input[key] !== undefined);
     if (temporalFields.length !== 0 && temporalFields.length !== 3) {
@@ -52,6 +52,24 @@ class SubmissionService {
     const registered = await this.registry.getTemplate(input.templateId);
     if (!registered) return { error: { code: 'not_found', message: 'Form not found.' } };
     const { schemaDigest, ...template } = registered;
+    let predecessor = null;
+    if (input.supersedesRecord !== undefined) {
+      if (!input.supersedesRecord || input.supersedesRecord.resourceKind !== 'form-submission'
+          || typeof input.supersedesRecord.id !== 'string') {
+        return requestError('supersedesRecord must identify a form-submission.');
+      }
+      try {
+        predecessor = await this.store.getSubmission(input.supersedesRecord.id);
+      } catch (error) {
+        if (!error || error.code !== 'EVALIDATION') throw error;
+      }
+      const sameActor = predecessor && predecessor.actor && input.actor
+        && predecessor.actor.id === input.actor.id && predecessor.actor.type === input.actor.type;
+      if (!predecessor || predecessor.templateId !== template.templateId
+          || (!sameActor && options.correctionAuthorized !== true)) {
+        return { error: { code: 'not_found', message: 'Form not found.' } };
+      }
+    }
     const validation = validateSubmissionValues(template, input.values);
     if (!validation.valid) return validationError(validation.errors);
 
@@ -89,6 +107,9 @@ class SubmissionService {
           clientOffsetMinutes: input.clientOffsetMinutes,
         }),
         ...(input.idempotencyKey === undefined ? {} : { idempotencyKey: input.idempotencyKey }),
+        ...(input.supersedesRecord === undefined ? {} : { supersedesRecord: input.supersedesRecord }),
+      }, {
+        allowForeignSupersede: predecessor !== null && options.correctionAuthorized === true,
       });
     } catch (error) {
       if (error && error.code === 'EVALIDATION') {
@@ -99,6 +120,18 @@ class SubmissionService {
           error: {
             code: 'idempotency_conflict',
             message: 'The idempotency key was already used for a different submission.',
+            details: [],
+          },
+        };
+      }
+      if (error && error.code === 'ENOTFOUND') {
+        return { error: { code: 'not_found', message: 'Form not found.' } };
+      }
+      if (error && error.code === 'ESUPERSEDED') {
+        return {
+          error: {
+            code: 'correction_conflict',
+            message: 'The submission has already been superseded.',
             details: [],
           },
         };

--- a/lib/forms/submission-store.js
+++ b/lib/forms/submission-store.js
@@ -31,9 +31,11 @@ const INPUT_KEYS = new Set([
   'schemaDigest',
   'values',
   'idempotencyKey',
+  'supersedesRecord',
 ]);
 const VALUE_KEYS = new Set(['fieldId', 'fieldType', 'fieldLabel', 'value', 'selectedOptions']);
 const OPTION_KEYS = new Set(['optionId', 'optionLabel']);
+const SUPERSEDES_KEYS = new Set(['resourceKind', 'id']);
 
 function codedError(message, code) {
   const error = new Error(message);
@@ -311,7 +313,22 @@ function normalizeSubmission(input) {
     templateVersion: input.templateVersion,
     schemaDigest: input.schemaDigest,
     values,
+    ...(input.supersedesRecord === undefined ? {} : {
+      supersedesRecord: normalizeSupersedesRecord(input.supersedesRecord),
+    }),
   };
+}
+
+function normalizeSupersedesRecord(value) {
+  assertPlainObject(value, 'supersedesRecord');
+  assertOnlyKeys(value, SUPERSEDES_KEYS, 'supersedesRecord');
+  if (value.resourceKind !== 'form-submission') {
+    throw codedError('supersedesRecord.resourceKind must be form-submission.', 'EVALIDATION');
+  }
+  if (typeof value.id !== 'string' || !UUID.test(value.id)) {
+    throw codedError('supersedesRecord.id must be a lowercase UUIDv4.', 'EVALIDATION');
+  }
+  return { resourceKind: value.resourceKind, id: value.id };
 }
 
 function normalizeIdempotencyKey(value) {
@@ -336,7 +353,15 @@ function metadataFor(record) {
     templateId: record.templateId,
     templateVersion: record.templateVersion,
     schemaDigest: record.schemaDigest,
+    values: normalizeJsonValue(record.values, 'values'),
+    ...(record.supersedesRecord === undefined ? {} : {
+      supersedesRecord: normalizeJsonValue(record.supersedesRecord, 'supersedesRecord'),
+    }),
   };
+}
+
+function sameActor(left, right) {
+  return Boolean(left && right && left.id === right.id && left.type === right.type);
 }
 
 class SubmissionStore {
@@ -348,6 +373,7 @@ class SubmissionStore {
     this.storageRoot = path.resolve(options.storageRoot);
     this.clock = options.clock || (() => new Date());
     this.idempotencyLocks = new Map();
+    this.supersessionLocks = new Map();
   }
 
   recordPath(submissionId) {
@@ -401,6 +427,24 @@ class SubmissionStore {
     }
   }
 
+  async withSupersessionLock(reference, operation) {
+    if (!reference) return operation();
+    const key = `${reference.resourceKind}:${reference.id}`;
+    const previous = this.supersessionLocks.get(key) || Promise.resolve();
+    let release;
+    const current = new Promise((resolve) => {
+      release = resolve;
+    });
+    this.supersessionLocks.set(key, current);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.supersessionLocks.get(key) === current) this.supersessionLocks.delete(key);
+    }
+  }
+
   async submissionFiles() {
     try {
       const entries = await fs.readdir(this.storageRoot, { withFileTypes: true });
@@ -429,6 +473,34 @@ class SubmissionStore {
       match = record;
     }
     return match;
+  }
+
+  async allRecords() {
+    const records = [];
+    for (const fileName of await this.submissionFiles()) {
+      records.push(normalizeJsonValue(
+        JSON.parse(await fs.readFile(path.join(this.storageRoot, fileName), 'utf8')),
+        'record'
+      ));
+    }
+    return records;
+  }
+
+  async assertSupersessionAvailable(normalized, allowForeignSupersede) {
+    const reference = normalized.supersedesRecord;
+    if (!reference) return;
+    const records = await this.allRecords();
+    const predecessor = records.find((record) => record.submissionId === reference.id);
+    if (!predecessor
+        || predecessor.templateId !== normalized.templateId
+        || (!allowForeignSupersede && !sameActor(predecessor.actor, normalized.actor))) {
+      throw codedError('Submission not found.', 'ENOTFOUND');
+    }
+    if (records.some((record) => record.supersedesRecord
+        && record.supersedesRecord.resourceKind === reference.resourceKind
+        && record.supersedesRecord.id === reference.id)) {
+      throw codedError('The submission has already been superseded.', 'ESUPERSEDED');
+    }
   }
 
   async writeTempContents(handle, bytes) {
@@ -490,7 +562,10 @@ class SubmissionStore {
 
   async createSubmission(input, options = {}) {
     assertPlainObject(options, 'options');
-    assertOnlyKeys(options, new Set(['idempotencyKey']), 'options');
+    assertOnlyKeys(options, new Set(['idempotencyKey', 'allowForeignSupersede']), 'options');
+    if (options.allowForeignSupersede !== undefined && typeof options.allowForeignSupersede !== 'boolean') {
+      throw codedError('options.allowForeignSupersede must be a boolean.', 'EVALIDATION');
+    }
     const inputKey = input && input.idempotencyKey;
     if (inputKey !== undefined && options.idempotencyKey !== undefined && inputKey !== options.idempotencyKey) {
       throw codedError('Conflicting idempotencyKey values were supplied.', 'EVALIDATION');
@@ -512,11 +587,21 @@ class SubmissionStore {
       templateVersion: normalized.templateVersion,
       schemaDigest: normalized.schemaDigest,
       values: normalized.values,
+      ...(normalized.supersedesRecord === undefined ? {} : {
+        supersedesRecord: normalized.supersedesRecord,
+      }),
       ...idempotency,
     });
+    const createRecord = (idempotency = {}) => this.withSupersessionLock(
+      normalized.supersedesRecord,
+      async () => {
+        await this.assertSupersessionAvailable(normalized, options.allowForeignSupersede === true);
+        return this.durableCreate(buildRecord(idempotency));
+      }
+    );
     if (idempotencyKey === null) {
       await this.ensureStorageRoot();
-      return this.durableCreate(buildRecord());
+      return createRecord();
     }
     const idempotencyKeyDigest = this.idempotencyDigest(
       normalized.actor,
@@ -535,11 +620,10 @@ class SubmissionStore {
         return normalizeJsonValue(original, 'record');
       }
 
-      const record = buildRecord({
+      return createRecord({
         idempotencyKeyDigest,
         requestDigest,
       });
-      return this.durableCreate(record);
     });
   }
 
@@ -555,21 +639,70 @@ class SubmissionStore {
     }
   }
 
-  async listSubmissions({ templateId } = {}) {
+  async resolveLatest(submissionId) {
+    let current = await this.getSubmission(submissionId);
+    if (!current) return null;
+    const records = await this.allRecords();
+    const successors = new Map();
+    for (const record of records) {
+      if (!record.supersedesRecord) continue;
+      const key = `${record.supersedesRecord.resourceKind}:${record.supersedesRecord.id}`;
+      if (successors.has(key)) throw codedError('The supersession chain has multiple successors.', 'EINTEGRITY');
+      successors.set(key, record);
+    }
+    const visited = new Set();
+    while (current) {
+      if (visited.has(current.submissionId)) throw codedError('The supersession chain contains a cycle.', 'EINTEGRITY');
+      visited.add(current.submissionId);
+      const successor = successors.get(`form-submission:${current.submissionId}`);
+      if (!successor) return current;
+      current = successor;
+    }
+    return null;
+  }
+
+  async getSubmissionHistory(submissionId) {
+    const latest = await this.resolveLatest(submissionId);
+    if (!latest) return null;
+    const predecessors = [];
+    const visited = new Set([latest.submissionId]);
+    let current = latest;
+    while (current.supersedesRecord) {
+      const predecessor = await this.getSubmission(current.supersedesRecord.id);
+      if (!predecessor || visited.has(predecessor.submissionId)) {
+        throw codedError('The supersession chain is incomplete or cyclic.', 'EINTEGRITY');
+      }
+      predecessors.push(predecessor);
+      visited.add(predecessor.submissionId);
+      current = predecessor;
+    }
+    return { latest, predecessors };
+  }
+
+  async listSubmissions({ templateId, actor, limit = 100 } = {}) {
     if (templateId !== undefined) {
       assertDefinitionId(templateId, 'templateId');
     }
-    const results = [];
-    for (const fileName of await this.submissionFiles()) {
-      const record = JSON.parse(await fs.readFile(path.join(this.storageRoot, fileName), 'utf8'));
-      if (templateId === undefined || record.templateId === templateId) {
-        results.push(metadataFor(record));
-      }
+    if (actor !== undefined) {
+      assertPlainObject(actor, 'actor');
     }
-    return results.sort((left, right) => (
-      left.receiptAt.localeCompare(right.receiptAt)
-      || left.submissionId.localeCompare(right.submissionId)
-    ));
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+      throw codedError('limit must be an integer from 1 through 100.', 'EVALIDATION');
+    }
+    const records = await this.allRecords();
+    const superseded = new Set(records
+      .filter((record) => record.supersedesRecord)
+      .map((record) => `${record.supersedesRecord.resourceKind}:${record.supersedesRecord.id}`));
+    return records
+      .filter((record) => (templateId === undefined || record.templateId === templateId)
+        && (actor === undefined || sameActor(record.actor, actor))
+        && !superseded.has(`form-submission:${record.submissionId}`))
+      .sort((left, right) => (
+        right.receiptAt.localeCompare(left.receiptAt)
+        || right.submissionId.localeCompare(left.submissionId)
+      ))
+      .slice(0, limit)
+      .map(metadataFor);
   }
 }
 

--- a/lookie-link.yaml.example
+++ b/lookie-link.yaml.example
@@ -104,6 +104,8 @@ repositories:
 #   enabled: true
 #   templatesPath: ~/.local/share/lookie-link/form-templates
 #   submissionsPath: ~/.local/share/lookie-link/form-submissions
+#   # IANA zone used when a browser cannot report its UTC offset.
+#   timezone: America/New_York
 #   # Required for browser mutations. Each entry is an exact scheme/host/port;
 #   # Host and X-Forwarded-* request headers are never trusted as substitutes.
 #   publicOrigins:

--- a/server.js
+++ b/server.js
@@ -818,6 +818,7 @@ function createApp(options = {}) {
       publicOrigin: options.formsPublicOrigin === undefined
         ? formsConfig.publicOrigins
         : options.formsPublicOrigin,
+      timezone: options.formsTimezone === undefined ? formsConfig.timezone : options.formsTimezone,
       contexts: options.formsCsrfContexts,
       audit: formsAudit,
       logger,

--- a/test/fixtures/forms/gym-session-entry.yaml
+++ b/test/fixtures/forms/gym-session-entry.yaml
@@ -7,8 +7,8 @@ grammarVersion: 1
 title: Gym Session Entry
 fields:
   - id: session-date
-    type: date
-    label: Session date
+    type: datetime
+    label: Session time
     required: true
   - id: lift
     type: select

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -180,7 +180,7 @@ async function getBrowserContext(server, templateId = 'gym-session-entry') {
 function nativeBody(token, overrides = {}) {
   return new URLSearchParams({
     _csrf: token,
-    'session-date': '2026-07-20',
+    'session-date': '2026-07-20T09:30',
     lift: 'bench',
     'top-weight': '225.5',
     'top-reps': '5',
@@ -193,7 +193,7 @@ function nativeBody(token, overrides = {}) {
 
 function jsonValues(overrides = {}) {
   return {
-    'session-date': '2026-07-20',
+    'session-date': '2026-07-20T09:30:00-04:00',
     lift: 'deadlift',
     'top-weight': 315,
     'top-reps': 3,
@@ -257,9 +257,57 @@ test('GET renders every field type, required markers, constraints, and a CSRF to
     assert.equal(document.querySelector('#field-entry-date').type, 'date');
     assert.equal(document.querySelector('#field-entry-time').type, 'time');
     assert.equal(document.querySelector('#field-recorded-at').type, 'datetime-local');
+    assert.ok(document.querySelector('input[name="recorded-at__offset"]'));
+    assert.ok(document.querySelector('input[name="recorded-at__timezone"]'));
+    assert.match(html, /getTimezoneOffset/);
     assert.equal(document.querySelector('#field-choice').tagName, 'SELECT');
     assert.equal(document.querySelector('#field-choices').multiple, true);
     assert.equal(document.querySelectorAll('[required]').length, everyTypeTemplate.fields.length);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('native datetime capture records an explicit offset and uses the configured zone when offset is absent', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, { formsTimezone: 'America/New_York' });
+  try {
+    const context = await getBrowserContext(server);
+    const explicitBody = nativeBody(context.token, {
+      'session-date': '2026-07-20T09:30',
+      'session-date__offset': '-240',
+      'session-date__timezone': 'America/New_York',
+    });
+    const explicit = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: explicitBody,
+    });
+    assert.equal(explicit.status, 303);
+
+    const fallbackBody = nativeBody(context.token, { 'session-date': '2026-01-20T09:30' });
+    const fallback = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: fallbackBody,
+    });
+    assert.equal(fallback.status, 303);
+
+    const records = await Promise.all((await submissionFiles(fixture.submissionsPath)).map(async (fileName) => (
+      JSON.parse(await fs.readFile(path.join(fixture.submissionsPath, fileName), 'utf8'))
+    )));
+    const summer = records.find((record) => record.eventAt.startsWith('2026-07-20'));
+    const winter = records.find((record) => record.eventAt.startsWith('2026-01-20'));
+    assert.deepEqual(
+      { eventAt: summer.eventAt, timezone: summer.timezone, clientOffsetMinutes: summer.clientOffsetMinutes },
+      { eventAt: '2026-07-20T09:30:00-04:00', timezone: 'America/New_York', clientOffsetMinutes: -240 }
+    );
+    assert.equal(summer.values.find((entry) => entry.fieldId === 'session-date').value, summer.eventAt);
+    assert.deepEqual(
+      { eventAt: winter.eventAt, timezone: winter.timezone, clientOffsetMinutes: winter.clientOffsetMinutes },
+      { eventAt: '2026-01-20T09:30:00-05:00', timezone: 'America/New_York', clientOffsetMinutes: -300 }
+    );
+    assert.equal(winter.values.find((entry) => entry.fieldId === 'session-date').value, winter.eventAt);
   } finally {
     await cleanup(fixture, server);
   }
@@ -790,6 +838,113 @@ test('receipt authorization conceals submissions from a different principal', as
     const reader = await server.request(accepted.headers.get('location'), { headers: { 'X-Read-All': 'yes' } });
     assert.equal(reader.status, 200);
     assert.match(await reader.text(), /Smooth reps/);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('correction API is immutable, linear, concealed, and list/history stay owner scoped', async () => {
+  const fixture = await makeFixture();
+  let tick = 0;
+  const formsStore = new SubmissionStore({
+    storageRoot: fixture.submissionsPath,
+    clock: () => new Date(Date.UTC(2026, 6, 20, 12, 0, tick++)),
+  });
+  const server = await startServer(fixture, {
+    formsStore,
+    formsAuthorize: ({ req, capability }) => {
+      req.accessContext = {
+        mode: 'scoped',
+        principal: { id: req.get('x-principal') || 'owner', kind: 'user' },
+      };
+      return capability === 'forms.submit' || capability === 'forms.view'
+        || ((capability === 'forms.read_submissions' || capability === 'forms.manage')
+          && req.get('x-reader') === 'yes');
+    },
+  });
+  try {
+    const form = await server.request('/forms/gym-session-entry', { headers: { 'X-Principal': 'owner' } });
+    const context = browserContext(form, await form.text());
+    const apiHeaders = (principal) => ({
+      'Content-Type': 'application/json',
+      Cookie: context.cookie,
+      Origin: PUBLIC_ORIGIN,
+      'X-CSRF-Token': context.token,
+      'X-Principal': principal,
+    });
+    const create = async (principal, values) => {
+      const response = await server.request('/api/forms/gym-session-entry/submissions', {
+        method: 'POST', headers: apiHeaders(principal), body: JSON.stringify({ values }),
+      });
+      assert.equal(response.status, 201);
+      return response.json();
+    };
+
+    const original = await create('owner', jsonValues({ notes: 'Original' }));
+    const originalPath = path.join(fixture.submissionsPath, `${original.submissionId}.json`);
+    const predecessorBytes = await fs.readFile(originalPath);
+    const second = await create('owner', jsonValues({ notes: 'Second entry' }));
+    const foreign = await create('other', jsonValues({ notes: 'Foreign entry' }));
+    const beforeDenied = await submissionFiles(fixture.submissionsPath);
+    const correctionBody = (id, notes = 'Corrected') => JSON.stringify({
+      values: jsonValues({ notes }),
+      supersedesRecord: { resourceKind: 'form-submission', id },
+    });
+
+    const denied = await server.request('/api/forms/gym-session-entry/submissions', {
+      method: 'POST', headers: apiHeaders('other'), body: correctionBody(original.submissionId),
+    });
+    const unknown = await server.request('/api/forms/gym-session-entry/submissions', {
+      method: 'POST', headers: apiHeaders('owner'),
+      body: correctionBody('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+    });
+    assert.equal(denied.status, 404);
+    assert.equal(unknown.status, 404);
+    assert.deepEqual(await denied.json(), await unknown.json());
+    assert.deepEqual(await submissionFiles(fixture.submissionsPath), beforeDenied);
+
+    const correctedResponse = await server.request('/api/forms/gym-session-entry/submissions', {
+      method: 'POST', headers: apiHeaders('owner'), body: correctionBody(original.submissionId),
+    });
+    assert.equal(correctedResponse.status, 201);
+    const corrected = await correctedResponse.json();
+    assert.equal(Buffer.compare(predecessorBytes, await fs.readFile(originalPath)), 0);
+
+    const duplicate = await server.request('/api/forms/gym-session-entry/submissions', {
+      method: 'POST', headers: apiHeaders('owner'), body: correctionBody(original.submissionId, 'Fork'),
+    });
+    assert.equal(duplicate.status, 409);
+    assert.equal((await submissionFiles(fixture.submissionsPath)).length, beforeDenied.length + 1);
+
+    const list = await server.request('/api/forms/gym-session-entry/submissions?limit=1000', {
+      headers: { 'X-Principal': 'owner' },
+    });
+    assert.equal(list.status, 200);
+    const listed = await list.json();
+    assert.equal(listed.limit, 100);
+    assert.deepEqual(listed.submissions.map((record) => record.submissionId), [
+      corrected.submissionId,
+      second.submissionId,
+    ]);
+    assert.equal(listed.submissions.some((record) => record.submissionId === foreign.submissionId), false);
+    assert.equal(listed.submissions.some((record) => record.submissionId === original.submissionId), false);
+    assert.equal(listed.submissions[0].values.find((entry) => entry.fieldId === 'notes').value, 'Corrected');
+
+    const bounded = await server.request('/api/forms/gym-session-entry/submissions?limit=1', {
+      headers: { 'X-Principal': 'owner' },
+    });
+    assert.equal((await bounded.json()).submissions.length, 1);
+    const history = await server.request(
+      `/api/forms/gym-session-entry/submissions/${original.submissionId}/history`,
+      { headers: { 'X-Principal': 'owner' } }
+    );
+    assert.equal(history.status, 200);
+    const chain = await history.json();
+    assert.equal(chain.latestSubmissionId, corrected.submissionId);
+    assert.deepEqual(chain.submissions.map((record) => record.submissionId), [
+      corrected.submissionId,
+      original.submissionId,
+    ]);
   } finally {
     await cleanup(fixture, server);
   }

--- a/test/forms-submission-store.test.js
+++ b/test/forms-submission-store.test.js
@@ -95,9 +95,10 @@ test('submission records round-trip with exact capture-time contract fields', as
       templateId: 'activity-log',
       templateVersion: 3,
       schemaDigest: SCHEMA_DIGEST,
+      values: submission().values,
     }]);
     assert.equal(Object.hasOwn(listed[0], 'actor'), false);
-    assert.equal(Object.hasOwn(listed[0], 'values'), false);
+    assert.equal(Object.hasOwn(listed[0], 'values'), true);
   } finally {
     await removeFixture(root);
   }
@@ -261,6 +262,66 @@ test('a rejected invalid write has no filesystem side effects', async () => {
       (error) => error.code === 'EVALIDATION'
     );
     await assert.rejects(fs.access(storageRoot), { code: 'ENOENT' });
+  } finally {
+    await removeFixture(root);
+  }
+});
+
+test('corrections preserve predecessor bytes, form a linear history, and replace the current list row', async () => {
+  const { root, storageRoot, store } = await fixture();
+  try {
+    const original = await store.createSubmission(submission());
+    const originalPath = path.join(storageRoot, `${original.submissionId}.json`);
+    const before = await fs.readFile(originalPath);
+    const corrected = await store.createSubmission(submission({
+      values: [
+        ...submission().values.slice(0, 2),
+        { fieldId: 'notes', fieldType: 'long-text', fieldLabel: 'Notes', value: 'Corrected pace' },
+      ],
+      supersedesRecord: { resourceKind: 'form-submission', id: original.submissionId },
+    }));
+
+    assert.equal(Buffer.compare(before, await fs.readFile(originalPath)), 0);
+    assert.deepEqual(await store.getSubmission(original.submissionId), original);
+    assert.equal((await store.resolveLatest(original.submissionId)).submissionId, corrected.submissionId);
+    const history = await store.getSubmissionHistory(original.submissionId);
+    assert.equal(history.latest.submissionId, corrected.submissionId);
+    assert.deepEqual(history.predecessors.map((record) => record.submissionId), [original.submissionId]);
+    const listed = await store.listSubmissions({ templateId: 'activity-log' });
+    assert.deepEqual(listed.map((record) => record.submissionId), [corrected.submissionId]);
+    assert.equal(listed[0].values.find((entry) => entry.fieldId === 'notes').value, 'Corrected pace');
+
+    await assert.rejects(
+      store.createSubmission(submission({
+        supersedesRecord: { resourceKind: 'form-submission', id: original.submissionId },
+      })),
+      (error) => error.code === 'ESUPERSEDED'
+    );
+    assert.equal((await store.submissionFiles()).length, 2);
+  } finally {
+    await removeFixture(root);
+  }
+});
+
+test('unknown and foreign correction predecessors are uniformly not found without a write', async () => {
+  const { root, store } = await fixture();
+  try {
+    const original = await store.createSubmission(submission());
+    const attempts = [
+      submission({
+        supersedesRecord: { resourceKind: 'form-submission', id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb' },
+      }),
+      submission({
+        actor: { id: 'coach-two', type: 'user' },
+        supersedesRecord: { resourceKind: 'form-submission', id: original.submissionId },
+      }),
+    ];
+    for (const attempt of attempts) {
+      await assert.rejects(store.createSubmission(attempt), (error) => (
+        error.code === 'ENOTFOUND' && error.message === 'Submission not found.'
+      ));
+    }
+    assert.deepEqual(await store.submissionFiles(), [`${original.submissionId}.json`]);
   } finally {
     await removeFixture(root);
   }


### PR DESCRIPTION
Three additions ahead of the forms UI redesign.

- **Session time**: the session field is now `datetime`. `datetime-local` gives no UTC offset, so the control is paired with hidden offset/timezone inputs populated by a **nonce'd** script (strict CSP, no inline handlers), falling back to the server's configured zone rather than assuming UTC. Records store the full ADR-93 temporal triple.
- **Corrections (edit after submit)** per ADR-93 §6: a correction is a NEW immutable record carrying `supersedesRecord: {resourceKind:'form-submission', id}`. The predecessor is never rewritten. Already-superseded predecessors are rejected (no forks); unknown, cross-template, and foreign-principal predecessors all return a uniform 404 with no file written. Resolution follows any member to the latest version; authorized history returns the chain.
- **Submissions list API** (`GET /api/forms/:templateId/submissions`): caller's own records, newest first, current versions only, bounded.

Verified independently: original 201 → correction 201 with the **predecessor byte-identical** on disk (2 files, nothing rewritten); double-supersede → 409 with no new file; foreign-principal correction → 404 with no new file.

147/147 tests; validate-raw-html, validate-editable-mode, skill-drift all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)