### PR TITLE
feat(forms): stepped numeric dropdowns, history from the form, Submit label

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -8,6 +8,8 @@ const { isDefinitionId } = require('./template-registry');
 
 const CONTEXT_COOKIE = 'lookie_forms_context';
 const MAX_CONTEXTS = 10000;
+const MAX_STEPPED_OPTIONS = 200;
+const RECENT_ENTRY_LIMIT = 3;
 const ARTIFACT_SANDBOX = 'sandbox allow-scripts allow-forms allow-popups';
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
@@ -138,8 +140,37 @@ function constraintAttributes(field) {
   const attributes = [];
   if (constraints.minimum !== undefined) attributes.push(`min="${escapeHtml(constraints.minimum)}"`);
   if (constraints.maximum !== undefined) attributes.push(`max="${escapeHtml(constraints.maximum)}"`);
-  if (field.type === 'number') attributes.push(constraints.integer === true ? 'step="1"' : 'step="any"');
+  if (field.type === 'number') {
+    attributes.push(`step="${escapeHtml(constraints.step ?? (constraints.integer === true ? 1 : 'any'))}"`);
+  }
   return attributes.length ? ` ${attributes.join(' ')}` : '';
+}
+
+function steppedValues(field) {
+  if (field.type !== 'number' || field.component !== 'stepped-select') return null;
+  const { minimum, maximum, step } = field.constraints || {};
+  if (![minimum, maximum, step].every((value) => typeof value === 'number' && Number.isFinite(value))
+      || step <= 0 || maximum < minimum) return null;
+  const intervals = Math.round((maximum - minimum) / step);
+  const count = intervals + 1;
+  if (!Number.isSafeInteger(count) || count < 1 || count > MAX_STEPPED_OPTIONS) return null;
+  const values = [];
+  for (let index = 0; index < count; index += 1) {
+    const computed = index === intervals ? maximum : minimum + (index * step);
+    const value = Number(computed.toPrecision(15));
+    if (!Number.isFinite(value) || (values.length && value <= values.at(-1))) return null;
+    values.push(Object.is(value, -0) ? 0 : value);
+  }
+  return values;
+}
+
+function renderSteppedOptions(value, options) {
+  const hasValue = value !== undefined && value !== null && value !== '';
+  const selectedValue = hasValue ? Number(value) : null;
+  return `<option value="">Select…</option>${options.map((option) => {
+    const text = String(option);
+    return `<option value="${escapeHtml(text)}"${hasValue && selectedValue === option ? ' selected' : ''}>${escapeHtml(text)}</option>`;
+  }).join('')}`;
 }
 
 function renderOptions(field, value, multiple) {
@@ -170,6 +201,14 @@ function renderControl(field, values, describedBy = [], invalid = false) {
   if (field.type === 'checkbox') {
     const checked = value === true || value === 'true' || value === 'on';
     return `<span class="checkbox-control"><input ${common} type="checkbox" value="true"${checked ? ' checked' : ''}><span class="checkbox-mark" aria-hidden="true"></span></span>`;
+  }
+  const steppedOptions = steppedValues(field);
+  if (steppedOptions) {
+    const select = `<select class="stepped-select" ${common}>${renderSteppedOptions(value, steppedOptions)}</select>`;
+    const unit = unitFromLabel(field.label);
+    return unit
+      ? `<div class="readout-control readout-control-select">${select}<span class="readout-unit" id="field-${escapeHtml(field.id)}-unit">${escapeHtml(unit)}</span></div>`
+      : select;
   }
   const inputTypes = {
     'short-text': 'text',
@@ -210,6 +249,20 @@ function datetimeCaptureScript(cspNonce) {
   }
 })();
 </script>`;
+}
+
+function renderRecentEntries(template, records, timezone) {
+  const entriesHref = `/forms/${encodeURIComponent(template.templateId)}/entries`;
+  const content = records.length
+    ? `<div class="entry-list">${records.map((record) => renderEntryRow(template, record, timezone)).join('')}</div>`
+    : '<p class="recent-entries-empty">Your first entry will appear here after you submit it.</p>';
+  return `<aside class="recent-entries" aria-labelledby="recent-entries-heading">
+        <div class="recent-entries-heading">
+          <h2 id="recent-entries-heading">Recent entries</h2>
+          <a href="${entriesHref}">View all</a>
+        </div>
+        ${content}
+      </aside>`;
 }
 
 function renderFormPage(template, csrfToken, values = {}, errors = [], options = {}) {
@@ -254,27 +307,19 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
         </section>`;
   }).join('');
   const editing = Boolean(options.correctionRecord);
