### PR TITLE
feat(forms): console-readout redesign, table receipt, entries list, corrections UI

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -121,9 +121,9 @@ function labelWithoutUnit(label) {
 
 function groupedFields(fields) {
   const groups = [
-    { key: 'selection', title: 'Choose', fields: [] },
-    { key: 'readouts', title: 'Readouts', fields: [] },
-    { key: 'details', title: 'Details', fields: [] },
+    { key: 'selection', title: 'What you\u2019re logging', fields: [] },
+    { key: 'readouts', title: 'Measurements', fields: [] },
+    { key: 'details', title: 'More about this entry', fields: [] },
   ];
   for (const field of fields || []) {
     if (field.type === 'select' || field.type === 'multi-select') groups[0].fields.push(field);
@@ -159,7 +159,7 @@ function renderControl(field, values, describedBy = [], invalid = false) {
   const description = describedBy.length ? ` aria-describedby="${describedBy.map(escapeHtml).join(' ')}"` : '';
   const common = `id="field-${escapeHtml(field.id)}" name="${escapeHtml(field.id)}"${field.required ? ' required' : ''}${invalid ? ' aria-invalid="true"' : ''}${description}`;
   if (field.type === 'select') {
-    return `<select ${common}><option value="">Choose…</option>${renderOptions(field, value, false)}</select>`;
+    return `<select ${common}><option value="">Select…</option>${renderOptions(field, value, false)}</select>`;
   }
   if (field.type === 'multi-select') {
     return `<select ${common} multiple size="${Math.min(6, Math.max(2, (field.options || []).length))}">${renderOptions(field, value, true)}</select>`;
@@ -169,7 +169,7 @@ function renderControl(field, values, describedBy = [], invalid = false) {
   }
   if (field.type === 'checkbox') {
     const checked = value === true || value === 'true' || value === 'on';
-    return `<input ${common} type="checkbox" value="true"${checked ? ' checked' : ''}>`;
+    return `<span class="checkbox-control"><input ${common} type="checkbox" value="true"${checked ? ' checked' : ''}><span class="checkbox-mark" aria-hidden="true"></span></span>`;
   }
   const inputTypes = {
     'short-text': 'text',
@@ -181,7 +181,8 @@ function renderControl(field, values, describedBy = [], invalid = false) {
   const datetimeCapture = field.type === 'datetime'
     ? ` data-datetime-local data-offset-field="${escapeHtml(field.id)}__offset" data-timezone-field="${escapeHtml(field.id)}__timezone"><input type="hidden" name="${escapeHtml(field.id)}__offset"><input type="hidden" name="${escapeHtml(field.id)}__timezone"`
     : '';
-  const input = `<input ${common} type="${inputTypes[field.type]}" value="${escapeHtml(value)}"${field.type === 'number' || field.type === 'date' ? constraintAttributes(field) : ''}${datetimeCapture}>`;
+  const placeholder = field.type === 'number' ? ' placeholder="\u2014"' : '';
+  const input = `<input ${common} type="${inputTypes[field.type]}" value="${escapeHtml(value)}"${placeholder}${field.type === 'number' || field.type === 'date' ? constraintAttributes(field) : ''}${datetimeCapture}>`;
   const unit = field.type === 'number' ? unitFromLabel(field.label) : null;
   return unit
     ? `<div class="readout-control">${input}<span class="readout-unit" id="field-${escapeHtml(field.id)}-unit">${escapeHtml(unit)}</span></div>`
@@ -249,16 +250,20 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
         </section>`;
   }).join('');
   const editing = Boolean(options.correctionRecord);
+  const titleForAction = String(template.title || '').replace(/\s+(?:entry|form)\s*$/i, '').trim();
+  const configuredSubmitLabel = template.presentation && template.presentation.submitLabel;
+  const defaultSubmitLabel = titleForAction && !/\bsubmit\b/i.test(titleForAction)
+    ? `Log ${titleForAction}`
+    : 'Save';
   const submitLabel = editing
     ? 'Save correction'
-    : template.presentation && template.presentation.submitLabel
-    ? template.presentation.submitLabel
-    : 'Submit';
+    : configuredSubmitLabel && !/\bsubmit\b/i.test(configuredSubmitLabel)
+    ? configuredSubmitLabel
+    : defaultSubmitLabel;
   const body = `${toolbarHtml()}
   <main class="layout form-layout">
     <header class="topbar">
       <h1>${escapeHtml(template.title)}</h1>
-      <p class="subtitle">Form</p>
       <p><a class="back" href="/">Back</a></p>
     </header>
 

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -215,7 +215,11 @@ function datetimeCaptureScript(cspNonce) {
 function renderFormPage(template, csrfToken, values = {}, errors = [], options = {}) {
   const errorsByField = errorMap(errors);
   const errorSummary = errors.length
-    ? `<div class="errors" role="alert"><strong>Please correct the highlighted fields.</strong><ul>${errors.map((error) => `<li>${escapeHtml(error.path.replace(/^values\./, ''))}: ${escapeHtml(error.message)}</li>`).join('')}</ul></div>`
+    ? `<div class="errors" role="alert"><strong>Please correct the highlighted fields.</strong><ul>${errors.map((error) => {
+        const id = String(error.path || '').replace(/^values\./, '').split(/[.[]/, 1)[0];
+        const field = (template.fields || []).find((entry) => entry.id === id);
+        return `<li>${escapeHtml(field && field.label ? field.label : id)}: ${escapeHtml(error.message)}</li>`;
+      }).join('')}</ul></div>`
     : '';
   const sections = groupedFields(template.fields).map((group) => {
     const fields = group.fields.map((field) => {
@@ -250,11 +254,17 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
         </section>`;
   }).join('');
   const editing = Boolean(options.correctionRecord);
-  const titleForAction = String(template.title || '').replace(/\s+(?:entry|form)\s*$/i, '').trim();
+  // A title is a page heading, not a verb phrase: "Gym - Strength (machine)"
+  // becomes "Log Gym - Strength (machine)", which reads as nonsense. Only reuse
+  // a title that is already a short, clean noun phrase; otherwise say plainly
+  // what the button does. Templates can always set presentation.submitLabel.
+  const rawTitle = String(template.title || '').replace(/\s+(?:entry|form)\s*$/i, '').trim();
+  const titleIsCleanNounPhrase = rawTitle.length > 0
+    && rawTitle.length <= 24
+    && !/[(){}\[\]:;,/|]|[-\u2010-\u2015\u2212]{1,}\s|\s[-\u2010-\u2015\u2212]/.test(rawTitle)
+    && !/\bsubmit\b/i.test(rawTitle);
   const configuredSubmitLabel = template.presentation && template.presentation.submitLabel;
-  const defaultSubmitLabel = titleForAction && !/\bsubmit\b/i.test(titleForAction)
-    ? `Log ${titleForAction}`
-    : 'Save';
+  const defaultSubmitLabel = titleIsCleanNounPhrase ? `Log ${rawTitle}` : 'Log entry';
   const submitLabel = editing
     ? 'Save correction'
     : configuredSubmitLabel && !/\bsubmit\b/i.test(configuredSubmitLabel)

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -109,6 +109,30 @@ function rawValue(values, field) {
   return field.default;
 }
 
+function unitFromLabel(label) {
+  const match = /\s*\(([^()]{1,16})\)\s*$/.exec(String(label || ''));
+  return match && match[1].trim() ? match[1].trim() : null;
+}
+
+function labelWithoutUnit(label) {
+  const unit = unitFromLabel(label);
+  return unit ? String(label).replace(/\s*\([^()]{1,16}\)\s*$/, '').trim() : String(label || '');
+}
+
+function groupedFields(fields) {
+  const groups = [
+    { key: 'selection', title: 'Choose', fields: [] },
+    { key: 'readouts', title: 'Readouts', fields: [] },
+    { key: 'details', title: 'Details', fields: [] },
+  ];
+  for (const field of fields || []) {
+    if (field.type === 'select' || field.type === 'multi-select') groups[0].fields.push(field);
+    else if (field.type === 'number') groups[1].fields.push(field);
+    else groups[2].fields.push(field);
+  }
+  return groups.filter((group) => group.fields.length > 0);
+}
+
 function constraintAttributes(field) {
   const constraints = field.constraints || {};
   const attributes = [];
@@ -130,9 +154,10 @@ function renderOptions(field, value, multiple) {
   }).join('');
 }
 
-function renderControl(field, values) {
+function renderControl(field, values, describedBy = [], invalid = false) {
   const value = rawValue(values, field);
-  const common = `id="field-${escapeHtml(field.id)}" name="${escapeHtml(field.id)}"${field.required ? ' required' : ''}`;
+  const description = describedBy.length ? ` aria-describedby="${describedBy.map(escapeHtml).join(' ')}"` : '';
+  const common = `id="field-${escapeHtml(field.id)}" name="${escapeHtml(field.id)}"${field.required ? ' required' : ''}${invalid ? ' aria-invalid="true"' : ''}${description}`;
   if (field.type === 'select') {
     return `<select ${common}><option value="">Choose…</option>${renderOptions(field, value, false)}</select>`;
   }
@@ -156,7 +181,11 @@ function renderControl(field, values) {
   const datetimeCapture = field.type === 'datetime'
     ? ` data-datetime-local data-offset-field="${escapeHtml(field.id)}__offset" data-timezone-field="${escapeHtml(field.id)}__timezone"><input type="hidden" name="${escapeHtml(field.id)}__offset"><input type="hidden" name="${escapeHtml(field.id)}__timezone"`
     : '';
-  return `<input ${common} type="${inputTypes[field.type]}" value="${escapeHtml(value)}"${field.type === 'number' || field.type === 'date' ? constraintAttributes(field) : ''}${datetimeCapture}>`;
+  const input = `<input ${common} type="${inputTypes[field.type]}" value="${escapeHtml(value)}"${field.type === 'number' || field.type === 'date' ? constraintAttributes(field) : ''}${datetimeCapture}>`;
+  const unit = field.type === 'number' ? unitFromLabel(field.label) : null;
+  return unit
+    ? `<div class="readout-control">${input}<span class="readout-unit" id="field-${escapeHtml(field.id)}-unit">${escapeHtml(unit)}</span></div>`
+    : input;
 }
 
 function datetimeCaptureScript(cspNonce) {
@@ -187,14 +216,42 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   const errorSummary = errors.length
     ? `<div class="errors" role="alert"><strong>Please correct the highlighted fields.</strong><ul>${errors.map((error) => `<li>${escapeHtml(error.path.replace(/^values\./, ''))}: ${escapeHtml(error.message)}</li>`).join('')}</ul></div>`
     : '';
-  const fields = template.fields.map((field) => {
-    const fieldErrors = errorsByField.get(field.id) || [];
-    const description = field.help ? `<small>${escapeHtml(field.help)}</small>` : '';
-    const inlineErrors = fieldErrors.map((message) => `<small class="field-error">${escapeHtml(message)}</small>`).join('');
-    const required = field.required ? ' <span aria-label="required">*</span>' : '';
-    return `<div class="field${fieldErrors.length ? ' invalid' : ''}"><label for="field-${escapeHtml(field.id)}">${escapeHtml(field.label)}${required}</label>${description}${renderControl(field, values)}${inlineErrors}</div>`;
+  const sections = groupedFields(template.fields).map((group) => {
+    const fields = group.fields.map((field) => {
+      const fieldErrors = errorsByField.get(field.id) || [];
+      const helpId = `field-${field.id}-help`;
+      const errorId = `field-${field.id}-error`;
+      const unitId = `field-${field.id}-unit`;
+      const describedBy = [
+        ...(field.help ? [helpId] : []),
+        ...(fieldErrors.length ? [errorId] : []),
+        ...(field.type === 'number' && unitFromLabel(field.label) ? [unitId] : []),
+      ];
+      const description = field.help
+        ? `<small id="${escapeHtml(helpId)}">${escapeHtml(field.help)}</small>`
+        : '';
+      const inlineErrors = fieldErrors.length
+        ? `<small class="field-error" id="${escapeHtml(errorId)}"><strong>Error:</strong> ${fieldErrors.map(escapeHtml).join('; ')}</small>`
+        : '';
+      const required = field.required ? ' <span aria-label="required">*</span>' : '';
+      const label = field.type === 'number' ? labelWithoutUnit(field.label) : field.label;
+      const classes = [
+        'field',
+        `field-${field.type}`,
+        field.type === 'number' ? 'field-readout' : '',
+        fieldErrors.length ? 'invalid' : '',
+      ].filter(Boolean).join(' ');
+      return `<div class="${classes}"><label for="field-${escapeHtml(field.id)}">${escapeHtml(label)}${required}</label>${description}${renderControl(field, values, describedBy, fieldErrors.length > 0)}${inlineErrors}</div>`;
+    }).join('');
+    return `<section class="form-section form-section-${group.key}" aria-labelledby="form-section-${group.key}">
+          <h2 id="form-section-${group.key}">${group.title}</h2>
+          <div class="form-section-fields">${fields}</div>
+        </section>`;
   }).join('');
-  const submitLabel = template.presentation && template.presentation.submitLabel
+  const editing = Boolean(options.correctionRecord);
+  const submitLabel = editing
+    ? 'Save correction'
+    : template.presentation && template.presentation.submitLabel
     ? template.presentation.submitLabel
     : 'Submit';
   const body = `${toolbarHtml()}
@@ -207,10 +264,12 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
 
     <section class="content form-card">
       ${template.description ? `<p class="form-description">${escapeHtml(template.description)}</p>` : ''}
+      ${editing ? '<p class="correction-note"><strong>Editing a logged entry.</strong> Saving creates a correction; the earlier version stays preserved.</p>' : ''}
       ${errorSummary}
       <form method="post" action="/forms/${encodeURIComponent(template.templateId)}">
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-        ${fields}
+        ${editing ? `<input type="hidden" name="_supersedes" value="${escapeHtml(options.correctionRecord.submissionId)}">` : ''}
+        ${sections}
         <button class="button-link button-link-primary form-primary-action" type="submit">${escapeHtml(submitLabel)}</button>
       </form>
     </section>
@@ -237,27 +296,122 @@ function renderReceiptPage(template, record, options = {}) {
   const fields = new Map((template && template.fields || []).map((field) => [field.id, field]));
   const rows = record.values.map((entry) => {
     const field = fields.get(entry.fieldId);
-    return `<dt>${escapeHtml(entry.fieldLabel || (field ? field.label : entry.fieldId))}</dt><dd>${escapeHtml(displayValue(entry))}</dd>`;
+    const capturedLabel = entry.fieldLabel || (field ? field.label : entry.fieldId);
+    const unit = entry.fieldType === 'number' ? unitFromLabel(capturedLabel) : null;
+    const label = unit ? labelWithoutUnit(capturedLabel) : capturedLabel;
+    return `<tr><th scope="row">${escapeHtml(label)}</th><td class="receipt-value${entry.fieldType === 'number' ? ' receipt-value-number' : ''}">${escapeHtml(displayValue(entry))}</td><td class="receipt-unit">${unit ? escapeHtml(unit) : ''}</td></tr>`;
   }).join('');
   const formHref = `/forms/${encodeURIComponent(record.templateId || template && template.templateId || '')}`;
+  const entriesHref = `${formHref}/entries`;
+  const editHref = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}/edit`;
+  const canEdit = options.canEdit !== false;
+  const received = formatRecordTime(record, options.timezone).dateTimeLabel;
   const body = `${toolbarHtml()}
   <main class="layout form-layout">
     <header class="topbar">
-      <h1>Submission received</h1>
+      <h1>Entry logged</h1>
       <p class="subtitle">${template ? escapeHtml(template.title) : 'Form receipt'}</p>
       <p><a class="back" href="/">Back</a></p>
     </header>
 
     <section class="content form-card receipt-card">
-      <p class="receipt">Receipt ${escapeHtml(record.submissionId)} · ${escapeHtml(record.receiptAt)}</p>
-      <dl>${rows}</dl>
-      <a class="button-link button-link-primary form-primary-action" href="${formHref}">Log another</a>
+      ${record.supersedesRecord ? '<p class="correction-note"><strong>Correction saved.</strong> This entry supersedes an earlier version, which remains preserved.</p>' : ''}
+      <div class="receipt-table-wrap"><table class="receipt-table">
+        <thead><tr><th scope="col">Field</th><th scope="col">Value</th><th scope="col">Unit</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table></div>
+      <nav class="form-actions" aria-label="Entry actions">
+        <a class="button-link button-link-primary form-primary-action" href="${formHref}">Log another</a>
+        <div class="form-secondary-actions">
+          ${canEdit ? `<a class="button-link" href="${editHref}">Edit</a>` : ''}
+          <a class="button-link" href="${entriesHref}">All entries</a>
+        </div>
+      </nav>
+      <p class="receipt-meta">Logged ${escapeHtml(received)}<br><span>Receipt ID ${escapeHtml(record.submissionId)}</span></p>
     </section>
   </main>
   ${themeScript(options.cspNonce)}`;
 
   return baseHtml({
     title: 'Submission receipt',
+    body,
+    customThemeCss: options.customThemeCss,
+    cspNonce: options.cspNonce,
+  });
+}
+
+function formatRecordTime(record, fallbackTimezone) {
+  const timestamp = record.eventAt || record.receiptAt;
+  const timeZone = record.timezone || fallbackTimezone;
+  const date = new Date(timestamp);
+  const options = timeZone ? { timeZone } : {};
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    ...options,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).formatToParts(date);
+  const value = (type) => parts.find((part) => part.type === type).value;
+  const dateKey = `${value('year')}-${value('month')}-${value('day')}`;
+  return {
+    timestamp,
+    dateKey,
+    dayLabel: new Intl.DateTimeFormat('en-US', {
+      ...options,
+      weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
+    }).format(date),
+    dateTimeLabel: new Intl.DateTimeFormat('en-US', {
+      ...options,
+      month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit',
+    }).format(date),
+  };
+}
+
+function entryMetrics(record) {
+  const numeric = record.values.filter((entry) => entry.fieldType === 'number').slice(0, 3);
+  const entries = numeric.length > 0
+    ? numeric
+    : record.values.filter((entry) => entry.fieldType !== 'long-text').slice(0, 2);
+  return entries.map((entry) => {
+    const unit = entry.fieldType === 'number' ? unitFromLabel(entry.fieldLabel) : null;
+    const label = unit ? labelWithoutUnit(entry.fieldLabel) : entry.fieldLabel;
+    return `<span class="entry-metric"><span class="entry-metric-label">${escapeHtml(label)}</span><strong>${escapeHtml(displayValue(entry))}</strong>${unit ? `<span class="entry-metric-unit">${escapeHtml(unit)}</span>` : ''}</span>`;
+  }).join('');
+}
+
+function renderEntriesPage(template, records, options = {}) {
+  const formHref = `/forms/${encodeURIComponent(template.templateId)}`;
+  const groups = new Map();
+  for (const record of records) {
+    const stamp = formatRecordTime(record, options.timezone);
+    if (!groups.has(stamp.dateKey)) groups.set(stamp.dateKey, { stamp, records: [] });
+    groups.get(stamp.dateKey).records.push({ record, stamp });
+  }
+  const entries = [...groups.values()].map(({ stamp, records: dayRecords }) => `
+      <section class="entries-day" aria-labelledby="entries-${escapeHtml(stamp.dateKey)}">
+        <h2 id="entries-${escapeHtml(stamp.dateKey)}"><time datetime="${escapeHtml(stamp.dateKey)}">${escapeHtml(stamp.dayLabel)}</time></h2>
+        <div class="entry-list">${dayRecords.map(({ record, stamp: rowStamp }) => {
+          const href = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}`;
+          const selection = record.values.find((entry) => entry.fieldType === 'select' || entry.fieldType === 'multi-select');
+          return `<a class="entry-row" href="${href}">
+            <span class="entry-row-heading"><time datetime="${escapeHtml(rowStamp.timestamp)}">${escapeHtml(rowStamp.dateTimeLabel)}</time>${selection ? `<strong>${escapeHtml(displayValue(selection))}</strong>` : ''}</span>
+            <span class="entry-metrics">${entryMetrics(record)}</span>
+          </a>`;
+        }).join('')}</div>
+      </section>`).join('');
+  const content = records.length > 0
+    ? entries
+    : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">Log an entry</a></div>`;
+  const body = `${toolbarHtml()}
+  <main class="layout form-layout entries-layout">
+    <header class="topbar">
+      <h1>All entries</h1>
+      <p class="subtitle">${escapeHtml(template.title)}</p>
+      <p><a class="back" href="${formHref}">Back to form</a></p>
+    </header>
+    <section class="content form-card entries-card">${content}</section>
+  </main>
+  ${themeScript(options.cspNonce)}`;
+  return baseHtml({
+    title: `${template.title} entries`,
     body,
     customThemeCss: options.customThemeCss,
     cspNonce: options.cspNonce,
@@ -360,6 +514,14 @@ function nativeValues(template, body, serverTimezone) {
     }
   }
   return { values, raw, eventTime };
+}
+
+function rawValuesForRecord(record) {
+  return Object.fromEntries(record.values.map((entry) => {
+    if (entry.fieldType !== 'datetime') return [entry.fieldId, entry.value];
+    const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})/.exec(String(entry.value));
+    return [entry.fieldId, match ? match[1] : entry.value];
+  }));
 }
 
 function exactOrigin(value) {
@@ -565,6 +727,68 @@ function createFormsRouter(options) {
     }
   });
 
+  router.get('/forms/:templateId/entries', async (req, res, next) => {
+    try {
+      if (!browserAuthenticated(req, res, 'form.submissions.list')) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.submissions.list');
+      const template = await registry.getTemplate(req.params.templateId);
+      if (!template) return formNotFound(req, res, 'form.submissions.list');
+      const visible = await allowed(req, 'forms.submit', template)
+        || await allowed(req, 'forms.read_submissions', template);
+      const actor = principalFor(req);
+      if (!visible || !actor) return formNotFound(req, res, 'form.submissions.list');
+      const submissions = await store.listSubmissions({
+        templateId: template.templateId,
+        actor,
+        limit: 100,
+      });
+      const cspNonce = crypto.randomBytes(18).toString('base64url');
+      formHeaders(res, cspNonce);
+      emitAudit(req, 'form.submissions.list', 'accepted', template);
+      res.status(200).type('html').send(renderEntriesPage(template, submissions, {
+        customThemeCss,
+        cspNonce,
+        timezone: serverTimezone,
+      }));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/forms/:templateId/receipts/:submissionId/edit', async (req, res, next) => {
+    try {
+      if (!browserAuthenticated(req, res, 'form.render')) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.render');
+      const template = await registry.getTemplate(req.params.templateId);
+      const record = await store.getSubmission(req.params.submissionId).catch((error) => {
+        if (error && error.code === 'EVALIDATION') return null;
+        throw error;
+      });
+      if (!template || !record || record.templateId !== template.templateId) {
+        return formNotFound(req, res, 'form.render');
+      }
+      const canSubmit = await allowed(req, 'forms.submit', template);
+      const principal = principalFor(req);
+      const own = principal && record.actor
+        && principal.id === record.actor.id && principal.type === record.actor.type;
+      const canRead = own || await allowed(req, 'forms.read_submissions', record);
+      if (!canRead || !canSubmit) return formNotFound(req, res, 'form.render');
+      const csrfToken = issueContext(req, res);
+      const cspNonce = crypto.randomBytes(18).toString('base64url');
+      formHeaders(res, cspNonce);
+      emitAudit(req, 'form.render', 'accepted', record);
+      res.status(200).type('html').send(renderFormPage(
+        template,
+        csrfToken,
+        rawValuesForRecord(record),
+        [],
+        { customThemeCss, cspNonce, correctionRecord: record }
+      ));
+    } catch (error) {
+      next(error);
+    }
+  });
+
   router.post('/forms/:templateId', (req, res, next) => {
     if (!req.is('application/x-www-form-urlencoded')) {
       emitAudit(req, 'form.submit', 'rejected_validation');
@@ -591,6 +815,7 @@ function createFormsRouter(options) {
       if (!actor) return formNotFound(req, res, 'form.submit');
       const allowedKeys = new Set([
         '_csrf',
+        '_supersedes',
         ...template.fields.flatMap((field) => field.type === 'datetime'
           ? [field.id, `${field.id}__offset`, `${field.id}__timezone`]
           : [field.id]),
@@ -601,12 +826,32 @@ function createFormsRouter(options) {
         return;
       }
       const submitted = nativeValues(template, req.body || {}, serverTimezone);
+      let predecessor = null;
+      let correctionAuthorized = false;
+      if (req.body._supersedes !== undefined) {
+        predecessor = await store.getSubmission(req.body._supersedes).catch((error) => {
+          if (error && error.code === 'EVALIDATION') return null;
+          throw error;
+        });
+        const own = predecessor && predecessor.actor
+          && predecessor.actor.id === actor.id && predecessor.actor.type === actor.type;
+        if (!predecessor || predecessor.templateId !== template.templateId) {
+          return formNotFound(req, res, 'form.submit');
+        }
+        correctionAuthorized = Boolean(own
+          || await allowed(req, 'forms.read_submissions', predecessor)
+          || await allowed(req, 'forms.manage', predecessor));
+        if (!correctionAuthorized) return formNotFound(req, res, 'form.submit');
+      }
       const result = await service.submit({
         templateId: template.templateId,
         values: submitted.values,
         actor,
         ...(submitted.eventTime || {}),
-      });
+        ...(predecessor ? {
+          supersedesRecord: { resourceKind: 'form-submission', id: predecessor.submissionId },
+        } : {}),
+      }, { correctionAuthorized });
       if (result.error) {
         if (result.error.code === 'not_found') return formNotFound(req, res, 'form.submit');
         emitAudit(req, 'form.submit', result.error.code === 'idempotency_conflict'
@@ -614,12 +859,15 @@ function createFormsRouter(options) {
           : 'rejected_validation', template);
         const cspNonce = crypto.randomBytes(18).toString('base64url');
         formHeaders(res, cspNonce);
-        res.status(result.error.code === 'idempotency_conflict' ? 409 : result.error.code === 'invalid_request' ? 400 : 422).type('html').send(renderFormPage(
+        const visibleErrors = result.error.details && result.error.details.length
+          ? result.error.details
+          : [{ path: 'entry', message: result.error.message }];
+        res.status(result.error.code === 'idempotency_conflict' || result.error.code === 'correction_conflict' ? 409 : result.error.code === 'invalid_request' ? 400 : 422).type('html').send(renderFormPage(
           template,
           issueContext(req, res),
           submitted.raw,
-          result.error.details,
-          { customThemeCss, cspNonce }
+          visibleErrors,
+          { customThemeCss, cspNonce, correctionRecord: predecessor }
         ));
         return;
       }
@@ -812,10 +1060,18 @@ function createFormsRouter(options) {
         || await allowed(req, 'forms.read_submissions', record);
       if (!canRead) return formNotFound(req, res, 'form.receipt.read');
       const template = await registry.getTemplate(req.params.templateId);
+      const latest = await store.resolveLatest(record.submissionId);
+      const canEdit = Boolean(template && latest && latest.submissionId === record.submissionId
+        && await allowed(req, 'forms.submit', template));
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.receipt.read', 'accepted', record);
-      res.status(200).type('html').send(renderReceiptPage(template, record, { customThemeCss, cspNonce }));
+      res.status(200).type('html').send(renderReceiptPage(template, record, {
+        customThemeCss,
+        cspNonce,
+        canEdit,
+        timezone: serverTimezone,
+      }));
     } catch (error) {
       next(error);
     }
@@ -829,6 +1085,7 @@ function createFormsRouter(options) {
 
 module.exports = {
   createFormsRouter,
+  renderEntriesPage,
   renderFormPage,
   renderReceiptPage,
 };

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -265,8 +265,8 @@ function valueForField(field, value, path, errors) {
       return value;
     }
     if (constraints.integer && (!Number.isSafeInteger(value))) addError(errors, path, 'must be a safe integer');
-    if (typeof constraints.minimum === 'number' && value < constraints.minimum) addError(errors, path, 'must be at least minimum');
-    if (typeof constraints.maximum === 'number' && value > constraints.maximum) addError(errors, path, 'must be at most maximum');
+    if (typeof constraints.minimum === 'number' && value < constraints.minimum) addError(errors, path, `must be at least ${constraints.minimum}`);
+    if (typeof constraints.maximum === 'number' && value > constraints.maximum) addError(errors, path, `must be at most ${constraints.maximum}`);
     return value;
   }
   if (field.type === 'checkbox') {

--- a/public/style.css
+++ b/public/style.css
@@ -674,40 +674,109 @@ tbody tr:last-child td {
   resize: vertical;
 }
 
-.form-layout .form-card input[type="checkbox"] {
+.form-layout .checkbox-control {
+  position: relative;
   display: block;
-  width: 52px;
-  height: 52px;
-  accent-color: var(--accent);
+  width: 2rem;
+  height: 2rem;
+}
+
+.form-layout .form-card .checkbox-control input[type="checkbox"] {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  width: 2rem;
+  min-height: 2rem;
+  height: 2rem;
+  margin: 0;
+  cursor: pointer;
+  opacity: 0;
+  padding: 0;
+}
+
+.form-layout .checkbox-mark {
+  box-sizing: border-box;
+  display: block;
+  width: 2rem;
+  height: 2rem;
+  border: 2px solid var(--border);
+  border-radius: 0.45rem;
+  background: var(--bg-code);
+  pointer-events: none;
+}
+
+.form-layout .checkbox-mark::after {
+  position: absolute;
+  top: 0.24rem;
+  left: 0.62rem;
+  width: 0.38rem;
+  height: 0.8rem;
+  border: solid var(--bg);
+  border-width: 0 0.18rem 0.18rem 0;
+  content: '';
+  opacity: 0;
+  transform: rotate(45deg);
+}
+
+.form-layout .checkbox-control input[type="checkbox"]:checked + .checkbox-mark {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.form-layout .checkbox-control input[type="checkbox"]:checked + .checkbox-mark::after {
+  opacity: 1;
+}
+
+.form-layout .checkbox-control input[type="checkbox"]:focus-visible + .checkbox-mark {
+  outline: 3px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .form-layout .readout-control {
   position: relative;
 }
 
-.form-layout .field-readout input {
-  height: 4.25rem;
-  padding: 0.45rem 2.7rem 0.45rem 0.65rem;
+.form-layout .field-readout input[type="number"] {
+  height: 5rem;
+  appearance: textfield;
+  padding: 0.5rem 3.75rem 0.5rem 0.75rem;
   font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
-  font-size: clamp(1.65rem, 8vw, 2.35rem);
+  font-size: 2.5rem;
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  letter-spacing: -0.045em;
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.form-layout .field-readout input[type="number"]::-webkit-inner-spin-button,
+.form-layout .field-readout input[type="number"]::-webkit-outer-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.form-layout .field-readout input[type="number"]::placeholder {
+  color: var(--text-soft);
+  font-weight: 400;
+  opacity: 0.55;
 }
 
 .form-layout .readout-unit {
   position: absolute;
   top: 50%;
-  right: 0.45rem;
-  max-width: 2.15rem;
-  border-left: 1px solid var(--border);
+  right: 0.6rem;
+  min-width: 1.8rem;
+  max-width: 2.55rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-elev);
   color: var(--text-soft);
-  font-size: 0.68rem;
+  font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
   line-height: 1.2;
   overflow-wrap: anywhere;
-  padding: 0.3rem 0 0.3rem 0.4rem;
+  padding: 0.35rem 0.38rem;
+  pointer-events: none;
   text-align: center;
   transform: translateY(-50%);
 }
@@ -726,6 +795,10 @@ tbody tr:last-child td {
 .form-layout .form-card .invalid textarea,
 .form-layout .form-card .errors {
   border: 2px solid var(--accent);
+}
+
+.form-layout .form-card .invalid .checkbox-mark {
+  border-color: var(--accent);
 }
 
 .form-layout .form-card .field .field-error {

--- a/public/style.css
+++ b/public/style.css
@@ -587,135 +587,364 @@ tbody tr:last-child td {
   font-size: 0.92rem;
 }
 
-/* First-party forms use the viewer shell directly; keep controls phone-friendly. */
+/* First-party form runner. Every rule is scoped away from document viewers. */
 .form-layout {
   max-width: 42rem;
 }
 
-.form-card {
+.form-layout .form-card {
   overflow-x: visible;
   padding: clamp(1rem, 4vw, 2rem);
 }
 
-.form-description {
-  margin-top: 0;
+.form-layout .form-description {
+  margin: 0 0 1.5rem;
   color: var(--text-soft);
   line-height: 1.5;
 }
 
-.form-card .field {
-  margin: 1.15rem 0;
+.form-layout .form-section + .form-section {
+  margin-top: 1.75rem;
 }
 
-.form-card .field label {
-  display: block;
-  margin-bottom: 0.45rem;
+.form-layout .form-section > h2,
+.form-layout .entries-day > h2,
+.form-layout .entry-metric-label,
+.form-layout .field > label,
+.form-layout .receipt-table thead th {
+  color: var(--text-soft);
+  font-size: 0.72rem;
   font-weight: 700;
+  letter-spacing: 0.12em;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 
-.form-card .field small {
+.form-layout .form-section > h2 {
+  margin: 0 0 0.7rem;
+}
+
+.form-layout .form-section-fields {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-layout .form-section-readouts .form-section-fields {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.form-layout .field {
+  min-width: 0;
+}
+
+.form-layout .field-long-text {
+  grid-column: 1 / -1;
+}
+
+.form-layout .field > label {
   display: block;
-  margin: 0.35rem 0;
+  margin-bottom: 0.4rem;
+}
+
+.form-layout .field small {
+  display: block;
+  margin: 0.4rem 0;
   color: var(--text-soft);
   line-height: 1.4;
 }
 
-.form-card input:not([type="hidden"]),
-.form-card select,
-.form-card textarea {
+.form-layout .form-card input:not([type="hidden"]),
+.form-layout .form-card select,
+.form-layout .form-card textarea {
+  box-sizing: border-box;
   width: 100%;
-  min-height: 48px;
+  min-height: 52px;
   border: 1px solid var(--border);
-  border-radius: 9px;
+  border-radius: 8px;
   background: var(--bg-code);
   color: var(--text);
   font: inherit;
   font-size: 16px;
-  padding: 0.7rem;
+  padding: 0.75rem;
 }
 
-.form-card textarea {
+.form-layout .form-card textarea {
+  min-height: 8rem;
   resize: vertical;
 }
 
-.form-card input[type="checkbox"] {
+.form-layout .form-card input[type="checkbox"] {
   display: block;
-  width: 48px;
-  height: 48px;
+  width: 52px;
+  height: 52px;
   accent-color: var(--accent);
 }
 
-.form-card input:focus-visible,
-.form-card select:focus-visible,
-.form-card textarea:focus-visible,
-.form-primary-action:focus-visible {
+.form-layout .readout-control {
+  position: relative;
+}
+
+.form-layout .field-readout input {
+  height: 4.25rem;
+  padding: 0.45rem 2.7rem 0.45rem 0.65rem;
+  font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  font-size: clamp(1.65rem, 8vw, 2.35rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  letter-spacing: -0.045em;
+}
+
+.form-layout .readout-unit {
+  position: absolute;
+  top: 50%;
+  right: 0.45rem;
+  max-width: 2.15rem;
+  border-left: 1px solid var(--border);
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+  padding: 0.3rem 0 0.3rem 0.4rem;
+  text-align: center;
+  transform: translateY(-50%);
+}
+
+.form-layout .form-card input:focus-visible,
+.form-layout .form-card select:focus-visible,
+.form-layout .form-card textarea:focus-visible,
+.form-layout .button-link:focus-visible,
+.form-layout .entry-row:focus-visible {
   outline: 3px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: 3px;
 }
 
-.form-card .invalid input,
-.form-card .invalid select,
-.form-card .invalid textarea {
-  border: 2px solid #f87171;
+.form-layout .form-card .invalid input,
+.form-layout .form-card .invalid select,
+.form-layout .form-card .invalid textarea,
+.form-layout .form-card .errors {
+  border: 2px solid var(--accent);
 }
 
-.form-card .field .field-error {
-  color: #fecaca;
+.form-layout .form-card .field .field-error {
+  color: var(--text);
   font-weight: 600;
 }
 
-.form-card .errors {
-  border: 1px solid #f87171;
-  border-radius: 9px;
-  background: #431c1c;
-  color: #fee2e2;
+.form-layout .form-card .errors,
+.form-layout .correction-note {
+  border-radius: 8px;
+  background: var(--bg-code);
+  color: var(--text);
   padding: 0.8rem;
 }
 
-.form-card .errors ul {
+.form-layout .form-card .errors {
+  margin-bottom: 1.25rem;
+}
+
+.form-layout .form-card .errors ul {
   margin-bottom: 0;
   padding-left: 1.25rem;
 }
 
-:root[data-theme="light"] .form-card .invalid input,
-:root[data-theme="light"] .form-card .invalid select,
-:root[data-theme="light"] .form-card .invalid textarea,
-:root[data-theme="light"] .form-card .errors {
-  border-color: #b91c1c;
+.form-layout .correction-note {
+  border-left: 3px solid var(--accent);
+  line-height: 1.45;
+  margin: 0 0 1.25rem;
 }
 
-:root[data-theme="light"] .form-card .field .field-error,
-:root[data-theme="light"] .form-card .errors {
-  color: #7f1d1d;
-}
-
-:root[data-theme="light"] .form-card .errors {
-  background: #fef2f2;
-}
-
-.form-primary-action {
+.form-layout .form-primary-action {
+  box-sizing: border-box;
   width: 100%;
-  min-height: 48px;
-  margin-top: 0.7rem;
+  min-height: 52px;
+  margin-top: 1.5rem;
   color: var(--bg);
   font: inherit;
   font-size: 1rem;
 }
 
-.receipt {
+.form-layout .form-card form > .form-primary-action {
+  position: sticky;
+  bottom: 0.75rem;
+  z-index: 1;
+}
+
+.form-layout .receipt-table-wrap {
+  overflow-x: auto;
+}
+
+.form-layout .receipt-table {
+  table-layout: fixed;
+}
+
+.form-layout .receipt-table th,
+.form-layout .receipt-table td {
+  overflow-wrap: anywhere;
+  padding: 0.75rem 0.4rem;
+  vertical-align: baseline;
+}
+
+.form-layout .receipt-table thead th:first-child,
+.form-layout .receipt-table tbody th {
+  width: 42%;
+}
+
+.form-layout .receipt-table thead th:nth-child(2),
+.form-layout .receipt-value {
+  text-align: right;
+}
+
+.form-layout .receipt-table thead th:last-child,
+.form-layout .receipt-unit {
+  width: 3rem;
   color: var(--text-soft);
-  overflow-wrap: anywhere;
+  text-align: right;
 }
 
-.receipt-card dt {
-  margin-top: 1rem;
-  font-weight: 700;
+.form-layout .receipt-table tbody th {
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  font-weight: 600;
 }
 
-.receipt-card dd {
-  margin: 0.25rem 0;
+.form-layout .receipt-value {
   white-space: pre-wrap;
+}
+
+.form-layout .receipt-value-number {
+  font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  font-size: 1.45rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.form-layout .form-actions {
+  margin-top: 1rem;
+}
+
+.form-layout .form-secondary-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin-top: 0.65rem;
+}
+
+.form-layout .form-secondary-actions .button-link {
+  min-height: 48px;
+}
+
+.form-layout .receipt-meta {
+  border-top: 1px solid var(--border);
+  color: var(--text-soft);
+  font-size: 0.78rem;
+  line-height: 1.6;
+  margin: 1.75rem 0 0;
   overflow-wrap: anywhere;
+  padding-top: 0.75rem;
+}
+
+.form-layout .entries-day + .entries-day {
+  margin-top: 1.75rem;
+}
+
+.form-layout .entries-day > h2 {
+  margin: 0 0 0.55rem;
+}
+
+.form-layout .entry-list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.form-layout .entry-row {
+  display: block;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-code);
+  color: var(--text);
+  padding: 0.8rem;
+}
+
+.form-layout .entry-row:active {
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.form-layout .entry-row-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.65rem;
+  color: var(--text-soft);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.form-layout .entry-row-heading strong {
+  color: var(--text);
+  text-align: right;
+}
+
+.form-layout .entry-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin-top: 0.75rem;
+}
+
+.form-layout .entry-metric {
+  min-width: 0;
+}
+
+.form-layout .entry-metric-label {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.form-layout .entry-metric strong {
+  font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  font-size: clamp(1.2rem, 6vw, 1.7rem);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.03em;
+}
+
+.form-layout .entry-metric-unit {
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  margin-left: 0.2rem;
+}
+
+.form-layout .entries-empty {
+  padding: 1rem 0;
+  text-align: center;
+}
+
+.form-layout .entries-empty h2 {
+  font-family: var(--heading-font, inherit);
+  margin-top: 0;
+}
+
+.form-layout .entries-empty p {
+  color: var(--text-soft);
+}
+
+@media (min-width: 420px) {
+  .form-layout .form-section-readouts .form-section-fields {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .form-layout,
+  .form-layout * {
+    scroll-behavior: auto;
+    transition-duration: 0.01ms;
+  }
 }
 
 .content.markdown pre,

--- a/public/style.css
+++ b/public/style.css
@@ -739,9 +739,11 @@ tbody tr:last-child td {
 .form-layout .field-readout input[type="number"] {
   height: 5rem;
   appearance: textfield;
-  padding: 0.5rem 3.75rem 0.5rem 0.75rem;
+  padding: 0.5rem 3rem 0.5rem 0.6rem;
   font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
-  font-size: 2.5rem;
+  /* Weights and reps are routinely 3-4 digits. A fixed 2.5rem clips "150" in a
+     narrow column, so scale with available width and keep a readable floor. */
+  font-size: clamp(1.6rem, 7.5vw, 2.5rem);
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   letter-spacing: -0.05em;
@@ -1006,7 +1008,7 @@ tbody tr:last-child td {
   color: var(--text-soft);
 }
 
-@media (min-width: 420px) {
+@media (min-width: 560px) {
   .form-layout .form-section-readouts .form-section-fields {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -33,7 +33,7 @@ const everyTypeTemplate = {
   fields: [
     { id: 'summary', type: 'short-text', label: 'Summary', required: true },
     { id: 'notes', type: 'long-text', label: 'Notes', required: true },
-    { id: 'count', type: 'number', label: 'Count', required: true, constraints: { minimum: 1, maximum: 10, integer: true } },
+    { id: 'count', type: 'number', label: 'Count (kg)', required: true, constraints: { minimum: 1, maximum: 10, integer: true } },
     { id: 'confirmed', type: 'checkbox', label: 'Confirmed', required: true },
     { id: 'entry-date', type: 'date', label: 'Entry date', required: true },
     { id: 'entry-time', type: 'time', label: 'Entry time', required: true },
@@ -253,6 +253,15 @@ test('GET renders every field type, required markers, constraints, and a CSRF to
     assert.equal(document.querySelector('#field-count').min, '1');
     assert.equal(document.querySelector('#field-count').max, '10');
     assert.equal(document.querySelector('#field-count').step, '1');
+    assert.equal(document.querySelector('.readout-unit').textContent, 'kg');
+    assert.deepEqual(
+      [...document.querySelectorAll('.form-section')].map((section) => section.className),
+      [
+        'form-section form-section-selection',
+        'form-section form-section-readouts',
+        'form-section form-section-details',
+      ]
+    );
     assert.equal(document.querySelector('#field-confirmed').type, 'checkbox');
     assert.equal(document.querySelector('#field-entry-date').type, 'date');
     assert.equal(document.querySelector('#field-entry-time').type, 'time');
@@ -356,13 +365,16 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     assert.equal(receiptResponse.status, 200);
     const receiptHtml = await receiptResponse.text();
     const receiptDocument = assertSharedFormsShell(receiptResponse, receiptHtml, customThemeMarker);
-    assert.equal(receiptDocument.querySelector('.topbar h1').textContent, 'Submission received');
+    assert.equal(receiptDocument.querySelector('.topbar h1').textContent, 'Entry logged');
     assert.equal(receiptDocument.querySelector('.topbar .back').getAttribute('href'), '/');
     assert.equal(
       receiptDocument.querySelector('.form-primary-action').getAttribute('href'),
       '/forms/gym-session-entry'
     );
     assert.equal(receiptDocument.querySelector('.form-primary-action').textContent, 'Log another');
+    assert.ok(receiptDocument.querySelector('.receipt-table'));
+    assert.equal(receiptDocument.querySelector('.receipt-card').firstElementChild.className, 'receipt-table-wrap');
+    assert.ok(receiptDocument.querySelector('.receipt-meta').textContent.includes('Receipt ID'));
     assert.match(receiptHtml, /&lt;em&gt;Notes&lt;\/em&gt;/);
     assert.match(receiptHtml, /&lt;img src=x onerror=alert\(1\)&gt;/);
     assert.doesNotMatch(receiptHtml, /<dd><img/);
@@ -801,7 +813,7 @@ test('receipt preserves capture-time field labels after a template rename', asyn
     await fs.writeFile(templatePath, yaml.dump(template), 'utf8');
     const receipt = await server.request(accepted.headers.get('location'));
     const html = await receipt.text();
-    assert.match(html, /<dt>Lift<\/dt>/);
+    assert.match(html, /<th scope="row">Lift<\/th>/);
     assert.doesNotMatch(html, /Renamed lift/);
   } finally {
     await cleanup(fixture, server);
@@ -835,9 +847,146 @@ test('receipt authorization conceals submissions from a different principal', as
     const denied = await server.request(accepted.headers.get('location'), { headers: { 'X-Principal': 'other' } });
     assert.equal(denied.status, 404);
     assert.equal(await denied.text(), 'Not found.');
+    const deniedEdit = await server.request(`${accepted.headers.get('location')}/edit`, {
+      headers: { 'X-Principal': 'other' },
+    });
+    assert.equal(deniedEdit.status, 404);
+    assert.equal(await deniedEdit.text(), 'Not found.');
     const reader = await server.request(accepted.headers.get('location'), { headers: { 'X-Read-All': 'yes' } });
     assert.equal(reader.status, 200);
     assert.match(await reader.text(), /Smooth reps/);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('entries page is reverse chronological, grouped with date and time, and strictly owner scoped', async () => {
+  const fixture = await makeFixture();
+  const times = [
+    new Date('2026-07-19T18:15:00.000Z'),
+    new Date('2026-07-20T08:30:00.000Z'),
+    new Date('2026-07-21T12:45:00.000Z'),
+  ];
+  let tick = 0;
+  const formsStore = new SubmissionStore({
+    storageRoot: fixture.submissionsPath,
+    clock: () => times[tick++],
+  });
+  const server = await startServer(fixture, {
+    formsStore,
+    formsTimezone: 'UTC',
+    formsAuthorize: ({ req, capability }) => {
+      req.accessContext = {
+        mode: 'scoped',
+        principal: { id: req.get('x-principal') || 'owner', kind: 'user' },
+      };
+      return capability === 'forms.submit' || capability === 'forms.view';
+    },
+  });
+  try {
+    const form = await server.request('/forms/gym-session-entry', { headers: { 'X-Principal': 'owner' } });
+    const context = browserContext(form, await form.text());
+    const submit = async (principal, values) => {
+      const response = await server.request('/api/forms/gym-session-entry/submissions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: context.cookie,
+          Origin: PUBLIC_ORIGIN,
+          'X-CSRF-Token': context.token,
+          'X-Principal': principal,
+        },
+        body: JSON.stringify({ values }),
+      });
+      assert.equal(response.status, 201);
+    };
+    await submit('owner', jsonValues({ 'top-weight': 205, notes: 'Older own' }));
+    await submit('owner', jsonValues({ 'top-weight': 225, notes: 'Newer own' }));
+    await submit('other', jsonValues({ 'top-weight': 999, notes: 'Foreign secret' }));
+
+    const response = await server.request('/forms/gym-session-entry/entries', {
+      headers: { 'X-Principal': 'owner' },
+    });
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    const document = new JSDOM(html).window.document;
+    const rows = [...document.querySelectorAll('.entry-row')];
+    assert.equal(rows.length, 2);
+    assert.match(rows[0].textContent, /225/);
+    assert.match(rows[1].textContent, /205/);
+    assert.doesNotMatch(html, /999|Foreign secret/);
+    assert.equal(document.querySelectorAll('.entries-day').length, 2);
+    for (const time of document.querySelectorAll('.entry-row-heading time')) {
+      assert.match(time.getAttribute('datetime'), /^2026-07-\d{2}T\d{2}:\d{2}/);
+      assert.match(time.textContent, /Jul \d{1,2}, 2026, \d{1,2}:\d{2} [AP]M/);
+    }
+
+    const empty = await server.request('/forms/gym-session-entry/entries', {
+      headers: { 'X-Principal': 'nobody' },
+    });
+    assert.equal(empty.status, 200);
+    assert.match(await empty.text(), /Ready for your first entry\?/);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('receipt edit prefills values and saves an immutable superseding correction', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, { formsTimezone: 'America/New_York' });
+  try {
+    const context = await getBrowserContext(server);
+    const accepted = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Cookie: context.cookie,
+        Origin: PUBLIC_ORIGIN,
+      },
+      body: nativeBody(context.token),
+    });
+    assert.equal(accepted.status, 303);
+    const originalId = accepted.headers.get('location').split('/').pop();
+    const originalPath = path.join(fixture.submissionsPath, `${originalId}.json`);
+    const originalBytes = await fs.readFile(originalPath);
+
+    const edit = await server.request(`${accepted.headers.get('location')}/edit`, {
+      headers: { Cookie: context.cookie },
+    });
+    assert.equal(edit.status, 200);
+    const editDocument = new JSDOM(await edit.text()).window.document;
+    assert.equal(editDocument.querySelector('#field-top-weight').value, '225.5');
+    assert.equal(editDocument.querySelector('#field-notes').value, 'Smooth reps');
+    assert.equal(editDocument.querySelector('input[name="_supersedes"]').value, originalId);
+    assert.match(editDocument.querySelector('.correction-note').textContent, /earlier version stays preserved/i);
+    const editToken = editDocument.querySelector('input[name="_csrf"]').value;
+
+    const correctionBody = nativeBody(editToken, { notes: 'Corrected form', 'top-weight': '230' });
+    correctionBody.set('_supersedes', originalId);
+    const correctedResponse = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Cookie: context.cookie,
+        Origin: PUBLIC_ORIGIN,
+      },
+      body: correctionBody,
+    });
+    assert.equal(correctedResponse.status, 303);
+    assert.equal(Buffer.compare(originalBytes, await fs.readFile(originalPath)), 0);
+    const correctedId = correctedResponse.headers.get('location').split('/').pop();
+    const corrected = JSON.parse(await fs.readFile(
+      path.join(fixture.submissionsPath, `${correctedId}.json`),
+      'utf8'
+    ));
+    assert.deepEqual(corrected.supersedesRecord, { resourceKind: 'form-submission', id: originalId });
+    assert.equal(corrected.values.find((entry) => entry.fieldId === 'top-weight').value, 230);
+    assert.equal((await submissionFiles(fixture.submissionsPath)).length, 2);
+
+    const receipt = await server.request(correctedResponse.headers.get('location'), {
+      headers: { Cookie: context.cookie },
+    });
+    assert.match(await receipt.text(), /supersedes an earlier version/);
   } finally {
     await cleanup(fixture, server);
   }

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -30,6 +30,7 @@ const everyTypeTemplate = {
   revision: 1,
   grammarVersion: 1,
   title: 'Every Field',
+  presentation: { submitLabel: 'Submit' },
   fields: [
     { id: 'summary', type: 'short-text', label: 'Summary', required: true },
     { id: 'notes', type: 'long-text', label: 'Notes', required: true },
@@ -253,7 +254,12 @@ test('GET renders every field type, required markers, constraints, and a CSRF to
     assert.equal(document.querySelector('#field-count').min, '1');
     assert.equal(document.querySelector('#field-count').max, '10');
     assert.equal(document.querySelector('#field-count').step, '1');
+    assert.equal(document.querySelector('#field-count').placeholder, '\u2014');
     assert.equal(document.querySelector('.readout-unit').textContent, 'kg');
+    assert.deepEqual(
+      [...document.querySelectorAll('.form-section > h2')].map((heading) => heading.textContent),
+      ['What you\u2019re logging', 'Measurements', 'More about this entry']
+    );
     assert.deepEqual(
       [...document.querySelectorAll('.form-section')].map((section) => section.className),
       [
@@ -270,8 +276,12 @@ test('GET renders every field type, required markers, constraints, and a CSRF to
     assert.ok(document.querySelector('input[name="recorded-at__timezone"]'));
     assert.match(html, /getTimezoneOffset/);
     assert.equal(document.querySelector('#field-choice').tagName, 'SELECT');
+    assert.equal(document.querySelector('#field-choice option').textContent, 'Select…');
     assert.equal(document.querySelector('#field-choices').multiple, true);
     assert.equal(document.querySelectorAll('[required]').length, everyTypeTemplate.fields.length);
+    assert.equal(document.querySelector('.topbar .subtitle'), null);
+    assert.equal(document.querySelector('.form-primary-action').textContent, 'Log Every Field');
+    assert.doesNotMatch(html, />Submit</);
   } finally {
     await cleanup(fixture, server);
   }
@@ -340,7 +350,9 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     const formDocument = assertSharedFormsShell(formResponse, formHtml, customThemeMarker);
     const context = browserContext(formResponse, formHtml);
     assert.equal(formDocument.querySelector('.topbar h1').textContent, 'Gym Session Entry');
+    assert.equal(formDocument.querySelector('.topbar .subtitle'), null);
     assert.equal(formDocument.querySelector('.topbar .back').getAttribute('href'), '/');
+    assert.equal(formDocument.querySelector('.form-primary-action').textContent, 'Log Gym Session');
     assert.equal(formDocument.querySelector('label[for="field-notes"]').textContent, '<em>Notes</em> *');
     assert.match(formHtml, /&lt;em&gt;Notes&lt;\/em&gt;/);
     assert.doesNotMatch(formHtml, /<em>Notes<\/em>/);


### PR DESCRIPTION
Addresses the operator feedback: forms UI looked bad, receipt ID at top was useless, no way to see past submissions, receipt should be a table, capture time, and allow editing.

- **Design**: numeric fields render as console-style readouts (large tabular numerals, unit chip inferred generically from a trailing parenthesis in the label); fields grouped by type affinity with user-voiced headings instead of a flat stack. All color from existing theme tokens (dark + light), no new fonts, strict CSP with nonces.
- **Receipt**: values table; receipt ID demoted to footer metadata; actions Log another / Edit / All entries.
- **Entries list** at `/forms/:templateId/entries` — reverse-chronological, grouped by day, date and time, same ownership rules as receipts.
- **Edit** prefills the form and submits a correction (superseding record); the earlier version is preserved.

Three defects caught by screenshot review rather than code review: a 3-digit weight was clipped (150 rendered as "15"); the title-derived button label produced "Log Gym — Strength (machine)"; errors said "weight-lbs: must be at most maximum" with no actual limit. All fixed and re-rendered at 390px/430px including the 4-digit worst case.

149/149 tests; all three validators exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)