### PR TITLE
feat(forms): template write API — draft, CAS revise, immutable publish (agent-first)

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -13,6 +13,14 @@ const MAX_STEPPED_OPTIONS = 200;
 const RECENT_ENTRY_LIMIT = 3;
 const ARTIFACT_SANDBOX = 'sandbox allow-scripts allow-forms allow-popups';
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const TEMPLATE_CREATE_KEYS = new Set([
+  'templateId', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
+  'lineage', 'presentation', 'fields',
+]);
+const TEMPLATE_PATCH_KEYS = new Set([
+  'revision', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
+  'lineage', 'presentation', 'fields',
+]);
 
 function escapeHtml(value) {
   return String(value ?? '')
@@ -761,6 +769,94 @@ function createFormsRouter(options) {
     return false;
   }
 
+  function managementBody(req, res, allowedKeys, type) {
+    if (!req.is('application/json')) {
+      emitAudit(req, type, 'rejected_validation');
+      res.status(415).json({ ok: false, error: 'Content-Type must be application/json.' });
+      return null;
+    }
+    if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
+      emitAudit(req, type, 'rejected_validation');
+      res.status(400).json({
+        ok: false,
+        error: { code: 'invalid_request', message: 'Request body must be an object.', details: [{path: '', message: 'must be an object'}] },
+      });
+      return null;
+    }
+    const forbidden = Object.keys(req.body).filter((key) => !allowedKeys.has(key));
+    if (forbidden.length) {
+      emitAudit(req, type, 'rejected_validation');
+      res.status(400).json({
+        ok: false,
+        error: {
+          code: 'invalid_request',
+          message: 'Unknown or server-derived template field.',
+          details: forbidden.map((key) => ({path: key, message: 'is not accepted from clients'})),
+        },
+      });
+      return null;
+    }
+    return req.body;
+  }
+
+  function managementContentType(req, res, type) {
+    if (req.is('application/json')) return true;
+    emitAudit(req, type, 'rejected_validation');
+    res.status(415).json({ ok: false, error: 'Content-Type must be application/json.' });
+    return false;
+  }
+
+  function managementEnvelope(req, res, mutation, type) {
+    const bearer = bearerPresented(req);
+    if (bearer && cookieValue(req, CONTEXT_COOKIE)) {
+      emitAudit(req, type, 'rejected_authn');
+      res.status(400).json({ ok: false, error: 'Ambiguous credentials are not accepted.' });
+      return false;
+    }
+    if (mutation && !bearer && (!originAllowed(req, publicOrigins)
+        || !validCsrf(req, req.get('x-csrf-token')))) {
+      emitAudit(req, type, originAllowed(req, publicOrigins) ? 'rejected_csrf' : 'rejected_origin');
+      res.status(403).json({ ok: false, error: 'Request refused.' });
+      return false;
+    }
+    return apiAuthenticated(req, res, type);
+  }
+
+  function templateProjection(record) {
+    return {
+      template: record.draft,
+      state: record.state,
+      publishedVersion: record.publishedVersion,
+      publishedVersions: record.publishedVersions,
+    };
+  }
+
+  function sendTemplateMutationError(req, res, error, type) {
+    if (error && error.code === 'EVALIDATION') {
+      emitAudit(req, type, 'rejected_validation');
+      res.status(422).json({
+        ok: false,
+        error: { code: 'validation_error', message: error.message, details: error.details || [] },
+      });
+      return true;
+    }
+    if (error && error.code === 'ESTALE') {
+      emitAudit(req, type, 'rejected_validation');
+      res.status(409).json({ ok: false, error: { code: 'revision_conflict', message: 'Template revision is stale.' } });
+      return true;
+    }
+    if (error && error.code === 'ECONFLICT') {
+      emitAudit(req, type, 'rejected_validation');
+      res.status(409).json({ ok: false, error: { code: 'conflict', message: error.message } });
+      return true;
+    }
+    if (error && error.code === 'ENOTFOUND') {
+      apiNotFound(req, res, type);
+      return true;
+    }
+    return false;
+  }
+
   router.use('/raw', (_req, res, next) => {
     res.set('Content-Security-Policy', ARTIFACT_SANDBOX);
     next();
@@ -781,6 +877,127 @@ function createFormsRouter(options) {
         error: oversized ? 'Submission body is too large.' : 'Invalid JSON body.',
       });
     });