-  // A title is a page heading, not a verb phrase: "Gym - Strength (machine)"
-  // becomes "Log Gym - Strength (machine)", which reads as nonsense. Only reuse
-  // a title that is already a short, clean noun phrase; otherwise say plainly
-  // what the button does. Templates can always set presentation.submitLabel.
-  const rawTitle = String(template.title || '').replace(/\s+(?:entry|form)\s*$/i, '').trim();
-  const titleIsCleanNounPhrase = rawTitle.length > 0
-    && rawTitle.length <= 24
-    && !/[(){}\[\]:;,/|]|[-\u2010-\u2015\u2212]{1,}\s|\s[-\u2010-\u2015\u2212]/.test(rawTitle)
-    && !/\bsubmit\b/i.test(rawTitle);
   const configuredSubmitLabel = template.presentation && template.presentation.submitLabel;
-  const defaultSubmitLabel = titleIsCleanNounPhrase ? `Log ${rawTitle}` : 'Log entry';
   const submitLabel = editing
     ? 'Save correction'
-    : configuredSubmitLabel && !/\bsubmit\b/i.test(configuredSubmitLabel)
-    ? configuredSubmitLabel
-    : defaultSubmitLabel;
+    : configuredSubmitLabel || 'Submit';
+  const entriesHref = `/forms/${encodeURIComponent(template.templateId)}/entries`;
   const body = `${toolbarHtml()}
   <main class="layout form-layout">
     <header class="topbar">
       <h1>${escapeHtml(template.title)}</h1>
-      <p><a class="back" href="/">Back</a></p>
+      <nav class="form-page-links" aria-label="Form navigation">
+        <a class="back" href="/">Back</a>
+        <a class="entries-link" href="${entriesHref}">View entries</a>
+      </nav>
     </header>
 
     <section class="content form-card">
@@ -287,6 +332,7 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
         ${sections}
         <button class="button-link button-link-primary form-primary-action" type="submit">${escapeHtml(submitLabel)}</button>
       </form>
+      ${renderRecentEntries(template, options.recentRecords || [], options.timezone)}
     </section>
   </main>
   ${datetimeCaptureScript(options.cspNonce)}
@@ -392,6 +438,17 @@ function entryMetrics(record) {
   }).join('');
 }
 
+function renderEntryRow(template, record, timezone) {
+  const formHref = `/forms/${encodeURIComponent(template.templateId)}`;
+  const stamp = formatRecordTime(record, timezone);
+  const href = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}`;
+  const selection = record.values.find((entry) => entry.fieldType === 'select' || entry.fieldType === 'multi-select');
+  return `<a class="entry-row" href="${href}">
+            <span class="entry-row-heading"><time datetime="${escapeHtml(stamp.timestamp)}">${escapeHtml(stamp.dateTimeLabel)}</time>${selection ? `<strong>${escapeHtml(displayValue(selection))}</strong>` : ''}</span>
+            <span class="entry-metrics">${entryMetrics(record)}</span>
+          </a>`;
+}
+
 function renderEntriesPage(template, records, options = {}) {
   const formHref = `/forms/${encodeURIComponent(template.templateId)}`;
   const groups = new Map();
@@ -403,14 +460,7 @@ function renderEntriesPage(template, records, options = {}) {
   const entries = [...groups.values()].map(({ stamp, records: dayRecords }) => `
       <section class="entries-day" aria-labelledby="entries-${escapeHtml(stamp.dateKey)}">
         <h2 id="entries-${escapeHtml(stamp.dateKey)}"><time datetime="${escapeHtml(stamp.dateKey)}">${escapeHtml(stamp.dayLabel)}</time></h2>
-        <div class="entry-list">${dayRecords.map(({ record, stamp: rowStamp }) => {
-          const href = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}`;
-          const selection = record.values.find((entry) => entry.fieldType === 'select' || entry.fieldType === 'multi-select');
-          return `<a class="entry-row" href="${href}">
-            <span class="entry-row-heading"><time datetime="${escapeHtml(rowStamp.timestamp)}">${escapeHtml(rowStamp.dateTimeLabel)}</time>${selection ? `<strong>${escapeHtml(displayValue(selection))}</strong>` : ''}</span>
-            <span class="entry-metrics">${entryMetrics(record)}</span>
-          </a>`;
-        }).join('')}</div>
+        <div class="entry-list">${dayRecords.map(({ record }) => renderEntryRow(template, record, options.timezone)).join('')}</div>
       </section>`).join('');
   const content = records.length > 0
     ? entries
@@ -655,6 +705,14 @@ function createFormsRouter(options) {
     return Boolean(await authorize({ req, capability, resource }));
   }
 
+  async function listVisibleSubmissions(req, template, limit) {
+    const visible = await allowed(req, 'forms.submit', template)
+      || await allowed(req, 'forms.read_submissions', template);
+    const actor = principalFor(req);
+    if (!visible || !actor) return null;
+    return store.listSubmissions({ templateId: template.templateId, actor, limit });
+  }
+
   function refuseQueryToken(req, res, next) {
     if (queryCarriesToken(req)) {
       emitAudit(req, eventTypeFor(req), 'rejected_validation');
@@ -732,11 +790,17 @@ function createFormsRouter(options) {
       const canRender = await allowed(req, 'forms.submit', template)
         || await allowed(req, 'forms.view', template);
       if (!canRender) return formNotFound(req, res, 'form.render');
+      const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
       const csrfToken = issueContext(req, res);
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.render', 'accepted', template);
-      res.status(200).type('html').send(renderFormPage(template, csrfToken, {}, [], { customThemeCss, cspNonce }));
+      res.status(200).type('html').send(renderFormPage(template, csrfToken, {}, [], {
+        customThemeCss,
+        cspNonce,
+        recentRecords,
+        timezone: serverTimezone,
+      }));
     } catch (error) {
       next(error);
     }
@@ -748,15 +812,8 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.submissions.list');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template) return formNotFound(req, res, 'form.submissions.list');
-      const visible = await allowed(req, 'forms.submit', template)
-        || await allowed(req, 'forms.read_submissions', template);
-      const actor = principalFor(req);
-      if (!visible || !actor) return formNotFound(req, res, 'form.submissions.list');
-      const submissions = await store.listSubmissions({
-        templateId: template.templateId,
-        actor,
-        limit: 100,
-      });
+      const submissions = await listVisibleSubmissions(req, template, 100);
+      if (!submissions) return formNotFound(req, res, 'form.submissions.list');
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.submissions.list', 'accepted', template);
@@ -788,6 +845,7 @@ function createFormsRouter(options) {
         && principal.id === record.actor.id && principal.type === record.actor.type;
       const canRead = own || await allowed(req, 'forms.read_submissions', record);
       if (!canRead || !canSubmit) return formNotFound(req, res, 'form.render');
+      const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
       const csrfToken = issueContext(req, res);
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
@@ -797,7 +855,13 @@ function createFormsRouter(options) {
         csrfToken,
         rawValuesForRecord(record),
         [],
-        { customThemeCss, cspNonce, correctionRecord: record }
+        {
+          customThemeCss,
+          cspNonce,
+          correctionRecord: record,
+          recentRecords,
+          timezone: serverTimezone,
+        }
       ));
     } catch (error) {
       next(error);
@@ -877,12 +941,19 @@ function createFormsRouter(options) {
         const visibleErrors = result.error.details && result.error.details.length
           ? result.error.details
           : [{ path: 'entry', message: result.error.message }];
+        const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
         res.status(result.error.code === 'idempotency_conflict' || result.error.code === 'correction_conflict' ? 409 : result.error.code === 'invalid_request' ? 400 : 422).type('html').send(renderFormPage(
           template,
           issueContext(req, res),
           submitted.raw,
           visibleErrors,
-          { customThemeCss, cspNonce, correctionRecord: predecessor }
+          {
+            customThemeCss,
+            cspNonce,
+            correctionRecord: predecessor,
+            recentRecords,
+            timezone: serverTimezone,
+          }
         ));
         return;
       }

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -31,7 +31,7 @@ const OPTION_KEYS = new Set(['id', 'label', 'disabled']);
 const CONSTRAINT_KEYS = {
   'short-text': new Set(['minLength', 'maxLength']),
   'long-text': new Set(['minLength', 'maxLength']),
-  number: new Set(['minimum', 'maximum', 'integer']),
+  number: new Set(['minimum', 'maximum', 'integer', 'step']),
   checkbox: new Set(),
   date: new Set(['minimum', 'maximum']),
   time: new Set(),
@@ -153,6 +153,14 @@ function validateConstraintBoundPair(constraints, path, errors, compare = (a, b)
   }
 }
 
+function isStepAligned(value, base, step) {
+  const quotient = (value - base) / step;
+  if (!Number.isFinite(quotient) || Math.abs(quotient) > Number.MAX_SAFE_INTEGER) return false;
+  const nearest = Math.round(quotient);
+  const tolerance = Number.EPSILON * Math.max(1, Math.abs(quotient)) * 8;
+  return Math.abs(quotient - nearest) <= tolerance;
+}
+
 function validateConstraints(field, path, errors) {
   if (!own(field, 'constraints')) return;
   const constraintsPath = `${path}.constraints`;
@@ -173,16 +181,23 @@ function validateConstraints(field, path, errors) {
       addError(errors, `${constraintsPath}.minLength`, 'must not exceed maxLength');
     }
   } else if (field.type === 'number') {
-    for (const key of ['minimum', 'maximum']) {
+    for (const key of ['minimum', 'maximum', 'step']) {
       if (own(constraints, key) && (typeof constraints[key] !== 'number' || !Number.isFinite(constraints[key]) || Object.is(constraints[key], -0))) {
         addError(errors, `${constraintsPath}.${key}`, 'must be a finite JSON number other than negative zero');
       }
+    }
+    if (Number.isFinite(constraints.step) && constraints.step <= 0) {
+      addError(errors, `${constraintsPath}.step`, 'must be greater than zero');
     }
     if (own(constraints, 'integer') && typeof constraints.integer !== 'boolean') {
       addError(errors, `${constraintsPath}.integer`, 'must be a boolean');
     }
     if (Number.isFinite(constraints.minimum) && Number.isFinite(constraints.maximum)) {
       validateConstraintBoundPair(constraints, constraintsPath, errors);
+      if (constraints.maximum >= constraints.minimum && constraints.step > 0
+          && !isStepAligned(constraints.maximum, constraints.minimum, constraints.step)) {
+        addError(errors, `${constraintsPath}.step`, 'must divide the minimum-to-maximum range evenly');
+      }
     }
   } else if (field.type === 'date') {
     for (const key of ['minimum', 'maximum']) {
@@ -267,6 +282,10 @@ function valueForField(field, value, path, errors) {
     if (constraints.integer && (!Number.isSafeInteger(value))) addError(errors, path, 'must be a safe integer');
     if (typeof constraints.minimum === 'number' && value < constraints.minimum) addError(errors, path, `must be at least ${constraints.minimum}`);
     if (typeof constraints.maximum === 'number' && value > constraints.maximum) addError(errors, path, `must be at most ${constraints.maximum}`);
+    if (typeof constraints.step === 'number'
+        && !isStepAligned(value, typeof constraints.minimum === 'number' ? constraints.minimum : 0, constraints.step)) {
+      addError(errors, path, `must align to step ${constraints.step}`);
+    }
     return value;
   }
   if (field.type === 'checkbox') {

--- a/public/style.css
+++ b/public/style.css
@@ -597,6 +597,17 @@ tbody tr:last-child td {
   padding: clamp(1rem, 4vw, 2rem);
 }
 
+.form-layout .form-page-links {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 0.55rem;
+}
+
+.form-layout .entries-link {
+  font-weight: 700;
+}
+
 .form-layout .form-description {
   margin: 0 0 1.5rem;
   color: var(--text-soft);
@@ -750,6 +761,25 @@ tbody tr:last-child td {
   line-height: 1;
 }
 
+.form-layout .field-readout .stepped-select {
+  height: 5rem;
+  padding: 0.5rem 2.4rem 0.5rem 0.6rem;
+  font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  font-size: clamp(1.6rem, 7.5vw, 2.5rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.form-layout .readout-control-select .stepped-select {
+  padding-right: 5rem;
+}
+
+.form-layout .readout-control-select .readout-unit {
+  right: 2.2rem;
+}
+
 .form-layout .field-readout input[type="number"]::-webkit-inner-spin-button,
 .form-layout .field-readout input[type="number"]::-webkit-outer-spin-button {
   margin: 0;
@@ -845,6 +875,47 @@ tbody tr:last-child td {
   position: sticky;
   bottom: 0.75rem;
   z-index: 1;
+}
+
+.form-layout .recent-entries {
+  border-top: 1px solid var(--border);
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+}
+
+.form-layout .recent-entries-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.65rem;
+}
+
+.form-layout .recent-entries-heading h2 {
+  margin: 0;
+  color: var(--text-soft);
+  font-family: var(--heading-font, inherit);
+  font-size: 0.9rem;
+}
+
+.form-layout .recent-entries-heading a {
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.form-layout .recent-entries .entry-row {
+  padding: 0.65rem;
+}
+
+.form-layout .recent-entries .entry-metrics {
+  margin-top: 0.5rem;
+}
+
+.form-layout .recent-entries-empty {
+  margin: 0;
+  color: var(--text-soft);
+  font-size: 0.9rem;
+  line-height: 1.45;
 }
 
 .form-layout .receipt-table-wrap {

--- a/test/fixtures/forms/gym-session-entry.yaml
+++ b/test/fixtures/forms/gym-session-entry.yaml
@@ -25,24 +25,32 @@ fields:
         label: Overhead press
   - id: top-weight
     type: number
-    label: Top weight
+    component: stepped-select
+    label: Top weight (lb)
     required: true
     constraints:
       minimum: 0
+      maximum: 995
+      step: 5
   - id: top-reps
     type: number
+    component: stepped-select
     label: Top reps
     required: true
     constraints:
       minimum: 0
+      maximum: 20
       integer: true
+      step: 1
   - id: rpe
     type: number
+    component: stepped-select
     label: RPE
     required: true
     constraints:
       minimum: 1
       maximum: 10
+      step: 0.5
   - id: felt-strong
     type: checkbox
     label: Felt strong

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -183,7 +183,7 @@ function nativeBody(token, overrides = {}) {
     _csrf: token,
     'session-date': '2026-07-20T09:30',
     lift: 'bench',
-    'top-weight': '225.5',
+    'top-weight': '225',
     'top-reps': '5',
     rpe: '8',
     'felt-strong': 'true',
@@ -280,8 +280,94 @@ test('GET renders every field type, required markers, constraints, and a CSRF to
     assert.equal(document.querySelector('#field-choices').multiple, true);
     assert.equal(document.querySelectorAll('[required]').length, everyTypeTemplate.fields.length);
     assert.equal(document.querySelector('.topbar .subtitle'), null);
-    assert.equal(document.querySelector('.form-primary-action').textContent, 'Log Every Field');
-    assert.doesNotMatch(html, />Submit</);
+    assert.equal(document.querySelector('.form-primary-action').textContent, 'Submit');
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('stepped number selects render bounded options, preserve selection, and store numbers', async () => {
+  const fixture = await makeFixture();
+  const template = {
+    contractVersion: 1,
+    resourceKind: 'form-template',
+    templateId: 'stepped-numbers',
+    ownerId: 'operator',
+    revision: 1,
+    grammarVersion: 1,
+    title: 'Stepped numbers',
+    fields: [
+      {
+        id: 'load', type: 'number', component: 'stepped-select', label: 'Load (kg)', required: true,
+        constraints: { minimum: 1, maximum: 3, step: 0.5 },
+      },
+      {
+        id: 'missing-range', type: 'number', component: 'stepped-select', label: 'Missing range', required: false,
+        constraints: { minimum: 0, step: 1 },
+      },
+      {
+        id: 'too-many', type: 'number', component: 'stepped-select', label: 'Too many', required: false,
+        constraints: { minimum: 0, maximum: 201, step: 1 },
+      },
+      { id: 'summary', type: 'short-text', label: 'Summary', required: true },
+    ],
+  };
+  await fs.writeFile(
+    path.join(fixture.templatesPath, 'stepped-numbers.yaml'),
+    yaml.dump(template),
+    'utf8'
+  );
+  const server = await startServer(fixture);
+  try {
+    const response = await server.request('/forms/stepped-numbers');
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    const context = browserContext(response, html);
+    const load = context.document.querySelector('#field-load');
+    assert.equal(load.tagName, 'SELECT');
+    assert.equal(load.className, 'stepped-select');
+    assert.deepEqual(
+      [...load.options].map((option) => option.value),
+      ['', '1', '1.5', '2', '2.5', '3']
+    );
+    assert.equal(context.document.querySelector('#field-missing-range').type, 'number');
+    assert.equal(context.document.querySelector('#field-missing-range').step, '1');
+    assert.equal(context.document.querySelector('#field-too-many').type, 'number');
+    assert.equal(context.document.querySelector('.form-primary-action').textContent, 'Submit');
+
+    const invalid = await server.request('/forms/stepped-numbers', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Cookie: context.cookie,
+        Origin: PUBLIC_ORIGIN,
+      },
+      body: new URLSearchParams({ _csrf: context.token, load: '2.5', summary: '' }),
+    });
+    assert.equal(invalid.status, 422);
+    const invalidDocument = new JSDOM(await invalid.text()).window.document;
+    assert.equal(invalidDocument.querySelector('#field-load').value, '2.5');
+    assert.equal(
+      invalidDocument.querySelector('.entries-link').getAttribute('href'),
+      '/forms/stepped-numbers/entries'
+    );
+
+    const accepted = await server.request('/forms/stepped-numbers', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Cookie: context.cookie,
+        Origin: PUBLIC_ORIGIN,
+      },
+      body: new URLSearchParams({ _csrf: context.token, load: '2.5', summary: 'Working set' }),
+    });
+    assert.equal(accepted.status, 303);
+    const records = await Promise.all((await submissionFiles(fixture.submissionsPath)).map((fileName) => (
+      fs.readFile(path.join(fixture.submissionsPath, fileName), 'utf8').then(JSON.parse)
+    )));
+    const storedLoad = records[0].values.find((entry) => entry.fieldId === 'load').value;
+    assert.equal(storedLoad, 2.5);
+    assert.equal(typeof storedLoad, 'number');
   } finally {
     await cleanup(fixture, server);
   }
@@ -352,7 +438,7 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     assert.equal(formDocument.querySelector('.topbar h1').textContent, 'Gym Session Entry');
     assert.equal(formDocument.querySelector('.topbar .subtitle'), null);
     assert.equal(formDocument.querySelector('.topbar .back').getAttribute('href'), '/');
-    assert.equal(formDocument.querySelector('.form-primary-action').textContent, 'Log Gym Session');
+    assert.equal(formDocument.querySelector('.form-primary-action').textContent, 'Submit');
     assert.equal(formDocument.querySelector('label[for="field-notes"]').textContent, '<em>Notes</em> *');
     assert.match(formHtml, /&lt;em&gt;Notes&lt;\/em&gt;/);
     assert.doesNotMatch(formHtml, /<em>Notes<\/em>/);
@@ -416,7 +502,7 @@ test('native POST redirects with 303 and the receipt page renders submitted valu
     assert.equal(receipt.status, 200);
     const html = await receipt.text();
     assert.match(html, /Bench press/);
-    assert.match(html, /225\.5/);
+    assert.match(html, /225/);
     assert.match(html, /Smooth reps/);
     assert.equal((await submissionFiles(fixture.submissionsPath)).length, 1);
   } finally {
@@ -431,7 +517,7 @@ test('native validation failure preserves entered values, renders errors, and wr
     const context = await getBrowserContext(server);
     const body = nativeBody(context.token);
     body.delete('notes');
-    body.set('rpe', '11');
+    body.set('rpe', '10');
     const response = await server.request('/forms/gym-session-entry', {
       method: 'POST',
       headers: {
@@ -444,9 +530,9 @@ test('native validation failure preserves entered values, renders errors, and wr
     assert.equal(response.status, 422);
     const document = new JSDOM(await response.text()).window.document;
     assert.match(document.body.textContent, /Please correct/);
-    assert.equal(document.querySelector('#field-rpe').value, '11');
+    assert.equal(document.querySelector('#field-rpe').value, '10');
     assert.equal(document.querySelector('#field-lift').value, 'bench');
-    assert.equal(document.querySelector('#field-top-weight').value, '225.5');
+    assert.equal(document.querySelector('#field-top-weight').value, '225');
     assert.deepEqual(await submissionFiles(fixture.submissionsPath), []);
   } finally {
     await cleanup(fixture, server);
@@ -845,7 +931,13 @@ test('receipt authorization conceals submissions from a different principal', as
   });
   try {
     const form = await server.request('/forms/gym-session-entry', { headers: { 'X-Principal': 'owner' } });
-    const context = browserContext(form, await form.text());
+    const formHtml = await form.text();
+    const context = browserContext(form, formHtml);
+    assert.equal(
+      context.document.querySelector('.entries-link').getAttribute('href'),
+      '/forms/gym-session-entry/entries'
+    );
+    assert.match(context.document.querySelector('.recent-entries-empty').textContent, /first entry/i);
     const accepted = await server.request('/forms/gym-session-entry', {
       method: 'POST',
       headers: {
@@ -914,7 +1006,22 @@ test('entries page is reverse chronological, grouped with date and time, and str
     };
     await submit('owner', jsonValues({ 'top-weight': 205, notes: 'Older own' }));
     await submit('owner', jsonValues({ 'top-weight': 225, notes: 'Newer own' }));
-    await submit('other', jsonValues({ 'top-weight': 999, notes: 'Foreign secret' }));
+    await submit('other', jsonValues({ 'top-weight': 995, notes: 'Foreign secret' }));
+
+    const refreshedForm = await server.request('/forms/gym-session-entry', {
+      headers: { 'X-Principal': 'owner' },
+    });
+    assert.equal(refreshedForm.status, 200);
+    const refreshedHtml = await refreshedForm.text();
+    const refreshedDocument = new JSDOM(refreshedHtml).window.document;
+    const recentRows = [...refreshedDocument.querySelectorAll('.recent-entries .entry-row')];
+    assert.equal(recentRows.length, 2);
+    assert.match(recentRows[0].textContent, /225/);
+    assert.match(recentRows[1].textContent, /205/);
+    assert.doesNotMatch(
+      refreshedDocument.querySelector('.recent-entries').textContent,
+      /995|Foreign secret/
+    );
 
     const response = await server.request('/forms/gym-session-entry/entries', {
       headers: { 'X-Principal': 'owner' },
@@ -926,7 +1033,7 @@ test('entries page is reverse chronological, grouped with date and time, and str
     assert.equal(rows.length, 2);
     assert.match(rows[0].textContent, /225/);
     assert.match(rows[1].textContent, /205/);
-    assert.doesNotMatch(html, /999|Foreign secret/);
+    assert.doesNotMatch(html, /995|Foreign secret/);
     assert.equal(document.querySelectorAll('.entries-day').length, 2);
     for (const time of document.querySelectorAll('.entry-row-heading time')) {
       assert.match(time.getAttribute('datetime'), /^2026-07-\d{2}T\d{2}:\d{2}/);
@@ -967,7 +1074,7 @@ test('receipt edit prefills values and saves an immutable superseding correction
     });
     assert.equal(edit.status, 200);
     const editDocument = new JSDOM(await edit.text()).window.document;
-    assert.equal(editDocument.querySelector('#field-top-weight').value, '225.5');
+    assert.equal(editDocument.querySelector('#field-top-weight').value, '225');
     assert.equal(editDocument.querySelector('#field-notes').value, 'Smooth reps');
     assert.equal(editDocument.querySelector('input[name="_supersedes"]').value, originalId);
     assert.match(editDocument.querySelector('.correction-note').textContent, /earlier version stays preserved/i);

--- a/test/forms-schema.test.js
+++ b/test/forms-schema.test.js
@@ -92,6 +92,10 @@ test('invalid constraint declarations report the individual constraint paths', (
     [field('text', 'short-text', {constraints: {minLength: 3, maxLength: 2}}), 'fields[0].constraints.minLength'],
     [field('count', 'number', {constraints: {minimum: NaN}}), 'fields[0].constraints.minimum'],
     [field('count', 'number', {constraints: {maximum: Infinity}}), 'fields[0].constraints.maximum'],
+    [field('count', 'number', {constraints: {step: 0}}), 'fields[0].constraints.step'],
+    [field('count', 'number', {constraints: {step: -1}}), 'fields[0].constraints.step'],
+    [field('count', 'number', {constraints: {step: Infinity}}), 'fields[0].constraints.step'],
+    [field('count', 'number', {constraints: {minimum: 0, maximum: 10, step: 3}}), 'fields[0].constraints.step'],
     [field('count', 'number', {constraints: {integer: 'yes'}}), 'fields[0].constraints.integer'],
     [field('day', 'date', {constraints: {minimum: '2026-02-30'}}), 'fields[0].constraints.minimum'],
     [field('day', 'date', {constraints: {minimum: '2027-01-01', maximum: '2026-01-01'}}), 'fields[0].constraints.minimum'],
@@ -115,6 +119,18 @@ test('defaults use submission validation and dynamic selection defaults are proh
     field('choice', 'select', {providerSlot: 'catalog', default: 'one'}),
   ]));
   assert.ok(paths(dynamic).includes('fields[0].default'));
+});
+
+test('number steps accept decimal ranges and reject submitted values off the step', () => {
+  const stepped = templateWith([
+    field('load', 'number', {
+      component: 'stepped-select',
+      constraints: { minimum: 0.5, maximum: 2, step: 0.5 },
+    }),
+  ]);
+  assert.deepEqual(validateTemplate(stepped), {valid: true, errors: []});
+  assert.equal(validateSubmissionValues(stepped, {load: 1.5}).valid, true);
+  assert.ok(paths(validateSubmissionValues(stepped, {load: 1.6})).includes('values.load'));
 });
 
 test('submission values reject every type constraint with exact value paths', () => {


### PR DESCRIPTION
Operator feedback: dropdowns for weight/sets/reps, reach history from inside the form without submitting, and the primary action should read "Submit".

- **Stepped dropdowns that stay numeric.** Fields keep `type: number`; the already-validated `component` hint (`stepped-select`) changes only the HTML control. Converting them to `select` would have stored option IDs as strings and destroyed numeric semantics for later analysis — verified the stored value is still a JSON number.
- `constraints.step` added (positive finite; must divide the range evenly; submitted values must align to the step). A normal number input now also emits the configured `step`.
- **Silent fallback** to a plain number input when bounds/step are missing or the option count falls outside 1..200, so a bad template can never emit a monstrous select.
- **History from the form**: an always-present link to the template's entries plus a compact recent-entries peek, both authorized like the entries page and working on a freshly loaded empty form.
- **"Submit"** is now the default primary action (still overridable via `presentation.submitLabel`).

Verified by probe: weight renders 62 options (0–300 by 5), history link present on an empty form, label reads "Submit", and a dropdown submission stores `150` with `typeof === 'number'`.

151/151 tests; validate-raw-html, validate-editable-mode, skill-drift all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)