### PR TITLE
feat(forms): logical storage destinations (alias to root), replacing the global submissions bucket

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -150,6 +150,12 @@ Neither response includes credentials, token names, repository roots, store path
 | `publish.maxRevisionBytes` | Positive integer; default `10485760` |
 | `publish.maxMetadataBytes` | Positive integer; default `65536` |
 | `publish.maxRevisions` | Positive integer; default `20` |
+| `forms.enabled` | Enables the first-party forms routes; default `false` |
+| `forms.templatesPath` | Directory containing validated form-template YAML files; required when forms are enabled |
+| `forms.destinations.<destinationId>` | Deployment-owned map from definition-ID aliases to absolute or `~/`-relative submission roots; roots are never disclosed to clients |
+| `forms.submissionsPath` | Legacy single submission root; when `destinations` is absent it becomes the `default` destination |
+| `forms.timezone` | IANA timezone used when a browser cannot report its UTC offset |
+| `forms.publicOrigins[]` / `.publicOrigin` | Exact allowed browser mutation origins, including scheme and port; browser mutations fail closed when absent |
 | `themes.<name>.dark` / `.light` | Custom CSS-variable maps. Accepted keys: `bg`, `bg_elev`, `bg_code`, `text`, `text_soft`, `accent`, `border`, `link`, `page_bg`, `toolbar_bg`, `toolbar_btn_bg`, `toolbar_btn_hover`, `toolbar_btn_text`, `toc_active_bg`, `heading_font` |
 
 Configuration file lookup is `LOOKIE_LINK_CONFIG`, then the user config directory, then the project root. The recognized server environment variables are `LOOKIE_LINK_CONFIG`, `ROOT_MAPPINGS`, `PORT`, `HOSTNAME`, `LOOKIE_LINK_ENABLE_EDITING`, `LOOKIE_LINK_ENABLE_ANNOTATIONS`, and `LOOKIE_LINK_ENABLE_RAW_HTML`. Secret environment-variable names are chosen by each `secretEnv` value.