+  });
+
+  router.get('/api/forms/templates', async (req, res, next) => {
+    const type = 'form.template.list';
+    try {
+      if (!managementEnvelope(req, res, false, type)) return;
+      const records = await registry.listManagementTemplates();
+      const templates = [];
+      for (const record of records) {
+        if (!await allowed(req, 'forms.manage', record.draft)) continue;
+        templates.push({
+          templateId: record.draft.templateId,
+          title: record.draft.title,
+          revision: record.draft.revision,
+          publishedVersion: record.publishedVersion && record.publishedVersion.templateVersion,
+          state: record.state,
+        });
+      }
+      emitAudit(req, type, 'accepted');
+      res.status(200).json({ ok: true, templates });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/api/forms/templates/:templateId', async (req, res, next) => {
+    const type = 'form.template.read';
+    try {
+      if (!managementEnvelope(req, res, false, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, type);
+      const record = await registry.getManagementTemplate(req.params.templateId);
+      if (!record || !await allowed(req, 'forms.manage', record.draft)) return apiNotFound(req, res, type);
+      emitAudit(req, type, 'accepted', record.draft);
+      res.status(200).json({ ok: true, ...templateProjection(record) });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/api/forms/templates', async (req, res, next) => {
+    const type = 'form.template.create';
+    try {
+      if (!managementEnvelope(req, res, true, type)) return;
+      const principal = principalFor(req);
+      const resource = principal && isDefinitionId(principal.id)
+        ? { resourceKind: 'form-template', ownerId: principal.id }
+        : null;
+      if (!managementContentType(req, res, type)) return;
+      if (!resource || !await allowed(req, 'forms.manage', resource)) {
+        emitAudit(req, type, 'rejected_authz');
+        res.status(403).json({ ok: false, error: 'Forbidden.' });
+        return;
+      }
+      const body = managementBody(req, res, TEMPLATE_CREATE_KEYS, type);
+      if (!body) return;
+      const draft = {
+        contractVersion: 1,
+        resourceKind: 'form-template',
+        templateId: body.templateId,
+        ownerId: principal.id,
+        revision: 1,
+        ...Object.fromEntries(Object.entries(body).filter(([key]) => key !== 'templateId')),
+      };
+      const record = await registry.createDraft(draft);
+      emitAudit(req, type, 'accepted', record.draft);
+      res.status(201).json({ ok: true, ...templateProjection(record) });
+    } catch (error) {
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  router.patch('/api/forms/templates/:templateId', async (req, res, next) => {
+    const type = 'form.template.revise';
+    try {
+      if (!managementEnvelope(req, res, true, type)) return;
+      if (!managementContentType(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, type);
+      const record = await registry.getManagementTemplate(req.params.templateId);
+      if (!record || !await allowed(req, 'forms.manage', record.draft)) return apiNotFound(req, res, type);
+      const body = managementBody(req, res, TEMPLATE_PATCH_KEYS, type);
+      if (!body) return;
+      if (!Number.isSafeInteger(body.revision) || body.revision < 1) {
+        emitAudit(req, type, 'rejected_validation', record.draft);
+        res.status(400).json({
+          ok: false,
+          error: { code: 'invalid_request', message: 'revision is required.', details: [{path: 'revision', message: 'must be a positive integer'}] },
+        });
+        return;
+      }
+      if (Object.keys(body).length === 1) {
+        emitAudit(req, type, 'rejected_validation', record.draft);
+        res.status(400).json({ ok: false, error: { code: 'invalid_request', message: 'At least one draft field must change.' } });
+        return;
+      }
+      const changes = {...body};
+      delete changes.revision;
+      const revised = await registry.reviseDraft(req.params.templateId, body.revision, changes);
+      emitAudit(req, type, 'accepted', revised.draft);
+      res.status(200).json({ ok: true, ...templateProjection(revised) });
+    } catch (error) {
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  router.post('/api/forms/templates/:templateId/publish', async (req, res, next) => {
+    const type = 'form.template.publish';
+    try {
+      if (!managementEnvelope(req, res, true, type)) return;
+      if (!managementContentType(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, type);
+      const record = await registry.getManagementTemplate(req.params.templateId);
+      if (!record || !await allowed(req, 'forms.manage', record.draft)) return apiNotFound(req, res, type);
+      const body = managementBody(req, res, new Set(), type);
+      if (!body) return;
+      const principal = principalFor(req);
+      const version = await registry.publishDraft(req.params.templateId, principal);
+      emitAudit(req, type, 'accepted', version);
+      res.status(201).json({ ok: true, version });
+    } catch (error) {
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
   });
 
   router.get('/forms/:templateId', async (req, res, next) => {

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -23,6 +23,11 @@ const TEMPLATE_KEYS = new Set([
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
   'presentation', 'fields',
 ]);
+const TEMPLATE_VERSION_KEYS = new Set([
+  'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'templateVersion',
+  'sourceRevision', 'grammarVersion', 'publishedAt', 'publishedBy', 'title',
+  'description', 'tags', 'lineage', 'presentation', 'fields', 'schemaDigest',
+]);
 const FIELD_KEYS = new Set([
   'id', 'type', 'label', 'help', 'required', 'default', 'component',
   'constraints', 'options', 'providerSlot',
@@ -432,6 +437,59 @@ function validateTemplate(doc) {
   return {valid: errors.length === 0, errors};
 }
 
+function validateTemplateVersion(doc) {
+  const errors = [];
+  if (!isRecord(doc)) return {valid: false, errors: [{path: '', message: 'template version must be an object'}]};
+  rejectUnknownKeys(doc, TEMPLATE_VERSION_KEYS, '', errors);
+  const required = [
+    'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'templateVersion',
+    'sourceRevision', 'grammarVersion', 'publishedAt', 'publishedBy', 'title',
+    'fields', 'schemaDigest',
+  ];
+  for (const key of required) if (!own(doc, key)) addError(errors, key, 'is required');
+
+  const draftProjection = {
+    ...doc,
+    resourceKind: 'form-template',
+    revision: doc.sourceRevision,
+  };
+  for (const key of [
+    'templateVersion', 'sourceRevision', 'publishedAt', 'publishedBy', 'schemaDigest',
+  ]) delete draftProjection[key];
+  for (const error of validateTemplate(draftProjection).errors) addError(errors, error.path, error.message);
+
+  if (own(doc, 'resourceKind') && doc.resourceKind !== 'form-template-version') {
+    addError(errors, 'resourceKind', 'must equal form-template-version');
+  }
+  if (own(doc, 'templateVersion')) {
+    validateInteger(doc.templateVersion, 'templateVersion', errors, 1, Number.MAX_SAFE_INTEGER);
+  }
+  if (own(doc, 'sourceRevision')) {
+    validateInteger(doc.sourceRevision, 'sourceRevision', errors, 1, Number.MAX_SAFE_INTEGER);
+  }
+  if (own(doc, 'publishedAt') && (typeof doc.publishedAt !== 'string'
+      || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(doc.publishedAt)
+      || !Number.isFinite(Date.parse(doc.publishedAt)))) {
+    addError(errors, 'publishedAt', 'must be a UTC RFC 3339 timestamp with millisecond precision');
+  }
+  if (own(doc, 'publishedBy') && doc.publishedBy !== null) {
+    if (!isRecord(doc.publishedBy)) {
+      addError(errors, 'publishedBy', 'must be a principal reference or null');
+    } else {
+      rejectUnknownKeys(doc.publishedBy, new Set(['id', 'type']), 'publishedBy', errors);
+      if (!own(doc.publishedBy, 'id')) addError(errors, 'publishedBy.id', 'is required');
+      else validateId(doc.publishedBy.id, 'publishedBy.id', errors);
+      if (!own(doc.publishedBy, 'type')) addError(errors, 'publishedBy.type', 'is required');
+      else validateId(doc.publishedBy.type, 'publishedBy.type', errors);
+    }
+  }
+  if (own(doc, 'schemaDigest') && (typeof doc.schemaDigest !== 'string'
+      || !/^sha256:[0-9a-f]{64}$/.test(doc.schemaDigest))) {
+    addError(errors, 'schemaDigest', 'must be a sha256 digest');
+  }
+  return {valid: errors.length === 0, errors};
+}
+
 function validateSubmissionValues(template, values) {
   const errors = [];
   const normalized = {};
@@ -461,5 +519,6 @@ function validateSubmissionValues(template, values) {
 
 module.exports = {
   validateTemplate,
+  validateTemplateVersion,
   validateSubmissionValues,
 };

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -1,14 +1,19 @@
 'use strict';
 
+const crypto = require('node:crypto');
 const fs = require('node:fs/promises');
 const fsSync = require('node:fs');
 const path = require('node:path');
 const yaml = require('js-yaml');
 
-const { schemaDigest } = require('./canonical');
-const { validateTemplate } = require('./schema');
+const { canonicalize, schemaDigest } = require('./canonical');
+const { validateTemplate, validateTemplateVersion } = require('./schema');
 
 const DEFINITION_ID = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const MUTABLE_TEMPLATE_KEYS = [
+  'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
+  'presentation', 'fields',
+];
 
 function isDefinitionId(value) {
   return typeof value === 'string' && value.length <= 64 && DEFINITION_ID.test(value);
@@ -16,6 +21,27 @@ function isDefinitionId(value) {
 
 function clone(value) {
   return structuredClone(value);
+}
+
+function codedError(code, message, details = []) {
+  const error = new Error(message);
+  error.code = code;
+  error.details = details;
+  return error;
+}
+
+function validationError(details) {
+  return codedError('EVALIDATION', 'Template validation failed.', details);
+}
+
+function versionMetadata(version) {
+  return {
+    templateVersion: version.templateVersion,
+    sourceRevision: version.sourceRevision,
+    publishedAt: version.publishedAt,
+    publishedBy: clone(version.publishedBy),
+    schemaDigest: version.schemaDigest,
+  };
 }
 
 class TemplateRegistry {
@@ -26,12 +52,14 @@ class TemplateRegistry {
     }
     this.templatesPath = path.resolve(options.templatesPath);
     this.logger = options.logger || console;
+    this.clock = options.clock || (() => new Date());
     this.destinationIds = options.destinationIds === undefined
       ? null
       : new Set(options.destinationIds);
     this.files = new Map();
     this.failureMessages = new Map();
     this.refreshPromise = null;
+    this.mutationLocks = new Map();
     this.assertConfiguredDestinationsAtStartup();
   }
 
@@ -53,16 +81,23 @@ class TemplateRegistry {
       throw error;
     }
     for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith('.yaml')) continue;
+      let filePath = null;
+      if (entry.isFile() && /\.(?:yaml|yml|json)$/.test(entry.name)) {
+        filePath = path.join(this.templatesPath, entry.name);
+      } else if (entry.isDirectory() && isDefinitionId(entry.name)) {
+        filePath = path.join(this.templatesPath, entry.name, 'draft.json');
+        if (!fsSync.existsSync(filePath)) continue;
+      }
+      if (!filePath) continue;
       let document;
       try {
-        document = yaml.load(fsSync.readFileSync(path.join(this.templatesPath, entry.name), 'utf8'));
+        document = yaml.load(fsSync.readFileSync(filePath, 'utf8'), {schema: yaml.JSON_SCHEMA});
       } catch (_error) {
         continue;
       }
       if (!validateTemplate(document).valid) continue;
       const reason = this.destinationFailure(document);
-      if (reason) throw new Error(`Form template ${entry.name} ${reason}.`);
+      if (reason) throw new Error(`Form template ${path.relative(this.templatesPath, filePath)} ${reason}.`);
     }
   }
 
@@ -73,45 +108,121 @@ class TemplateRegistry {
     this.logger.warn(`Skipping form template ${message}`);
   }
 
-  async readCandidate(fileName) {
-    const filePath = path.join(this.templatesPath, fileName);
+  async descriptors() {
+    const entries = await fs.readdir(this.templatesPath, { withFileTypes: true });
+    const descriptors = [];
+    for (const entry of entries) {
+      if (entry.isFile() && /\.(?:yaml|yml|json)$/.test(entry.name)) {
+        descriptors.push({
+          key: `file:${entry.name}`,
+          fileName: entry.name,
+          draftPath: path.join(this.templatesPath, entry.name),
+          managedId: null,
+        });
+      } else if (entry.isDirectory() && isDefinitionId(entry.name)) {
+        const draftPath = path.join(this.templatesPath, entry.name, 'draft.json');
+        try {
+          const stat = await fs.lstat(draftPath);
+          if (!stat.isFile() || stat.isSymbolicLink()) continue;
+          descriptors.push({
+            key: `managed:${entry.name}`,
+            fileName: `${entry.name}/draft.json`,
+            draftPath,
+            managedId: entry.name,
+          });
+        } catch (error) {
+          if (!error || error.code !== 'ENOENT') throw error;
+        }
+      }
+    }
+    return descriptors.sort((left, right) => left.key.localeCompare(right.key));
+  }
+
+  versionsPath(templateId) {
+    return path.join(this.templatesPath, templateId, 'versions');
+  }
+
+  async readVersions(templateId, previousVersions = []) {
+    let entries;
     try {
-      const stat = await fs.lstat(filePath);
+      entries = await fs.readdir(this.versionsPath(templateId), { withFileTypes: true });
+    } catch (error) {
+      if (error && error.code === 'ENOENT') return [];
+      throw error;
+    }
+    const files = entries
+      .filter((entry) => entry.isFile() && /^[1-9]\d*\.json$/.test(entry.name))
+      .sort((left, right) => Number(left.name.slice(0, -5)) - Number(right.name.slice(0, -5)));
+    const versions = [];
+    try {
+      for (const entry of files) {
+        const version = JSON.parse(await fs.readFile(path.join(this.versionsPath(templateId), entry.name), 'utf8'));
+        const validation = validateTemplateVersion(version);
+        const expectedVersion = versions.length + 1;
+        if (!validation.valid) {
+          throw new Error(validation.errors.map((item) => `${item.path || 'version'} ${item.message}`).join('; '));
+        }
+        if (version.templateId !== templateId || version.templateVersion !== expectedVersion
+            || entry.name !== `${expectedVersion}.json`) {
+          throw new Error('version identity or sequence does not match its directory');
+        }
+        if (version.schemaDigest !== `sha256:${schemaDigest(version)}`) {
+          throw new Error('schemaDigest does not match the canonical field schema');
+        }
+        versions.push(version);
+      }
+      return versions;
+    } catch (error) {
+      this.logFailure(`${templateId}/versions`, error && error.message ? error.message : 'could not be read');
+      return clone(previousVersions);
+    }
+  }
+
+  async readCandidate(descriptor) {
+    const previous = this.files.get(descriptor.key);
+    try {
+      const stat = await fs.lstat(descriptor.draftPath);
       if (!stat.isFile() || stat.isSymbolicLink()) {
-        this.logFailure(fileName, 'not a regular file');
+        this.logFailure(descriptor.fileName, 'not a regular file');
         return null;
       }
-      const document = yaml.load(await fs.readFile(filePath, 'utf8'));
+      const document = yaml.load(await fs.readFile(descriptor.draftPath, 'utf8'), {schema: yaml.JSON_SCHEMA});
       const validation = validateTemplate(document);
       if (!validation.valid) {
         const reason = validation.errors
           .map((error) => `${error.path || 'template'} ${error.message}`)
           .join('; ');
-        this.logFailure(fileName, reason);
+        this.logFailure(descriptor.fileName, reason);
+        return null;
+      }
+      if (descriptor.managedId && document.templateId !== descriptor.managedId) {
+        this.logFailure(descriptor.fileName, 'templateId does not match its directory');
         return null;
       }
       const destinationFailure = this.destinationFailure(document);
       if (destinationFailure) {
-        this.logFailure(fileName, destinationFailure);
+        this.logFailure(descriptor.fileName, destinationFailure);
         return null;
       }
+      const versions = await this.readVersions(document.templateId, previous && previous.versions);
       const entry = {
-        fileName,
+        ...descriptor,
         template: clone(document),
         schemaDigest: schemaDigest(document),
+        versions,
       };
-      this.failureMessages.delete(fileName);
+      this.failureMessages.delete(descriptor.fileName);
       return entry;
     } catch (error) {
-      this.logFailure(fileName, error && error.message ? error.message : 'could not be read');
+      this.logFailure(descriptor.fileName, error && error.message ? error.message : 'could not be read');
       return null;
     }
   }
 
   async refreshNow() {
-    let entries;
+    let descriptors;
     try {
-      entries = await fs.readdir(this.templatesPath, { withFileTypes: true });
+      descriptors = await this.descriptors();
     } catch (error) {
       if (error && error.code === 'ENOENT') {
         this.logFailure('(registry)', 'template directory does not exist');
@@ -122,26 +233,22 @@ class TemplateRegistry {
     }
 
     this.failureMessages.delete('(registry)');
-    const fileNames = entries
-      .filter((entry) => entry.name.endsWith('.yaml'))
-      .map((entry) => entry.name)
-      .sort();
     const nextFiles = new Map();
-    for (const fileName of fileNames) {
-      const candidate = await this.readCandidate(fileName);
-      if (candidate) nextFiles.set(fileName, candidate);
-      else if (this.files.has(fileName)) nextFiles.set(fileName, this.files.get(fileName));
+    for (const descriptor of descriptors) {
+      const candidate = await this.readCandidate(descriptor);
+      if (candidate) nextFiles.set(descriptor.key, candidate);
+      else if (this.files.has(descriptor.key)) nextFiles.set(descriptor.key, this.files.get(descriptor.key));
     }
 
     const claimedIds = new Map();
-    for (const [fileName, entry] of nextFiles) {
+    for (const [key, entry] of nextFiles) {
       const templateId = entry.template.templateId;
       if (claimedIds.has(templateId)) {
-        this.logFailure(fileName, `duplicates templateId ${templateId}`);
-        nextFiles.delete(fileName);
+        this.logFailure(entry.fileName, `duplicates templateId ${templateId}`);
+        nextFiles.delete(key);
         continue;
       }
-      claimedIds.set(templateId, fileName);
+      claimedIds.set(templateId, key);
     }
     this.files = nextFiles;
   }
@@ -162,13 +269,28 @@ class TemplateRegistry {
     };
   }
 
-  async getTemplate(templateId) {
+  managementEntry(entry) {
+    const publishedVersions = entry.versions.map(versionMetadata);
+    return {
+      draft: clone(entry.template),
+      state: publishedVersions.length ? 'published' : 'draft',
+      publishedVersion: publishedVersions.length ? clone(publishedVersions.at(-1)) : null,
+      publishedVersions,
+    };
+  }
+
+  async entryFor(templateId) {
     if (!isDefinitionId(templateId)) return null;
     await this.refresh();
     for (const entry of this.files.values()) {
-      if (entry.template.templateId === templateId) return this.publicEntry(entry);
+      if (entry.template.templateId === templateId) return entry;
     }
     return null;
+  }
+
+  async getTemplate(templateId) {
+    const entry = await this.entryFor(templateId);
+    return entry ? this.publicEntry(entry) : null;
   }
 
   async listTemplates() {
@@ -176,6 +298,171 @@ class TemplateRegistry {
     return [...this.files.values()]
       .map((entry) => this.publicEntry(entry))
       .sort((left, right) => left.templateId.localeCompare(right.templateId));
+  }
+
+  async getManagementTemplate(templateId) {
+    const entry = await this.entryFor(templateId);
+    return entry ? this.managementEntry(entry) : null;
+  }
+
+  async listManagementTemplates() {
+    await this.refresh();
+    return [...this.files.values()]
+      .map((entry) => this.managementEntry(entry))
+      .sort((left, right) => left.draft.templateId.localeCompare(right.draft.templateId));
+  }
+
+  async syncDirectory(directoryPath) {
+    const handle = await fs.open(directoryPath, 'r');
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async durableReplace(targetPath, bytes) {
+    const directoryPath = path.dirname(targetPath);
+    const createdDirectory = await fs.mkdir(directoryPath, {recursive: true});
+    if (createdDirectory) await this.syncDirectory(path.dirname(createdDirectory));
+    const tempPath = path.join(directoryPath, `.${path.basename(targetPath)}.${crypto.randomUUID()}.tmp`);
+    let handle;
+    try {
+      handle = await fs.open(tempPath, 'wx', 0o600);
+      await handle.writeFile(bytes, 'utf8');
+      await handle.sync();
+      await handle.close();
+      handle = null;
+      await fs.rename(tempPath, targetPath);
+      await this.syncDirectory(directoryPath);
+    } catch (error) {
+      if (handle) await handle.close().catch(() => {});
+      await fs.unlink(tempPath).catch(() => {});
+      throw error;
+    }
+  }
+
+  async withMutationLock(templateId, operation) {
+    const predecessor = this.mutationLocks.get(templateId) || Promise.resolve();
+    let release;
+    const current = new Promise((resolve) => { release = resolve; });
+    this.mutationLocks.set(templateId, current);
+    await predecessor;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.mutationLocks.get(templateId) === current) this.mutationLocks.delete(templateId);
+    }
+  }
+
+  validateDraft(template) {
+    const validation = validateTemplate(template);
+    if (!validation.valid) throw validationError(validation.errors);
+    const destinationFailure = this.destinationFailure(template);
+    if (destinationFailure) {
+      throw validationError([{path: 'destinationId', message: destinationFailure}]);
+    }
+  }
+
+  async createDraft(template) {
+    if (!template || !isDefinitionId(template.templateId)) {
+      throw validationError([{path: 'templateId', message: 'must be a definition ID'}]);
+    }
+    this.validateDraft(template);
+    return this.withMutationLock(template.templateId, async () => {
+      if (await this.entryFor(template.templateId)) throw codedError('ECONFLICT', 'Template already exists.');
+      await fs.mkdir(this.templatesPath, {recursive: true});
+      const templateDirectory = path.join(this.templatesPath, template.templateId);
+      try {
+        await fs.mkdir(templateDirectory);
+      } catch (error) {
+        if (error && error.code === 'EEXIST') throw codedError('ECONFLICT', 'Template already exists.');
+        throw error;
+      }
+      await this.syncDirectory(this.templatesPath);
+      const descriptor = {
+        key: `managed:${template.templateId}`,
+        fileName: `${template.templateId}/draft.json`,
+        draftPath: path.join(templateDirectory, 'draft.json'),
+        managedId: template.templateId,
+      };
+      await this.durableReplace(descriptor.draftPath, canonicalize(template));
+      const entry = {
+        ...descriptor,
+        template: clone(template),
+        schemaDigest: schemaDigest(template),
+        versions: [],
+      };
+      this.files.set(descriptor.key, entry);
+      return this.managementEntry(entry);
+    });
+  }
+
+  async reviseDraft(templateId, expectedRevision, changes) {
+    return this.withMutationLock(templateId, async () => {
+      const entry = await this.entryFor(templateId);
+      if (!entry) throw codedError('ENOTFOUND', 'Template not found.');
+      if (entry.template.revision !== expectedRevision) {
+        throw codedError('ESTALE', 'Template revision is stale.');
+      }
+      const revised = clone(entry.template);
+      for (const key of MUTABLE_TEMPLATE_KEYS) {
+        if (!Object.prototype.hasOwnProperty.call(changes, key)) continue;
+        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation'].includes(key)) {
+          delete revised[key];
+        } else {
+          revised[key] = clone(changes[key]);
+        }
+      }
+      revised.revision += 1;
+      this.validateDraft(revised);
+      await this.durableReplace(entry.draftPath, canonicalize(revised));
+      entry.template = revised;
+      entry.schemaDigest = schemaDigest(revised);
+      this.files.set(entry.key, entry);
+      return this.managementEntry(entry);
+    });
+  }
+
+  async publishDraft(templateId, principal) {
+    return this.withMutationLock(templateId, async () => {
+      const entry = await this.entryFor(templateId);
+      if (!entry) throw codedError('ENOTFOUND', 'Template not found.');
+      const templateVersion = entry.versions.length + 1;
+      const draft = entry.template;
+      const version = {
+        contractVersion: 1,
+        resourceKind: 'form-template-version',
+        templateId: draft.templateId,
+        ownerId: draft.ownerId,
+        templateVersion,
+        sourceRevision: draft.revision,
+        grammarVersion: draft.grammarVersion,
+        publishedAt: this.clock().toISOString(),
+        publishedBy: clone(principal),
+        title: draft.title,
+        ...(Object.prototype.hasOwnProperty.call(draft, 'description') ? {description: clone(draft.description)} : {}),
+        ...(Object.prototype.hasOwnProperty.call(draft, 'tags') ? {tags: clone(draft.tags)} : {}),
+        ...(Object.prototype.hasOwnProperty.call(draft, 'lineage') ? {lineage: clone(draft.lineage)} : {}),
+        ...(Object.prototype.hasOwnProperty.call(draft, 'presentation') ? {presentation: clone(draft.presentation)} : {}),
+        fields: clone(draft.fields),
+        schemaDigest: `sha256:${schemaDigest(draft)}`,
+      };
+      const validation = validateTemplateVersion(version);
+      if (!validation.valid) throw validationError(validation.errors);
+      const versionPath = path.join(this.versionsPath(templateId), `${templateVersion}.json`);
+      try {
+        await fs.lstat(versionPath);
+        throw codedError('ECONFLICT', 'Template version already exists.');
+      } catch (error) {
+        if (!error || error.code !== 'ENOENT') throw error;
+      }
+      await this.durableReplace(versionPath, canonicalize(version));
+      entry.versions.push(version);
+      this.files.set(entry.key, entry);
+      return clone(version);
+    });
   }
 }
 

--- a/test/forms-template-api.test.js
+++ b/test/forms-template-api.test.js
@@ -1,0 +1,387 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { Duplex } = require('node:stream');
+
+const { createApp } = require('../server');
+const { TemplateRegistry } = require('../lib/forms/template-registry');
+
+const PUBLIC_ORIGIN = 'http://forms.example.test';
+const AGENT_HEADERS = {
+  Authorization: 'Bearer template-secret',
+  'X-Manage': 'yes',
+};
+
+function inject(app, route, init = {}) {
+  return new Promise((resolve, reject) => {
+    const output = [];
+    const socket = new Duplex({
+      read() {},
+      write(chunk, _encoding, callback) {
+        output.push(Buffer.from(chunk));
+        callback();
+      },
+    });
+    socket.remoteAddress = '127.0.0.1';
+    const request = new http.IncomingMessage(socket);
+    request.method = init.method || 'GET';
+    request.url = route;
+    request.headers = {host: 'forms.example.test'};
+    for (const [name, value] of Object.entries(init.headers || {})) {
+      request.headers[name.toLowerCase()] = value;
+    }
+    const body = init.body === undefined ? Buffer.alloc(0) : Buffer.from(String(init.body));
+    if (body.length > 0 && request.headers['content-length'] === undefined) {
+      request.headers['content-length'] = String(body.length);
+    }
+    const response = new http.ServerResponse(request);
+    response.assignSocket(socket);
+    const chunks = [];
+    response.write = (chunk, encoding) => {
+      if (chunk !== undefined && chunk !== null) chunks.push(Buffer.from(chunk, encoding));
+      return true;
+    };
+    response.end = (chunk, encoding) => {
+      if (chunk !== undefined && chunk !== null) chunks.push(Buffer.from(chunk, encoding));
+      response.finished = true;
+      response.emit('finish');
+      return response;
+    };
+    response.on('finish', () => {
+      const responseBody = Buffer.concat(chunks);
+      const headers = response.getHeaders();
+      resolve({
+        status: response.statusCode,
+        headers: {get: (name) => {
+          const value = headers[String(name).toLowerCase()];
+          return Array.isArray(value) ? value.join(', ') : value ?? null;
+        }},
+        text: async () => responseBody.toString('utf8'),
+        json: async () => JSON.parse(responseBody.toString('utf8')),
+      });
+    });
+    response.on('error', reject);
+    request.push(body);
+    request.push(null);
+    app.handle(request, response, reject);
+  });
+}
+
+async function makeServer() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-template-api-'));
+  const templatesPath = path.join(root, 'templates');
+  const defaultRoot = path.join(root, 'default-submissions');
+  const gymRoot = path.join(root, 'gym-submissions');
+  await fs.mkdir(templatesPath);
+  const times = [
+    new Date('2026-07-21T12:00:00.000Z'),
+    new Date('2026-07-21T13:00:00.000Z'),
+    new Date('2026-07-21T14:00:00.000Z'),
+  ];
+  let tick = 0;
+  const registry = new TemplateRegistry({
+    templatesPath,
+    destinationIds: ['default', 'gym-log'],
+    clock: () => times[tick++] || times.at(-1),
+    logger: {warn() {}},
+  });
+  const app = createApp({
+    mappings: {},
+    accessConfig: {
+      humanDefault: 'restricted',
+      tokens: {
+        templateAgent: {
+          secret: 'template-secret',
+          permissions: {view: true},
+          repos: 'all',
+          subject: {agentId: 'template-agent'},
+        },
+      },
+    },
+    formsConfig: {
+      enabled: true,
+      templatesPath,
+      destinations: {default: defaultRoot, 'gym-log': gymRoot},
+    },
+    formsRegistry: registry,
+    formsPublicOrigin: PUBLIC_ORIGIN,
+    formsAudit: () => {},
+    formsAuthorize: ({req, capability}) => req.get('x-manage') === 'yes'
+      && (capability === 'forms.manage' || capability === 'forms.submit'),
+  });
+  return {
+    root,
+    templatesPath,
+    defaultRoot,
+    gymRoot,
+    registry,
+    request: (route, init) => inject(app, route, init),
+    close: () => fs.rm(root, {recursive: true, force: true}),
+  };
+}
+
+function draftBody(templateId = 'training-log') {
+  return {
+    templateId,
+    grammarVersion: 1,
+    destinationId: 'gym-log',
+    title: 'Training log',
+    fields: [
+      {
+        id: 'lift',
+        type: 'select',
+        label: 'Lift',
+        required: true,
+        options: [{id: 'squat', label: 'Squat'}, {id: 'bench', label: 'Bench press'}],
+      },
+      {id: 'notes', type: 'long-text', label: 'Notes', required: true},
+    ],
+  };
+}
+
+function jsonMutation(body, headers = AGENT_HEADERS) {
+  return {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json', ...headers},
+    body: JSON.stringify(body),
+  };
+}
+
+function patchMutation(body, headers = AGENT_HEADERS) {
+  return {...jsonMutation(body, headers), method: 'PATCH'};
+}
+
+async function diskSnapshot(root) {
+  const snapshot = {};
+  async function walk(directory, prefix = '') {
+    let entries;
+    try {
+      entries = await fs.readdir(directory, {withFileTypes: true});
+    } catch (error) {
+      if (error && error.code === 'ENOENT') return;
+      throw error;
+    }
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      const relative = path.join(prefix, entry.name);
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) await walk(fullPath, relative);
+      else snapshot[relative] = (await fs.readFile(fullPath)).toString('base64');
+    }
+  }
+  await walk(root);
+  return snapshot;
+}
+
+test('template API lifecycle uses CAS and preserves immutable versions and old receipts', async () => {
+  const server = await makeServer();
+  try {
+    const createdResponse = await server.request('/api/forms/templates', jsonMutation(draftBody()));
+    assert.equal(createdResponse.status, 201);
+    const created = await createdResponse.json();
+    assert.equal(created.template.revision, 1);
+    assert.equal(created.template.ownerId, 'template-agent');
+    assert.equal(created.state, 'draft');
+    assert.equal(created.publishedVersion, null);
+
+    const revisedResponse = await server.request('/api/forms/templates/training-log', patchMutation({
+      revision: 1,
+      title: 'Strength training log',
+    }));
+    assert.equal(revisedResponse.status, 200);
+    assert.equal((await revisedResponse.json()).template.revision, 2);
+
+    const draftPath = path.join(server.templatesPath, 'training-log', 'draft.json');
+    const beforeStale = await fs.readFile(draftPath);
+    const staleResponse = await server.request('/api/forms/templates/training-log', patchMutation({
+      revision: 1,
+      title: 'Stale overwrite',
+    }));
+    assert.equal(staleResponse.status, 409);
+    assert.equal((await staleResponse.json()).error.code, 'revision_conflict');
+    assert.equal(Buffer.compare(beforeStale, await fs.readFile(draftPath)), 0);
+
+    const firstPublish = await server.request(
+      '/api/forms/templates/training-log/publish',
+      jsonMutation({}),
+    );
+    assert.equal(firstPublish.status, 201);
+    const firstVersion = (await firstPublish.json()).version;
+    assert.equal(firstVersion.templateVersion, 1);
+    assert.equal(firstVersion.sourceRevision, 2);
+    assert.deepEqual(firstVersion.publishedBy, {id: 'template-agent', type: 'agent'});
+    assert.match(firstVersion.schemaDigest, /^sha256:[0-9a-f]{64}$/);
+    const firstVersionPath = path.join(server.templatesPath, 'training-log', 'versions', '1.json');
+    const firstVersionBytes = await fs.readFile(firstVersionPath);
+
+    const submitted = await server.request('/api/forms/training-log/submissions', jsonMutation({
+      values: {lift: 'squat', notes: 'Original receipt value'},
+    }));
+    assert.equal(submitted.status, 201);
+    const receiptUrl = (await submitted.json()).receiptUrl;
+
+    const nextFields = draftBody().fields;
+    nextFields[0].label = 'Movement';
+    nextFields[0].options[0].label = 'Back squat';
+    const secondRevision = await server.request('/api/forms/templates/training-log', patchMutation({
+      revision: 2,
+      fields: nextFields,
+    }));
+    assert.equal(secondRevision.status, 200);
+    assert.equal((await secondRevision.json()).template.revision, 3);
+    const secondPublish = await server.request(
+      '/api/forms/templates/training-log/publish',
+      jsonMutation({}),
+    );
+    assert.equal(secondPublish.status, 201);
+    assert.equal((await secondPublish.json()).version.templateVersion, 2);
+    assert.equal(Buffer.compare(firstVersionBytes, await fs.readFile(firstVersionPath)), 0);
+    assert.ok(await fs.readFile(path.join(server.templatesPath, 'training-log', 'versions', '2.json')));
+
+    const receipt = await server.request(receiptUrl, {headers: AGENT_HEADERS});
+    assert.equal(receipt.status, 200);
+    const receiptHtml = await receipt.text();
+    assert.match(receiptHtml, /<th scope="row">Lift<\/th>/);
+    assert.match(receiptHtml, />Squat</);
+    assert.match(receiptHtml, /Original receipt value/);
+    assert.doesNotMatch(receiptHtml, />Movement</);
+    assert.doesNotMatch(receiptHtml, />Back squat</);
+
+    const listed = await server.request('/api/forms/templates', {headers: AGENT_HEADERS});
+    assert.deepEqual((await listed.json()).templates, [{
+      templateId: 'training-log',
+      title: 'Strength training log',
+      revision: 3,
+      publishedVersion: 2,
+      state: 'published',
+    }]);
+    const fetchedResponse = await server.request('/api/forms/templates/training-log', {headers: AGENT_HEADERS});
+    assert.equal(fetchedResponse.status, 200);
+    const fetched = await fetchedResponse.json();
+    assert.equal(fetched.publishedVersions.length, 2);
+    assert.equal(fetched.publishedVersion.templateVersion, 2);
+    assert.doesNotMatch(JSON.stringify(fetched), new RegExp(server.root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  } finally {
+    await server.close();
+  }
+});
+
+test('invalid grammar and server-derived fields return exact paths with no write', async () => {
+  const server = await makeServer();
+  try {
+    const before = await diskSnapshot(server.templatesPath);
+    const invalid = draftBody('invalid-template');
+    invalid.fields[1].constraints = {minimum: 2};
+    const invalidResponse = await server.request('/api/forms/templates', jsonMutation(invalid));
+    assert.equal(invalidResponse.status, 422);
+    assert.deepEqual(
+      (await invalidResponse.json()).error.details.map((error) => error.path),
+      ['fields[1].constraints.minimum'],
+    );
+    assert.deepEqual(await diskSnapshot(server.templatesPath), before);
+
+    const forged = {...draftBody('forged-template'), revision: 40, schemaDigest: `sha256:${'a'.repeat(64)}`};
+    const forgedResponse = await server.request('/api/forms/templates', jsonMutation(forged));
+    assert.equal(forgedResponse.status, 400);
+    assert.deepEqual(
+      (await forgedResponse.json()).error.details.map((error) => error.path),
+      ['revision', 'schemaDigest'],
+    );
+    assert.deepEqual(await diskSnapshot(server.templatesPath), before);
+  } finally {
+    await server.close();
+  }
+});
+
+test('template routes enforce forms.manage, browser CSRF, URL credential, and destination safety', async () => {
+  const server = await makeServer();
+  try {
+    assert.equal((await server.request('/api/forms/templates', {headers: AGENT_HEADERS})).status, 200);
+    assert.equal((await server.request('/api/forms/templates', jsonMutation(draftBody()))).status, 201);
+    const before = await diskSnapshot(server.templatesPath);
+    const deniedHeaders = {Authorization: 'Bearer template-secret'};
+    const deniedCases = [
+      ['/api/forms/templates', {headers: deniedHeaders}, 200],
+      ['/api/forms/templates/training-log', {headers: deniedHeaders}, 404],
+      ['/api/forms/templates', jsonMutation(draftBody('denied-create'), deniedHeaders), 403],
+      ['/api/forms/templates/training-log', patchMutation({revision: 1, title: 'Denied'}, deniedHeaders), 404],
+      ['/api/forms/templates/training-log/publish', jsonMutation({}, deniedHeaders), 404],
+    ];
+    for (const [route, init, expected] of deniedCases) {
+      const response = await server.request(route, init);
+      assert.equal(response.status, expected, `${init.method || 'GET'} ${route}`);
+      if (route === '/api/forms/templates' && !init.method) {
+        assert.deepEqual((await response.json()).templates, []);
+      }
+      assert.deepEqual(await diskSnapshot(server.templatesPath), before);
+    }
+
+    const unauthenticated = await server.request('/api/forms/templates');
+    assert.equal(unauthenticated.status, 401);
+    const missingBrowserEnvelope = await server.request('/api/forms/templates', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(draftBody('browser-attempt')),
+    });
+    assert.equal(missingBrowserEnvelope.status, 403);
+    const queryCredential = await server.request('/api/forms/templates?token=template-secret', jsonMutation(draftBody('query-attempt')));
+    assert.equal(queryCredential.status, 400);
+    assert.deepEqual(await diskSnapshot(server.templatesPath), before);
+
+    for (const [templateId, destinationId] of [
+      ['path-destination', '../outside'],
+      ['unknown-destination', 'operator-created'],
+    ]) {
+      const body = draftBody(templateId);
+      body.destinationId = destinationId;
+      const response = await server.request('/api/forms/templates', jsonMutation(body));
+      assert.equal(response.status, 422);
+      assert.deepEqual((await response.json()).error.details.map((error) => error.path), ['destinationId']);
+      assert.deepEqual(await diskSnapshot(server.templatesPath), before);
+    }
+
+    const responseBodies = [];
+    for (const route of ['/api/forms/templates', '/api/forms/templates/training-log']) {
+      const response = await server.request(route, {headers: AGENT_HEADERS});
+      responseBodies.push(await response.text());
+    }
+    for (const body of responseBodies) {
+      assert.doesNotMatch(body, new RegExp(server.defaultRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      assert.doesNotMatch(body, new RegExp(server.gymRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('managed drafts and version metadata retain their last-known-good registry state', async () => {
+  const server = await makeServer();
+  try {
+    assert.equal((await server.request('/api/forms/templates', jsonMutation(draftBody()))).status, 201);
+    assert.equal((await server.request(
+      '/api/forms/templates/training-log/publish',
+      jsonMutation({}),
+    )).status, 201);
+    const draftPath = path.join(server.templatesPath, 'training-log', 'draft.json');
+    const versionPath = path.join(server.templatesPath, 'training-log', 'versions', '1.json');
+    const draftBytes = await fs.readFile(draftPath);
+    const versionBytes = await fs.readFile(versionPath);
+
+    await fs.writeFile(draftPath, '{broken');
+    assert.equal((await server.registry.getTemplate('training-log')).title, 'Training log');
+    await fs.writeFile(draftPath, draftBytes);
+    await server.registry.getTemplate('training-log');
+
+    await fs.writeFile(versionPath, '{broken');
+    const retained = await server.registry.getManagementTemplate('training-log');
+    assert.equal(retained.publishedVersion.templateVersion, 1);
+    assert.equal(retained.state, 'published');
+    await fs.writeFile(versionPath, versionBytes);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
Templates could only be changed by hand-editing YAML. This adds the write API that agents use directly and that the coming browser builder will sit on top of — one API, two client types.

- `GET /api/forms/templates` · `GET /api/forms/templates/:id` · `POST /api/forms/templates` · `PATCH /api/forms/templates/:id` · `POST /api/forms/templates/:id/publish`
- **CAS on `revision`** — a caller must send the revision it read; stale writes are 409 with nothing written.
- **Publish creates an immutable `form-template-version`**; publishing again adds a version rather than rewriting one.
- **Auth per ADR-92**: every route goes through the central `forms.manage` decision. Bearer requests carry explicit authority and are CSRF-exempt (the agent path); browser mutations additionally require exact Origin/Referer plus a synchronizer token. URL credentials and mixed bearer/browser credentials are refused. Denial shapes follow the ADR: filtered 200 for collections, uniform 404 for items, 403 for create.
- Writes use the same fsync-hardened atomic discipline as submissions, and the registry keeps its last-known-good behavior so a bad write can never take a live form down.

**Verified by probe**, including the property that protects existing data: an entry logged *before* a template rename + publish still renders `150`, `Leg Press`, and its original `Machine` label afterward — submissions pin their schema digest and snapshot labels, so restructuring a form never rewrites history. Also verified: CAS 200 then 409 on a stale revision, publish 201, and denial shapes (item 404 / create 403) without `forms.manage`.

159/159 tests; validate-raw-html, validate-editable-mode, skill-drift all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)