@@ -211,9 +217,15 @@ equality test intentionally does not cover them.
 | Receipt: `/forms/:templateId/receipts/:submissionId` | `GET` | Submitter (or `read_submissions`) | `forms.enabled` | Uniform 404 for non-owners and unknown IDs. |
 
 Templates are file-backed and validated on load (invalid ones are skipped, last
-known good retained). Each accepted submission is one immutable JSON file with a
-capture-time field type and label, option label snapshots, schema digest, and
-optional idempotency key.
+known good retained). A template may select an optional definition-ID
+`destinationId`; omission selects `default`. The deployment-owned destination
+adapter maps approved aliases to private storage roots. A template cannot define
+that map or use a path as an alias, and an unknown alias prevents startup rather
+than falling back. Each accepted submission is one immutable JSON file under the
+selected root, with a capture-time field type and label, option label snapshots,
+schema digest, and optional idempotency key. Receipt, correction, history, and
+list reads use the same template destination, and no client response or audit
+event includes storage paths.
 
 Forms builder UI, dynamic option providers, sessions, and reaction dispatch are
 **not** implemented.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The authoritative inventory of recognized keys, defaults, and environment overrides is [CAPABILITIES.md](CAPABILITIES.md#configuration-key-inventory). Unknown YAML keys are not feature declarations; in particular, there are no implemented forms, templates, or submissions settings.
+The authoritative inventory of recognized keys, defaults, and environment overrides is [CAPABILITIES.md](CAPABILITIES.md#configuration-key-inventory). Unknown YAML keys are not feature declarations; only settings listed in that inventory are supported.
 
 ## File lookup and precedence
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ const os = require('node:os');
 const path = require('node:path');
 const fs = require('node:fs');
 const yaml = require('js-yaml');
+const { configuredDestinationRoots } = require('./forms/destination-adapter');
 
 const DEFAULT_PORT = 9876;
 const DEFAULT_HOSTNAME = 'localhost';
@@ -240,6 +241,10 @@ function getFormsConfig() {
   }
 
   const enabled = parseBoolean(config.forms.enabled) === true;
+  const destinations = config.forms.destinations !== undefined
+    || typeof config.forms.submissionsPath === 'string'
+    ? configuredDestinationRoots(config.forms)
+    : undefined;
   return {
     enabled,
     templatesPath: typeof config.forms.templatesPath === 'string'
@@ -248,6 +253,7 @@ function getFormsConfig() {
     submissionsPath: typeof config.forms.submissionsPath === 'string'
       ? path.resolve(expandHome(config.forms.submissionsPath))
       : undefined,
+    destinations,
     timezone: typeof config.forms.timezone === 'string'
       ? config.forms.timezone
       : undefined,

--- a/lib/forms/destination-adapter.js
+++ b/lib/forms/destination-adapter.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { SubmissionStore } = require('./submission-store');
+const { isDefinitionId } = require('./template-registry');
+
+const DEFAULT_DESTINATION_ID = 'default';
+
+function destinationError(destinationId) {
+  const error = new Error(`Form destination "${destinationId}" is not configured.`);
+  error.code = 'EDESTINATION';
+  return error;
+}
+
+function expandHome(value) {
+  if (value === '~') return os.homedir();
+  if (value.startsWith('~/')) return path.join(os.homedir(), value.slice(2));
+  return value;
+}
+
+function configuredDestinationRoots(config = {}) {
+  let configured = config.destinations;
+  if (configured === undefined && typeof config.submissionsPath === 'string') {
+    configured = { [DEFAULT_DESTINATION_ID]: config.submissionsPath };
+  }
+  if (!configured || typeof configured !== 'object' || Array.isArray(configured)) {
+    throw new Error('forms.destinations must be a map of destination aliases to storage roots.');
+  }
+
+  const roots = {};
+  for (const [destinationId, configuredRoot] of Object.entries(configured)) {
+    if (!isDefinitionId(destinationId)) {
+      throw new Error('Each forms.destinations key must be a valid definition ID.');
+    }
+    if (typeof configuredRoot !== 'string' || !configuredRoot.trim()) {
+      throw new Error(`Storage root for form destination "${destinationId}" must be a path.`);
+    }
+    roots[destinationId] = path.resolve(expandHome(configuredRoot));
+  }
+  if (Object.keys(roots).length === 0) {
+    throw new Error('forms.destinations must configure at least one destination.');
+  }
+  return roots;
+}
+
+function prepareStorageRoot(destinationId, storageRoot) {
+  try {
+    fs.mkdirSync(storageRoot, { recursive: true });
+    const stat = fs.lstatSync(storageRoot);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error('not a directory');
+  } catch (_error) {
+    throw new Error(`Storage root for form destination "${destinationId}" is not a usable directory.`);
+  }
+}
+
+function destinationIdFor(template) {
+  return template && template.destinationId || DEFAULT_DESTINATION_ID;
+}
+
+function storeForTemplate(store, template) {
+  const destinationId = destinationIdFor(template);
+  if (store && typeof store.forDestination === 'function') {
+    return store.forDestination(destinationId);
+  }
+  if (destinationId === DEFAULT_DESTINATION_ID) return store;
+  throw destinationError(destinationId);
+}
+
+class DestinationAdapter {
+  #stores;
+
+  constructor(config = {}) {
+    const roots = configuredDestinationRoots(config);
+    this.#stores = new Map();
+    for (const [destinationId, storageRoot] of Object.entries(roots)) {
+      prepareStorageRoot(destinationId, storageRoot);
+      this.#stores.set(destinationId, new SubmissionStore({
+        storageRoot,
+        ...(config.clock ? { clock: config.clock } : {}),
+      }));
+    }
+  }
+
+  destinationIds() {
+    return [...this.#stores.keys()];
+  }
+
+  forDestination(destinationId) {
+    if (!isDefinitionId(destinationId) || !this.#stores.has(destinationId)) {
+      throw destinationError(destinationId);
+    }
+    return this.#stores.get(destinationId);
+  }
+
+  // SubmissionService accepts either this adapter or a legacy single-root
+  // SubmissionStore, so retain the common method shape at the boundary.
+  createSubmission(input, options) {
+    return this.forDestination(DEFAULT_DESTINATION_ID).createSubmission(input, options);
+  }
+}
+
+module.exports = {
+  DEFAULT_DESTINATION_ID,
+  DestinationAdapter,
+  configuredDestinationRoots,
+  destinationIdFor,
+  storeForTemplate,
+};

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -4,6 +4,7 @@ const crypto = require('node:crypto');
 const express = require('express');
 
 const { baseHtml, themeScript, toolbarHtml } = require('../renderer');
+const { storeForTemplate } = require('./destination-adapter');
 const { isDefinitionId } = require('./template-registry');
 
 const CONTEXT_COOKIE = 'lookie_forms_context';
@@ -710,7 +711,8 @@ function createFormsRouter(options) {
       || await allowed(req, 'forms.read_submissions', template);
     const actor = principalFor(req);
     if (!visible || !actor) return null;
-    return store.listSubmissions({ templateId: template.templateId, actor, limit });
+    return storeForTemplate(store, template)
+      .listSubmissions({ templateId: template.templateId, actor, limit });
   }
 
   function refuseQueryToken(req, res, next) {
@@ -832,11 +834,13 @@ function createFormsRouter(options) {
       if (!browserAuthenticated(req, res, 'form.render')) return;
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.render');
       const template = await registry.getTemplate(req.params.templateId);
-      const record = await store.getSubmission(req.params.submissionId).catch((error) => {
+      if (!template) return formNotFound(req, res, 'form.render');
+      const destinationStore = storeForTemplate(store, template);
+      const record = await destinationStore.getSubmission(req.params.submissionId).catch((error) => {
         if (error && error.code === 'EVALIDATION') return null;
         throw error;
       });
-      if (!template || !record || record.templateId !== template.templateId) {
+      if (!record || record.templateId !== template.templateId) {
         return formNotFound(req, res, 'form.render');
       }
       const canSubmit = await allowed(req, 'forms.submit', template);
@@ -890,6 +894,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.submit');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template || !await allowed(req, 'forms.submit', template)) return formNotFound(req, res, 'form.submit');
+      const destinationStore = storeForTemplate(store, template);
       const actor = principalFor(req);
       if (!actor) return formNotFound(req, res, 'form.submit');
       const allowedKeys = new Set([
@@ -908,7 +913,7 @@ function createFormsRouter(options) {
       let predecessor = null;
       let correctionAuthorized = false;
       if (req.body._supersedes !== undefined) {
-        predecessor = await store.getSubmission(req.body._supersedes).catch((error) => {
+        predecessor = await destinationStore.getSubmission(req.body._supersedes).catch((error) => {
           if (error && error.code === 'EVALIDATION') return null;
           throw error;
         });
@@ -992,6 +997,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res);
       const template = await registry.getTemplate(req.params.templateId);
       if (!template || !await allowed(req, 'forms.submit', template)) return apiNotFound(req, res);
+      const destinationStore = storeForTemplate(store, template);
       const actor = principalFor(req);
       if (!actor) return apiNotFound(req, res);
       const body = req.body && typeof req.body === 'object' && !Array.isArray(req.body) ? req.body : {};
@@ -1009,7 +1015,7 @@ function createFormsRouter(options) {
       if (body.supersedesRecord !== undefined) {
         const reference = body.supersedesRecord;
         const predecessor = reference && reference.resourceKind === 'form-submission'
-          ? await store.getSubmission(reference.id).catch((error) => {
+          ? await destinationStore.getSubmission(reference.id).catch((error) => {
             if (error && error.code === 'EVALIDATION') return null;
             throw error;
           })
@@ -1082,7 +1088,7 @@ function createFormsRouter(options) {
         res.status(400).json({ ok: false, error: 'limit must be a positive integer.' });
         return;
       }
-      const submissions = await store.listSubmissions({
+      const submissions = await storeForTemplate(store, template).listSubmissions({
         templateId: template.templateId,
         actor,
         limit: Math.min(parsedLimit, 100),
@@ -1103,7 +1109,10 @@ function createFormsRouter(options) {
       }
       if (!apiAuthenticated(req, res, 'form.submission.history')) return;
       if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, 'form.submission.history');
-      const history = await store.getSubmissionHistory(req.params.submissionId).catch((error) => {
+      const template = await registry.getTemplate(req.params.templateId);
+      if (!template) return apiNotFound(req, res, 'form.submission.history');
+      const destinationStore = storeForTemplate(store, template);
+      const history = await destinationStore.getSubmissionHistory(req.params.submissionId).catch((error) => {
         if (error && error.code === 'EVALIDATION') return null;
         throw error;
       });
@@ -1134,7 +1143,10 @@ function createFormsRouter(options) {
     try {
       if (!browserAuthenticated(req, res, 'form.receipt.read')) return;
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.receipt.read');
-      const record = await store.getSubmission(req.params.submissionId).catch((error) => {
+      const template = await registry.getTemplate(req.params.templateId);
+      if (!template) return formNotFound(req, res, 'form.receipt.read');
+      const destinationStore = storeForTemplate(store, template);
+      const record = await destinationStore.getSubmission(req.params.submissionId).catch((error) => {
         if (error && error.code === 'EVALIDATION') return null;
         throw error;
       });
@@ -1145,8 +1157,7 @@ function createFormsRouter(options) {
       const canRead = ownReceipt
         || await allowed(req, 'forms.read_submissions', record);
       if (!canRead) return formNotFound(req, res, 'form.receipt.read');
-      const template = await registry.getTemplate(req.params.templateId);
-      const latest = await store.resolveLatest(record.submissionId);
+      const latest = await destinationStore.resolveLatest(record.submissionId);
       const canEdit = Boolean(template && latest && latest.submissionId === record.submissionId
         && await allowed(req, 'forms.submit', template));
       const cspNonce = crypto.randomBytes(18).toString('base64url');

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -20,7 +20,7 @@ const CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/u;
 
 const TEMPLATE_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision',
-  'grammarVersion', 'title', 'description', 'tags', 'lineage',
+  'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
   'presentation', 'fields',
 ]);
 const FIELD_KEYS = new Set([
@@ -403,6 +403,7 @@ function validateTemplate(doc) {
   if (own(doc, 'ownerId')) validateId(doc.ownerId, 'ownerId', errors);
   if (own(doc, 'revision')) validateInteger(doc.revision, 'revision', errors, 1, Number.MAX_SAFE_INTEGER);
   if (own(doc, 'grammarVersion') && doc.grammarVersion !== 1) addError(errors, 'grammarVersion', 'must equal 1');
+  if (own(doc, 'destinationId')) validateId(doc.destinationId, 'destinationId', errors);
   if (own(doc, 'title')) validateText(doc.title, 'title', errors, {minimum: 1, maximum: 200});
   if (own(doc, 'description')) validateText(doc.description, 'description', errors, {maximum: 2000});
   if (own(doc, 'tags')) {

--- a/lib/forms/submission-service.js
+++ b/lib/forms/submission-service.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { validateSubmissionValues } = require('./schema');
+const { storeForTemplate } = require('./destination-adapter');
 
 function validationError(errors) {
   return {
@@ -52,6 +53,7 @@ class SubmissionService {
     const registered = await this.registry.getTemplate(input.templateId);
     if (!registered) return { error: { code: 'not_found', message: 'Form not found.' } };
     const { schemaDigest, ...template } = registered;
+    const destinationStore = storeForTemplate(this.store, template);
     let predecessor = null;
     if (input.supersedesRecord !== undefined) {
       if (!input.supersedesRecord || input.supersedesRecord.resourceKind !== 'form-submission'
@@ -59,7 +61,7 @@ class SubmissionService {
         return requestError('supersedesRecord must identify a form-submission.');
       }
       try {
-        predecessor = await this.store.getSubmission(input.supersedesRecord.id);
+        predecessor = await destinationStore.getSubmission(input.supersedesRecord.id);
       } catch (error) {
         if (!error || error.code !== 'EVALIDATION') throw error;
       }
@@ -95,7 +97,7 @@ class SubmissionService {
 
     let record;
     try {
-      record = await this.store.createSubmission({
+      record = await destinationStore.createSubmission({
         actor: input.actor,
         templateId: template.templateId,
         templateVersion: template.revision,

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs/promises');
+const fsSync = require('node:fs');
 const path = require('node:path');
 const yaml = require('js-yaml');
 
@@ -25,9 +26,44 @@ class TemplateRegistry {
     }
     this.templatesPath = path.resolve(options.templatesPath);
     this.logger = options.logger || console;
+    this.destinationIds = options.destinationIds === undefined
+      ? null
+      : new Set(options.destinationIds);
     this.files = new Map();
     this.failureMessages = new Map();
     this.refreshPromise = null;
+    this.assertConfiguredDestinationsAtStartup();
+  }
+
+  destinationFailure(template) {
+    if (!this.destinationIds) return null;
+    const destinationId = template.destinationId || 'default';
+    return this.destinationIds.has(destinationId)
+      ? null
+      : `references unknown destinationId ${destinationId}`;
+  }
+
+  assertConfiguredDestinationsAtStartup() {
+    if (!this.destinationIds) return;
+    let entries;
+    try {
+      entries = fsSync.readdirSync(this.templatesPath, { withFileTypes: true });
+    } catch (error) {
+      if (error && error.code === 'ENOENT') return;
+      throw error;
+    }
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.yaml')) continue;
+      let document;
+      try {
+        document = yaml.load(fsSync.readFileSync(path.join(this.templatesPath, entry.name), 'utf8'));
+      } catch (_error) {
+        continue;
+      }
+      if (!validateTemplate(document).valid) continue;
+      const reason = this.destinationFailure(document);
+      if (reason) throw new Error(`Form template ${entry.name} ${reason}.`);
+    }
   }
 
   logFailure(fileName, reason) {
@@ -52,6 +88,11 @@ class TemplateRegistry {
           .map((error) => `${error.path || 'template'} ${error.message}`)
           .join('; ');
         this.logFailure(fileName, reason);
+        return null;
+      }
+      const destinationFailure = this.destinationFailure(document);
+      if (destinationFailure) {
+        this.logFailure(fileName, destinationFailure);
         return null;
       }
       const entry = {

--- a/lookie-link.yaml.example
+++ b/lookie-link.yaml.example
@@ -103,7 +103,14 @@ repositories:
 # forms:
 #   enabled: true
 #   templatesPath: ~/.local/share/lookie-link/form-templates
-#   submissionsPath: ~/.local/share/lookie-link/form-submissions
+#   # Deployment-owned aliases. Templates may select one of these definition
+#   # IDs, but cannot declare storage paths or create destinations.
+#   destinations:
+#     gym-log: ~/.local/share/lookie-link/gym-submissions
+#     default: ~/.local/share/lookie-link/form-submissions
+#   # Legacy single-root configuration remains supported as `default` when
+#   # destinations is absent:
+#   # submissionsPath: ~/.local/share/lookie-link/form-submissions
 #   # IANA zone used when a browser cannot report its UTC offset.
 #   timezone: America/New_York
 #   # Required for browser mutations. Each entry is an exact scheme/host/port;

--- a/server.js
+++ b/server.js
@@ -82,7 +82,10 @@ const {
   buildWhoAmIDocument,
 } = require('./lib/agent-discovery');
 const { TemplateRegistry } = require('./lib/forms/template-registry');
-const { SubmissionStore } = require('./lib/forms/submission-store');
+const {
+  DestinationAdapter,
+  configuredDestinationRoots,
+} = require('./lib/forms/destination-adapter');
 const { SubmissionService } = require('./lib/forms/submission-service');
 const { createFormsRouter } = require('./lib/forms/routes');
 
@@ -788,11 +791,16 @@ function createApp(options = {}) {
     next();
   });
   if (formsConfig && formsConfig.enabled === true) {
-    if (!formsConfig.templatesPath || !formsConfig.submissionsPath) {
-      throw new Error('forms.templatesPath and forms.submissionsPath are required when forms are enabled.');
+    if (!formsConfig.templatesPath) {
+      throw new Error('forms.templatesPath is required when forms are enabled.');
     }
-    const formsRegistry = options.formsRegistry || new TemplateRegistry({ templatesPath: formsConfig.templatesPath });
-    const formsStore = options.formsStore || new SubmissionStore({ storageRoot: formsConfig.submissionsPath });
+    const destinationRoots = configuredDestinationRoots(formsConfig);
+    const formsRegistry = options.formsRegistry || new TemplateRegistry({
+      templatesPath: formsConfig.templatesPath,
+      destinationIds: Object.keys(destinationRoots),
+      logger,
+    });
+    const formsStore = options.formsStore || new DestinationAdapter({ destinations: destinationRoots });
     const formsService = options.formsService || new SubmissionService({ registry: formsRegistry, store: formsStore });
     const formsAudit = typeof options.formsAudit === 'function'
       ? options.formsAudit

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -1300,6 +1300,129 @@ test('exit gate survives fresh registry, store, service, and app construction', 
   }
 });
 
+test('destination aliases isolate writes, lists, and receipts without disclosing storage roots', async () => {
+  const fixture = await makeFixture();
+  const gymRoot = path.join(fixture.root, 'private-gym-records');
+  const notesRoot = path.join(fixture.root, 'private-notes-records');
+  const defaultRoot = path.join(fixture.root, 'private-default-records');
+  const source = yaml.load(await fs.readFile(GYM_FIXTURE, 'utf8'));
+  const gymTemplate = {...source, templateId: 'gym-log', title: 'Gym Log', destinationId: 'gym-records'};
+  const notesTemplate = {...source, templateId: 'training-notes', title: 'Training Notes', destinationId: 'notes-records'};
+  const defaultTemplate = {...source, templateId: 'daily-log', title: 'Daily Log'};
+  await fs.rm(path.join(fixture.templatesPath, 'gym-session-entry.yaml'));
+  await fs.writeFile(path.join(fixture.templatesPath, 'gym-log.yaml'), yaml.dump(gymTemplate), 'utf8');
+  await fs.writeFile(path.join(fixture.templatesPath, 'training-notes.yaml'), yaml.dump(notesTemplate), 'utf8');
+  await fs.writeFile(path.join(fixture.templatesPath, 'daily-log.yaml'), yaml.dump(defaultTemplate), 'utf8');
+  const events = [];
+  const server = await startServer(fixture, {
+    formsConfig: {
+      enabled: true,
+      templatesPath: fixture.templatesPath,
+      destinations: {
+        'gym-records': gymRoot,
+        'notes-records': notesRoot,
+        default: defaultRoot,
+      },
+    },
+    formsAudit: (event) => events.push(event),
+  });
+  try {
+    const created = {};
+    const responseBodies = [];
+    for (const templateId of ['gym-log', 'training-notes', 'daily-log']) {
+      const context = await getBrowserContext(server, templateId);
+      const response = await server.request(`/api/forms/${templateId}/submissions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: context.cookie,
+          Origin: PUBLIC_ORIGIN,
+          'X-CSRF-Token': context.token,
+        },
+        body: JSON.stringify({ values: jsonValues({ notes: `private value for ${templateId}` }) }),
+      });
+      assert.equal(response.status, 201);
+      const body = await response.json();
+      created[templateId] = body;
+      responseBodies.push(JSON.stringify(body));
+    }
+
+    assert.deepEqual((await submissionFiles(gymRoot)), [`${created['gym-log'].submissionId}.json`]);
+    assert.deepEqual((await submissionFiles(notesRoot)), [`${created['training-notes'].submissionId}.json`]);
+    assert.deepEqual((await submissionFiles(defaultRoot)), [`${created['daily-log'].submissionId}.json`]);
+
+    for (const [templateId, otherTemplateId] of [
+      ['gym-log', 'training-notes'],
+      ['training-notes', 'daily-log'],
+      ['daily-log', 'gym-log'],
+    ]) {
+      const ownReceipt = await server.request(created[templateId].receiptUrl);
+      assert.equal(ownReceipt.status, 200);
+      responseBodies.push(await ownReceipt.text());
+      const crossed = await server.request(
+        `/forms/${templateId}/receipts/${created[otherTemplateId].submissionId}`
+      );
+      assert.equal(crossed.status, 404);
+      responseBodies.push(await crossed.text());
+      const entries = await server.request(`/api/forms/${templateId}/submissions`);
+      assert.equal(entries.status, 200);
+      const entriesBody = await entries.json();
+      assert.deepEqual(entriesBody.submissions.map((entry) => entry.submissionId), [created[templateId].submissionId]);
+      responseBodies.push(JSON.stringify(entriesBody));
+    }
+
+    const disclosed = `${responseBodies.join('\n')}\n${JSON.stringify(events)}`;
+    for (const storageRoot of [gymRoot, notesRoot, defaultRoot]) {
+      assert.doesNotMatch(disclosed, new RegExp(storageRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('an unknown destination alias fails startup without silently writing to default', async () => {
+  const fixture = await makeFixture();
+  const defaultRoot = path.join(fixture.root, 'default-records');
+  const document = yaml.load(await fs.readFile(GYM_FIXTURE, 'utf8'));
+  document.destinationId = 'operator-must-approve';
+  await fs.writeFile(path.join(fixture.templatesPath, 'gym-session-entry.yaml'), yaml.dump(document), 'utf8');
+  try {
+    await assert.rejects(
+      () => startServer(fixture, {
+        formsConfig: {
+          enabled: true,
+          templatesPath: fixture.templatesPath,
+          destinations: { default: defaultRoot },
+        },
+      }),
+      /gym-session-entry\.yaml references unknown destinationId operator-must-approve/
+    );
+    assert.deepEqual(await submissionFiles(defaultRoot), []);
+  } finally {
+    await cleanup(fixture, null);
+  }
+});
+
+test('legacy submissionsPath configuration reads records created before the destination adapter', async () => {
+  const fixture = await makeFixture();
+  const legacyStore = new SubmissionStore({ storageRoot: fixture.submissionsPath });
+  const legacyRecord = await legacyStore.createSubmission({
+    actor: { id: 'local-user', type: 'human' },
+    templateId: 'gym-session-entry',
+    templateVersion: 1,
+    schemaDigest: `sha256:${'a'.repeat(64)}`,
+    values: [{ fieldId: 'notes', fieldType: 'long-text', fieldLabel: 'Notes', value: 'Legacy entry' }],
+  });
+  const server = await startServer(fixture);
+  try {
+    const receipt = await server.request(`/forms/gym-session-entry/receipts/${legacyRecord.submissionId}`);
+    assert.equal(receipt.status, 200);
+    assert.match(await receipt.text(), /Legacy entry/);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
 test('registry keeps last-known-good data and rejects non-definition IDs without path reads', async () => {
   const fixture = await makeFixture();
   const warnings = [];

--- a/test/forms-schema.test.js
+++ b/test/forms-schema.test.js
@@ -68,6 +68,14 @@ test('unknown template and field keys report their exact paths', () => {
   assert.ok(paths(validateTemplate(templateWith(fields))).includes('fields[2].surprise'));
 });
 
+test('destinationId accepts only a logical definition ID, never a path', () => {
+  assert.equal(validateTemplate({...everyTypeTemplate, destinationId: 'gym-log'}).valid, true);
+  for (const destinationId of ['/var/lib/forms', '../forms', '~/forms', 'C:\\forms']) {
+    const result = validateTemplate({...everyTypeTemplate, destinationId});
+    assert.ok(paths(result).includes('destinationId'), destinationId);
+  }
+});
+
 test('unknown field types and duplicate field and option IDs are rejected', () => {
   const fields = [
     field('same', 'mystery'),


### PR DESCRIPTION
Submissions all shared one global `submissionsPath`, so a second form would dump its data into the first form's directory. Replaced with the ADR-93 destination model.

- `forms.destinations` maps **definition-ID aliases to storage roots** — deployment configuration, owned by the operator.
- A template may carry only an optional `destinationId` alias. It can never contain a root, path, URL, command, or credentials; omission resolves to `default`. A `DestinationAdapter` privately owns one immutable store per approved alias.
- Every route (list, receipt, history, correction, predecessor, latest) resolves the template's destination before reading, so there is no cross-destination scan or bleed.
- Storage roots never appear in responses or audit events; resolution errors name at most the alias.
- **Backwards compatible**: with `submissionsPath` set and no `destinations`, config synthesizes `{default: submissionsPath}`, so existing deployments and stored records are unaffected.
- **Fail closed**: a template naming an unknown alias is rejected rather than silently falling back to `default`.

This is the control that makes the upcoming browser-based template builder safe: if templates could name paths, anyone able to author one could write anywhere the server can reach. Verified by probe — a path-like `destinationId` is rejected by the validator, two templates with different aliases write to their own roots with no bleed, and no storage root appears in a rendered response.

155/155 tests; all three validators exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)