### PR TITLE
feat(forms): form hub navigation and browser field builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added server-rendered first-party form pages with native Post/Redirect/Get submission, a JSON submission endpoint sharing one service, and receipt views.
 - Browser mutations require an exact configured Origin plus a synchronizer token, and fail closed when no public origin is configured.
 - Submissions capture field type and label at capture time alongside option label snapshots, so later template edits never re-caption an issued receipt.
+- Added persistent Log/History/Configure navigation and a mobile-first, server-rendered template builder with approved destination aliases, stable option IDs, draft revision conflicts, and distinct immutable publishing.
 - Forms are disabled unless the `forms` configuration block is present.
 
 ## 2026-07-20 — Unreleased — Reconciled Runtime Surface

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -213,6 +213,13 @@ equality test intentionally does not cover them.
 |---|---|---|---|---|
 | Form page: `/forms/:templateId` | `GET` | `forms.submit` or `forms.view` | `forms.enabled` | Server-rendered first-party form; issues the browser context cookie and synchronizer token. |
 | Native submit: `/forms/:templateId` | `POST` | `forms.submit` | `forms.enabled` | Requires exact configured Origin + `_csrf` token; Post/Redirect/Get to the receipt. Fails closed when no public origin is configured. |
+| Entry history: `/forms/:templateId/entries` | `GET` | `forms.submit` or `forms.read_submissions` | `forms.enabled` | Owner-scoped server-rendered history; shares persistent form navigation. |
+| Template builder: `/forms/:templateId/configure` | `GET`, `POST` | `forms.manage` | `forms.enabled` | Server-rendered builder. Browser writes require exact Origin + CSRF and use the template API mutation controller with revision CAS. |
+| First template: `/forms/:templateId/configure/create` | `POST` | `forms.manage` | `forms.enabled` | Available only when no templates exist; destination is selected from configured aliases. |
+| Publish template: `/forms/:templateId/configure/publish` | `POST` | `forms.manage` | `forms.enabled` | Creates an immutable version from the rendered draft revision; stale revisions conflict. |
+| Template collection: `/api/forms/templates` | `GET`, `POST` | `forms.manage` | `forms.enabled` | Lists visible templates or creates a draft. Browser writes require exact Origin + CSRF; bearer agents use JSON. |
+| Template item: `/api/forms/templates/:templateId` | `GET`, `PATCH` | `forms.manage` | `forms.enabled` | Reads management metadata or revises a draft with required revision CAS. Unauthorized item access is a uniform 404. |
+| Publish API: `/api/forms/templates/:templateId/publish` | `POST` | `forms.manage` | `forms.enabled` | Creates the next immutable version; accepts an optional positive draft revision CAS guard. |
 | JSON submit: `/api/forms/:templateId/submissions` | `POST` | `forms.submit` | `forms.enabled` | Same submission service as the native path. |
 | Receipt: `/forms/:templateId/receipts/:submissionId` | `GET` | Submitter (or `read_submissions`) | `forms.enabled` | Uniform 404 for non-owners and unknown IDs. |
 
@@ -227,5 +234,4 @@ schema digest, and optional idempotency key. Receipt, correction, history, and
 list reads use the same template destination, and no client response or audit
 event includes storage paths.
 
-Forms builder UI, dynamic option providers, sessions, and reaction dispatch are
-**not** implemented.
+Dynamic option providers, sessions, and reaction dispatch are **not** implemented.

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -21,6 +21,18 @@ const TEMPLATE_PATCH_KEYS = new Set([
   'revision', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
   'lineage', 'presentation', 'fields',
 ]);
+const TEMPLATE_PUBLISH_KEYS = new Set(['revision']);
+const FIELD_TYPES = [
+  ['short-text', 'Short text'],
+  ['long-text', 'Long text'],
+  ['number', 'Number'],
+  ['checkbox', 'Checkbox'],
+  ['date', 'Date'],
+  ['time', 'Time'],
+  ['datetime', 'Date and time'],
+  ['select', 'Select one'],
+  ['multi-select', 'Select multiple'],
+];
 
 function escapeHtml(value) {
   return String(value ?? '')
@@ -99,6 +111,18 @@ function formHeaders(res, cspNonce) {
     "base-uri 'none'",
     "frame-ancestors 'self'",
   ].join('; '));
+}
+
+function formHubNav(templateId, active, canManage) {
+  const formHref = `/forms/${encodeURIComponent(templateId)}`;
+  const links = [
+    ['log', formHref, 'Log an entry'],
+    ['history', `${formHref}/entries`, 'History'],
+    ...(canManage ? [['configure', `${formHref}/configure`, 'Configure']] : []),
+  ];
+  return `<nav class="form-hub-nav" aria-label="Form views">${links.map(([key, href, label]) =>
+    `<a class="${key === 'history' ? 'entries-link' : `${key}-link`}" href="${href}"${key === active ? ' aria-current="page"' : ''}>${label}</a>`
+  ).join('')}</nav>`;
 }
 
 function errorMap(errors) {
@@ -320,15 +344,12 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   const submitLabel = editing
     ? 'Save correction'
     : configuredSubmitLabel || 'Submit';
-  const entriesHref = `/forms/${encodeURIComponent(template.templateId)}/entries`;
   const body = `${toolbarHtml()}
   <main class="layout form-layout">
     <header class="topbar">
       <h1>${escapeHtml(template.title)}</h1>
-      <nav class="form-page-links" aria-label="Form navigation">
-        <a class="back" href="/">Back</a>
-        <a class="entries-link" href="${entriesHref}">View entries</a>
-      </nav>
+      <p><a class="back" href="/">Back</a></p>
+      ${formHubNav(template.templateId, 'log', options.canManage)}
     </header>
 
     <section class="content form-card">
@@ -479,7 +500,7 @@ function renderEntriesPage(template, records, options = {}) {
     <header class="topbar">
       <h1>All entries</h1>
       <p class="subtitle">${escapeHtml(template.title)}</p>
-      <p><a class="back" href="${formHref}">Back to form</a></p>
+      ${formHubNav(template.templateId, 'history', options.canManage)}
     </header>
     <section class="content form-card entries-card">${content}</section>
   </main>
@@ -490,6 +511,296 @@ function renderEntriesPage(template, records, options = {}) {
     customThemeCss: options.customThemeCss,
     cspNonce: options.cspNonce,
   });
+}
+
+function fieldTypeOptions(selectedType) {
+  return FIELD_TYPES.map(([value, label]) =>
+    `<option value="${value}"${value === selectedType ? ' selected' : ''}>${label}</option>`
+  ).join('');
+}
+
+function builderErrors(errors) {
+  if (!errors || errors.length === 0) return '';
+  return `<div class="errors builder-errors" role="alert"><strong>Draft not saved.</strong><ul>${errors.map((error) =>
+    `<li>${escapeHtml(error.path || 'template')}: ${escapeHtml(error.message || 'is invalid')}</li>`
+  ).join('')}</ul></div>`;
+}
+
+function builderOption(option, fieldIndex, optionIndex, optionCount) {
+  const prefix = `field.${fieldIndex}.option.${optionIndex}`;
+  return `<div class="builder-option">
+    <input type="hidden" name="${prefix}.id" value="${escapeHtml(option.id)}">
+    <label><span>Option label</span><input name="${prefix}.label" value="${escapeHtml(option.label)}" maxlength="200" required></label>
+    <div class="builder-row-actions" aria-label="Actions for option ${optionIndex + 1}">
+      <button type="submit" name="_action" value="option-up:${fieldIndex}:${optionIndex}"${optionIndex === 0 ? ' disabled' : ''}>Move up</button>
+      <button type="submit" name="_action" value="option-down:${fieldIndex}:${optionIndex}"${optionIndex === optionCount - 1 ? ' disabled' : ''}>Move down</button>
+      <button class="builder-remove" type="submit" name="_action" value="option-remove:${fieldIndex}:${optionIndex}"${optionCount === 1 ? ' disabled' : ''}>Remove</button>
+    </div>
+  </div>`;
+}
+
+function builderField(field, fieldIndex, fieldCount) {
+  const prefix = `field.${fieldIndex}`;
+  const constraints = field.constraints || {};
+  const selection = field.type === 'select' || field.type === 'multi-select';
+  const bounds = ['number', 'date', 'datetime'].includes(field.type)
+    ? `<div class="builder-grid builder-bounds">
+        <label><span>Minimum</span><input name="${prefix}.minimum" value="${escapeHtml(constraints.minimum)}" inputmode="${field.type === 'number' ? 'decimal' : 'text'}"></label>
+        <label><span>Maximum</span><input name="${prefix}.maximum" value="${escapeHtml(constraints.maximum)}" inputmode="${field.type === 'number' ? 'decimal' : 'text'}"></label>
+        ${field.type === 'number' ? `<label><span>Step</span><input name="${prefix}.step" value="${escapeHtml(constraints.step)}" inputmode="decimal"></label>
+        <label class="builder-check"><input type="checkbox" name="${prefix}.integer" value="true"${constraints.integer === true ? ' checked' : ''}><span>Whole numbers only</span></label>` : ''}
+      </div>`
+    : '';
+  const options = selection && field.providerSlot
+    ? `<section class="builder-options"><input type="hidden" name="${prefix}.providerSlot" value="${escapeHtml(field.providerSlot)}"><p class="builder-help">Options for this field come from the configured provider <strong>${escapeHtml(field.providerSlot)}</strong> and cannot be edited here.</p></section>`
+    : selection
+    ? `<section class="builder-options" aria-labelledby="field-${fieldIndex}-options">
+        <div class="builder-section-heading"><h3 id="field-${fieldIndex}-options">Options</h3><button type="submit" name="_action" value="option-add:${fieldIndex}">Add option</button></div>
+        <p class="builder-help">Option IDs are retained when labels are renamed, so earlier entries keep matching the same choice.</p>
+        ${(field.options || []).map((option, optionIndex) => builderOption(option, fieldIndex, optionIndex, field.options.length)).join('')}
+      </section>`
+    : '';
+  return `<fieldset class="builder-field">
+    <legend>Field ${fieldIndex + 1}</legend>
+    <input type="hidden" name="${prefix}.id" value="${escapeHtml(field.id)}">
+    <div class="builder-grid">
+      <label><span>Label</span><input name="${prefix}.label" value="${escapeHtml(field.label)}" maxlength="200" required></label>
+      <label><span>Type</span><select name="${prefix}.type">${fieldTypeOptions(field.type)}</select></label>
+      <label class="builder-wide"><span>Help text</span><textarea name="${prefix}.help" rows="2" maxlength="1000">${escapeHtml(field.help || '')}</textarea></label>
+      <label><span>Component hint</span><input name="${prefix}.component" value="${escapeHtml(field.component || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*"></label>
+      <label class="builder-check"><input type="checkbox" name="${prefix}.required" value="true"${field.required ? ' checked' : ''}><span>Required</span></label>
+    </div>
+    ${bounds}
+    ${options}
+    <div class="builder-row-actions" aria-label="Actions for field ${fieldIndex + 1}">
+      <button type="submit" name="_action" value="field-up:${fieldIndex}"${fieldIndex === 0 ? ' disabled' : ''}>Move up</button>
+      <button type="submit" name="_action" value="field-down:${fieldIndex}"${fieldIndex === fieldCount - 1 ? ' disabled' : ''}>Move down</button>
+      <button class="builder-remove" type="submit" name="_action" value="field-remove:${fieldIndex}"${fieldCount === 1 ? ' disabled' : ''}>Remove field</button>
+    </div>
+  </fieldset>`;
+}
+
+function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
+  const template = record.draft;
+  const configureHref = `/forms/${encodeURIComponent(template.templateId)}/configure`;
+  const published = record.publishedVersion;
+  const status = options.status
+    ? `<p class="builder-status" role="status">${escapeHtml(options.status)}</p>`
+    : '';
+  const conflict = options.conflict
+    ? '<div class="builder-conflict" role="alert"><strong>This template changed since you opened it.</strong> The newest draft is shown below. Your stale edit was not saved; review the changes and try again.</div>'
+    : '';
+  const destinationOptions = destinationIds.map((destinationId) =>
+    `<option value="${escapeHtml(destinationId)}"${(template.destinationId || 'default') === destinationId ? ' selected' : ''}>${escapeHtml(destinationId)}</option>`
+  ).join('');
+  const publishedText = published
+    ? `Version ${published.templateVersion}, from draft revision ${published.sourceRevision}`
+    : 'Not published yet';
+  const body = `${toolbarHtml()}
+  <main class="layout form-layout builder-layout">
+    <header class="topbar">
+      <p class="eyebrow">Form builder</p>
+      <h1>${escapeHtml(template.title)}</h1>
+      ${formHubNav(template.templateId, 'configure', true)}
+    </header>
+    <section class="content form-card builder-card">
+      <dl class="builder-revisions">
+        <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
+        <div><dt>Published</dt><dd>${escapeHtml(publishedText)}</dd></div>
+      </dl>
+      ${status}${conflict}${builderErrors(options.errors)}
+      <p class="builder-warning"><strong>Past entries stay intact.</strong> Removing a field or changing its type does not alter earlier submissions: they keep their captured values and labels. New entries will use this draft after you publish it.</p>
+      <form method="post" action="${configureHref}" class="builder-form">
+        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+        <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+        <section class="builder-basics" aria-labelledby="builder-basics-heading">
+          <h2 id="builder-basics-heading">Template</h2>
+          <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
+          <label><span>Destination</span><select name="destinationId" required>${destinationOptions}</select></label>
+          <p class="builder-help">Destinations are deployment-approved aliases. Filesystem paths cannot be entered here.</p>
+        </section>
+        <section class="builder-fields" aria-labelledby="builder-fields-heading">
+          <div class="builder-section-heading"><h2 id="builder-fields-heading">Fields</h2><button type="submit" name="_action" value="field-add">Add field</button></div>
+          ${template.fields.map((field, index) => builderField(field, index, template.fields.length)).join('')}
+        </section>
+        <button class="button-link button-link-primary form-primary-action" type="submit" name="_action" value="save">Save draft</button>
+      </form>
+      <section class="builder-publish" aria-labelledby="builder-publish-heading">
+        <h2 id="builder-publish-heading">Publish</h2>
+        <p>Publishing creates a new immutable version from the saved draft. Past published versions and submissions remain unchanged.</p>
+        <form method="post" action="${configureHref}/publish">
+          <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+          <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+          <button class="button-link builder-publish-action" type="submit">Publish saved draft</button>
+        </form>
+      </section>
+    </section>
+  </main>
+  ${themeScript(options.cspNonce)}`;
+  return baseHtml({
+    title: `Configure ${template.title}`,
+    body,
+    customThemeCss: options.customThemeCss,
+    cspNonce: options.cspNonce,
+  });
+}
+
+function renderFirstRunPage(templateId, csrfToken, destinationIds, options = {}) {
+  const destinationOptions = destinationIds.map((destinationId) =>
+    `<option value="${escapeHtml(destinationId)}">${escapeHtml(destinationId)}</option>`
+  ).join('');
+  const body = `${toolbarHtml()}
+  <main class="layout form-layout builder-layout">
+    <header class="topbar"><p class="eyebrow">Forms</p><h1>Create your first form</h1></header>
+    <section class="content form-card builder-card first-run-card">
+      <p>No form templates exist yet. Create <strong>${escapeHtml(templateId)}</strong> to start logging entries.</p>
+      ${builderErrors(options.errors)}
+      <form method="post" action="/forms/${encodeURIComponent(templateId)}/configure/create">
+        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+        <label><span>Title</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required autofocus></label>
+        <label><span>Destination</span><select name="destinationId" required>${destinationOptions}</select></label>
+        <p class="builder-help">Only deployment-approved destination aliases are available; a filesystem path is never accepted.</p>
+        <button class="button-link button-link-primary form-primary-action" type="submit">Create form</button>
+      </form>
+    </section>
+  </main>
+  ${themeScript(options.cspNonce)}`;
+  return baseHtml({
+    title: 'Create your first form',
+    body,
+    customThemeCss: options.customThemeCss,
+    cspNonce: options.cspNonce,
+  });
+}
+
+function postedString(body, name, fallback = '') {
+  const value = body && body[name];
+  return typeof value === 'string' ? value : fallback;
+}
+
+function generatedDefinitionId(prefix) {
+  return `${prefix}-${crypto.randomBytes(6).toString('hex')}`;
+}
+
+function postedIndices(body, expression) {
+  const indices = new Set();
+  for (const key of Object.keys(body || {})) {
+    const match = expression.exec(key);
+    if (match) indices.add(Number(match[1]));
+  }
+  return [...indices].filter(Number.isSafeInteger).sort((left, right) => left - right);
+}
+
+function postedFields(current, body) {
+  const indices = postedIndices(body, /^field\.(\d+)\./);
+  const currentById = new Map((current.fields || []).map((field) => [field.id, field]));
+  return indices.map((fieldIndex) => {
+    const prefix = `field.${fieldIndex}`;
+    const id = postedString(body, `${prefix}.id`);
+    const type = postedString(body, `${prefix}.type`);
+    const previous = currentById.get(id);
+    const sameType = previous && previous.type === type;
+    const field = {
+      ...(sameType ? structuredClone(previous) : {}),
+      id,
+      type,
+      label: postedString(body, `${prefix}.label`),
+      required: postedString(body, `${prefix}.required`) === 'true',
+    };
+    const help = postedString(body, `${prefix}.help`);
+    if (help) field.help = help;
+    else delete field.help;
+    const component = postedString(body, `${prefix}.component`);
+    if (component) field.component = component;
+    else delete field.component;
+
+    delete field.constraints;
+    if (type === 'number') {
+      const constraints = {};
+      for (const key of ['minimum', 'maximum', 'step']) {
+        const value = postedString(body, `${prefix}.${key}`);
+        if (value !== '') constraints[key] = Number(value);
+      }
+      if (postedString(body, `${prefix}.integer`) === 'true') constraints.integer = true;
+      if (Object.keys(constraints).length) field.constraints = constraints;
+    } else if (type === 'date' || type === 'datetime') {
+      const constraints = {};
+      for (const key of ['minimum', 'maximum']) {
+        const value = postedString(body, `${prefix}.${key}`);
+        if (value !== '') constraints[key] = value;
+      }
+      if (Object.keys(constraints).length) field.constraints = constraints;
+    } else if (sameType && previous.constraints) {
+      field.constraints = structuredClone(previous.constraints);
+    }
+
+    delete field.options;
+    delete field.providerSlot;
+    if (type === 'select' || type === 'multi-select') {
+      const providerSlot = postedString(body, `${prefix}.providerSlot`);
+      if (providerSlot) {
+        field.providerSlot = providerSlot;
+      } else {
+        const optionIndices = postedIndices(body, new RegExp(`^field\\.${fieldIndex}\\.option\\.(\\d+)\\.`));
+        field.options = optionIndices.map((optionIndex) => {
+          const optionPrefix = `${prefix}.option.${optionIndex}`;
+          const optionId = postedString(body, `${optionPrefix}.id`);
+          const previousOption = sameType && Array.isArray(previous.options)
+            ? previous.options.find((option) => option.id === optionId)
+            : null;
+          return {
+            id: optionId,
+            label: postedString(body, `${optionPrefix}.label`),
+            ...(previousOption && previousOption.disabled ? {disabled: true} : {}),
+          };
+        });
+        if (field.options.length === 0) {
+          field.options.push({id: generatedDefinitionId('option'), label: 'New option'});
+        }
+      }
+    }
+    return field;
+  });
+}
+
+function applyBuilderAction(fields, action) {
+  if (action === 'field-add') {
+    fields.push({
+      id: generatedDefinitionId('field'),
+      type: 'short-text',
+      label: 'New field',
+      required: false,
+    });
+    return;
+  }
+  let match = /^field-(up|down|remove):(\d+)$/.exec(action);
+  if (match) {
+    const index = Number(match[2]);
+    if (match[1] === 'remove' && fields.length > 1 && fields[index]) fields.splice(index, 1);
+    if (match[1] === 'up' && index > 0 && fields[index]) [fields[index - 1], fields[index]] = [fields[index], fields[index - 1]];
+    if (match[1] === 'down' && fields[index] && fields[index + 1]) [fields[index], fields[index + 1]] = [fields[index + 1], fields[index]];
+    return;
+  }
+  match = /^option-(add|up|down|remove):(\d+)(?::(\d+))?$/.exec(action);
+  if (!match) return;
+  const field = fields[Number(match[2])];
+  if (!field || !Array.isArray(field.options)) return;
+  const index = Number(match[3]);
+  if (match[1] === 'add') field.options.push({id: generatedDefinitionId('option'), label: 'New option'});
+  if (match[1] === 'remove' && field.options.length > 1 && field.options[index]) field.options.splice(index, 1);
+  if (match[1] === 'up' && index > 0 && field.options[index]) [field.options[index - 1], field.options[index]] = [field.options[index], field.options[index - 1]];
+  if (match[1] === 'down' && field.options[index] && field.options[index + 1]) [field.options[index], field.options[index + 1]] = [field.options[index + 1], field.options[index]];
+}
+
+function builderPatch(current, body) {
+  const fields = postedFields(current, body);
+  applyBuilderAction(fields, postedString(body, '_action', 'save'));
+  return {
+    revision: Number(postedString(body, 'revision')),
+    title: postedString(body, 'title'),
+    destinationId: postedString(body, 'destinationId'),
+    fields,
+  };
 }
 
 function timeZoneOffset(timestamp, timeZone) {
@@ -643,6 +954,7 @@ function createFormsRouter(options) {
   const logger = options.logger || console;
   const customThemeCss = options.customThemeCss || '';
   const publicOrigins = configuredOrigins(options.publicOrigin);
+  const destinationIds = [...(options.destinationIds || registry.destinationIds || ['default'])].sort();
   const serverTimezone = options.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
   try {
     new Intl.DateTimeFormat('en-US', { timeZone: serverTimezone }).format(new Date());
@@ -651,6 +963,7 @@ function createFormsRouter(options) {
   }
   const router = express.Router();
   const formParser = express.urlencoded({ extended: false, limit: '256kb', parameterLimit: 500 });
+  const builderParser = express.urlencoded({ extended: false, limit: '2mb', parameterLimit: 10000 });
   const apiParser = express.json({ limit: '2mb' });
 
   if (publicOrigins.length === 0) {
@@ -831,6 +1144,29 @@ function createFormsRouter(options) {
     };
   }
 
+  async function createTemplateThroughApi(req, body) {
+    const principal = principalFor(req);
+    const draft = {
+      contractVersion: 1,
+      resourceKind: 'form-template',
+      templateId: body.templateId,
+      ownerId: principal.id,
+      revision: 1,
+      ...Object.fromEntries(Object.entries(body).filter(([key]) => key !== 'templateId')),
+    };
+    return registry.createDraft(draft);
+  }
+
+  async function reviseTemplateThroughApi(templateId, body) {
+    const changes = {...body};
+    delete changes.revision;
+    return registry.reviseDraft(templateId, body.revision, changes);
+  }
+
+  async function publishTemplateThroughApi(req, templateId, body) {
+    return registry.publishDraft(templateId, principalFor(req), body.revision);
+  }
+
   function sendTemplateMutationError(req, res, error, type) {
     if (error && error.code === 'EVALIDATION') {
       emitAudit(req, type, 'rejected_validation');
@@ -932,15 +1268,7 @@ function createFormsRouter(options) {
       }
       const body = managementBody(req, res, TEMPLATE_CREATE_KEYS, type);
       if (!body) return;
-      const draft = {
-        contractVersion: 1,
-        resourceKind: 'form-template',
-        templateId: body.templateId,
-        ownerId: principal.id,
-        revision: 1,
-        ...Object.fromEntries(Object.entries(body).filter(([key]) => key !== 'templateId')),
-      };
-      const record = await registry.createDraft(draft);
+      const record = await createTemplateThroughApi(req, body);
       emitAudit(req, type, 'accepted', record.draft);
       res.status(201).json({ ok: true, ...templateProjection(record) });
     } catch (error) {
@@ -971,9 +1299,7 @@ function createFormsRouter(options) {
         res.status(400).json({ ok: false, error: { code: 'invalid_request', message: 'At least one draft field must change.' } });
         return;
       }
-      const changes = {...body};
-      delete changes.revision;
-      const revised = await registry.reviseDraft(req.params.templateId, body.revision, changes);
+      const revised = await reviseTemplateThroughApi(req.params.templateId, body);
       emitAudit(req, type, 'accepted', revised.draft);
       res.status(200).json({ ok: true, ...templateProjection(revised) });
     } catch (error) {
@@ -989,13 +1315,195 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, type);
       const record = await registry.getManagementTemplate(req.params.templateId);
       if (!record || !await allowed(req, 'forms.manage', record.draft)) return apiNotFound(req, res, type);
-      const body = managementBody(req, res, new Set(), type);
+      const body = managementBody(req, res, TEMPLATE_PUBLISH_KEYS, type);
       if (!body) return;
-      const principal = principalFor(req);
-      const version = await registry.publishDraft(req.params.templateId, principal);
+      if (body.revision !== undefined && (!Number.isSafeInteger(body.revision) || body.revision < 1)) {
+        emitAudit(req, type, 'rejected_validation', record.draft);
+        res.status(400).json({
+          ok: false,
+          error: { code: 'invalid_request', message: 'revision must be a positive integer.', details: [{path: 'revision', message: 'must be a positive integer'}] },
+        });
+        return;
+      }
+      const version = await publishTemplateThroughApi(req, req.params.templateId, body);
       emitAudit(req, type, 'accepted', version);
       res.status(201).json({ ok: true, version });
     } catch (error) {
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  function parseBuilder(req, res, next) {
+    if (!req.is('application/x-www-form-urlencoded')) {
+      emitAudit(req, 'form.template.revise', 'rejected_validation');
+      res.status(415).type('text/plain').send('Unsupported media type.');
+      return;
+    }
+    builderParser(req, res, (error) => {
+      if (!error) return next();
+      emitAudit(req, 'form.template.revise', error.status === 413 ? 'rejected_size' : 'rejected_validation');
+      res.status(error.status === 413 ? 413 : 400).type('text/plain').send('Invalid form body.');
+    });
+  }
+
+  function validBuilderBody(body, create = false) {
+    const fixed = create
+      ? new Set(['_csrf', 'title', 'destinationId'])
+      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId']);
+    const fieldKey = /^field\.\d+\.(?:id|type|label|required|help|component|minimum|maximum|step|integer|providerSlot|option\.\d+\.(?:id|label))$/;
+    return body && typeof body === 'object' && !Array.isArray(body)
+      && Object.entries(body).every(([key, value]) => typeof value === 'string'
+        && (fixed.has(key) || (!create && fieldKey.test(key))));
+  }
+
+  async function canCreateTemplate(req) {
+    const principal = principalFor(req);
+    const resource = principal && isDefinitionId(principal.id)
+      ? {resourceKind: 'form-template', ownerId: principal.id}
+      : null;
+    return Boolean(resource && await allowed(req, 'forms.manage', resource));
+  }
+
+  function sendFirstRun(res, templateId, csrfToken, responseOptions = {}, status = 200) {
+    const cspNonce = crypto.randomBytes(18).toString('base64url');
+    formHeaders(res, cspNonce);
+    res.status(status).type('html').send(renderFirstRunPage(templateId, csrfToken, destinationIds, {
+      customThemeCss,
+      cspNonce,
+      ...responseOptions,
+    }));
+  }
+
+  function sendConfigure(res, record, csrfToken, responseOptions = {}, status = 200) {
+    const cspNonce = crypto.randomBytes(18).toString('base64url');
+    formHeaders(res, cspNonce);
+    res.status(status).type('html').send(renderConfigurePage(record, csrfToken, destinationIds, {
+      customThemeCss,
+      cspNonce,
+      ...responseOptions,
+    }));
+  }
+
+  router.get('/forms/:templateId/configure', async (req, res, next) => {
+    const type = 'form.template.read';
+    try {
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+      const record = await registry.getManagementTemplate(req.params.templateId);
+      if (!record) {
+        const records = await registry.listManagementTemplates();
+        if (records.length !== 0 || !await canCreateTemplate(req)) return formNotFound(req, res, type);
+        emitAudit(req, type, 'accepted', {templateId: req.params.templateId});
+        sendFirstRun(res, req.params.templateId, issueContext(req, res));
+        return;
+      }
+      if (!await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
+      emitAudit(req, type, 'accepted', record.draft);
+      sendConfigure(res, record, issueContext(req, res));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/forms/:templateId/configure/create', parseBuilder, async (req, res, next) => {
+    const type = 'form.template.create';
+    try {
+      if (!browserEnvelope(req, res, req.body && req.body._csrf, type)) return;
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+      const records = await registry.listManagementTemplates();
+      if (records.length !== 0 || !await canCreateTemplate(req)) return formNotFound(req, res, type);
+      if (!validBuilderBody(req.body, true)) {
+        emitAudit(req, type, 'rejected_validation');
+        res.status(400).type('text/plain').send('Invalid form body.');
+        return;
+      }
+      const body = {
+        templateId: req.params.templateId,
+        grammarVersion: 1,
+        destinationId: postedString(req.body, 'destinationId'),
+        title: postedString(req.body, 'title'),
+        fields: [{id: 'entry', type: 'short-text', label: 'Entry', required: true}],
+      };
+      const record = await createTemplateThroughApi(req, body);
+      emitAudit(req, type, 'accepted', record.draft);
+      res.redirect(303, `/forms/${encodeURIComponent(req.params.templateId)}/configure`);
+    } catch (error) {
+      if (error && error.code === 'EVALIDATION') {
+        emitAudit(req, type, 'rejected_validation');
+        sendFirstRun(res, req.params.templateId, issueContext(req, res), {
+          errors: error.details,
+          title: postedString(req.body, 'title'),
+        }, 422);
+        return;
+      }
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  router.post('/forms/:templateId/configure', parseBuilder, async (req, res, next) => {
+    const type = 'form.template.revise';
+    try {
+      if (!browserEnvelope(req, res, req.body && req.body._csrf, type)) return;
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+      const record = await registry.getManagementTemplate(req.params.templateId);
+      if (!record || !await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
+      if (!validBuilderBody(req.body)) {
+        emitAudit(req, type, 'rejected_validation', record.draft);
+        res.status(400).type('text/plain').send('Invalid form body.');
+        return;
+      }
+      const patch = builderPatch(record.draft, req.body);
+      const revised = await reviseTemplateThroughApi(req.params.templateId, patch);
+      emitAudit(req, type, 'accepted', revised.draft);
+      sendConfigure(res, revised, issueContext(req, res), {status: 'Draft saved.'});
+    } catch (error) {
+      if (error && error.code === 'ESTALE') {
+        emitAudit(req, type, 'rejected_validation');
+        const latest = await registry.getManagementTemplate(req.params.templateId);
+        sendConfigure(res, latest, issueContext(req, res), {conflict: true}, 409);
+        return;
+      }
+      if (error && error.code === 'EVALIDATION') {
+        emitAudit(req, type, 'rejected_validation');
+        const current = await registry.getManagementTemplate(req.params.templateId);
+        const candidate = {
+          ...current,
+          draft: {...current.draft, ...builderPatch(current.draft, req.body), revision: current.draft.revision},
+        };
+        sendConfigure(res, candidate, issueContext(req, res), {errors: error.details}, 422);
+        return;
+      }
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  router.post('/forms/:templateId/configure/publish', parseBuilder, async (req, res, next) => {
+    const type = 'form.template.publish';
+    try {
+      if (!browserEnvelope(req, res, req.body && req.body._csrf, type)) return;
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+      const record = await registry.getManagementTemplate(req.params.templateId);
+      if (!record || !await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
+      if (!req.body || Object.keys(req.body).some((key) => !['_csrf', 'revision'].includes(key))
+          || !Number.isSafeInteger(Number(req.body.revision)) || Number(req.body.revision) < 1) {
+        emitAudit(req, type, 'rejected_validation', record.draft);
+        res.status(400).type('text/plain').send('Invalid form body.');
+        return;
+      }
+      const version = await publishTemplateThroughApi(req, req.params.templateId, {revision: Number(req.body.revision)});
+      const published = await registry.getManagementTemplate(req.params.templateId);
+      emitAudit(req, type, 'accepted', version);
+      sendConfigure(res, published, issueContext(req, res), {status: `Published version ${version.templateVersion}.`});
+    } catch (error) {
+      if (error && error.code === 'ESTALE') {
+        emitAudit(req, type, 'rejected_validation');
+        const latest = await registry.getManagementTemplate(req.params.templateId);
+        sendConfigure(res, latest, issueContext(req, res), {conflict: true}, 409);
+        return;
+      }
       if (!sendTemplateMutationError(req, res, error, type)) next(error);
     }
   });
@@ -1005,10 +1513,17 @@ function createFormsRouter(options) {
       if (!browserAuthenticated(req, res, 'form.render')) return;
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.render');
       const template = await registry.getTemplate(req.params.templateId);
-      if (!template) return formNotFound(req, res, 'form.render');
+      if (!template) {
+        const records = await registry.listManagementTemplates();
+        if (records.length !== 0 || !await canCreateTemplate(req)) return formNotFound(req, res, 'form.render');
+        emitAudit(req, 'form.render', 'accepted', {templateId: req.params.templateId});
+        sendFirstRun(res, req.params.templateId, issueContext(req, res));
+        return;
+      }
       const canRender = await allowed(req, 'forms.submit', template)
         || await allowed(req, 'forms.view', template);
       if (!canRender) return formNotFound(req, res, 'form.render');
+      const canManage = await allowed(req, 'forms.manage', template);
       const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
       const csrfToken = issueContext(req, res);
       const cspNonce = crypto.randomBytes(18).toString('base64url');
@@ -1019,6 +1534,7 @@ function createFormsRouter(options) {
         cspNonce,
         recentRecords,
         timezone: serverTimezone,
+        canManage,
       }));
     } catch (error) {
       next(error);
@@ -1033,6 +1549,7 @@ function createFormsRouter(options) {
       if (!template) return formNotFound(req, res, 'form.submissions.list');
       const submissions = await listVisibleSubmissions(req, template, 100);
       if (!submissions) return formNotFound(req, res, 'form.submissions.list');
+      const canManage = await allowed(req, 'forms.manage', template);
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.submissions.list', 'accepted', template);
@@ -1040,6 +1557,7 @@ function createFormsRouter(options) {
         customThemeCss,
         cspNonce,
         timezone: serverTimezone,
+        canManage,
       }));
     } catch (error) {
       next(error);
@@ -1067,6 +1585,7 @@ function createFormsRouter(options) {
       const canRead = own || await allowed(req, 'forms.read_submissions', record);
       if (!canRead || !canSubmit) return formNotFound(req, res, 'form.render');
       const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
+      const canManage = await allowed(req, 'forms.manage', template);
       const csrfToken = issueContext(req, res);
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
@@ -1082,6 +1601,7 @@ function createFormsRouter(options) {
           correctionRecord: record,
           recentRecords,
           timezone: serverTimezone,
+          canManage,
         }
       ));
     } catch (error) {
@@ -1164,6 +1684,7 @@ function createFormsRouter(options) {
           ? result.error.details
           : [{ path: 'entry', message: result.error.message }];
         const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
+        const canManage = await allowed(req, 'forms.manage', template);
         res.status(result.error.code === 'idempotency_conflict' || result.error.code === 'correction_conflict' ? 409 : result.error.code === 'invalid_request' ? 400 : 422).type('html').send(renderFormPage(
           template,
           issueContext(req, res),
@@ -1175,6 +1696,7 @@ function createFormsRouter(options) {
             correctionRecord: predecessor,
             recentRecords,
             timezone: serverTimezone,
+            canManage,
           }
         ));
         return;
@@ -1399,7 +1921,9 @@ function createFormsRouter(options) {
 
 module.exports = {
   createFormsRouter,
+  renderConfigurePage,
   renderEntriesPage,
+  renderFirstRunPage,
   renderFormPage,
   renderReceiptPage,
 };

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -425,10 +425,13 @@ class TemplateRegistry {
     });
   }
 
-  async publishDraft(templateId, principal) {
+  async publishDraft(templateId, principal, expectedRevision) {
     return this.withMutationLock(templateId, async () => {
       const entry = await this.entryFor(templateId);
       if (!entry) throw codedError('ENOTFOUND', 'Template not found.');
+      if (expectedRevision !== undefined && entry.template.revision !== expectedRevision) {
+        throw codedError('ESTALE', 'Template revision is stale.');
+      }
       const templateVersion = entry.versions.length + 1;
       const draft = entry.template;
       const version = {

--- a/public/style.css
+++ b/public/style.css
@@ -597,6 +597,38 @@ tbody tr:last-child td {
   padding: clamp(1rem, 4vw, 2rem);
 }
 
+.form-layout .form-hub-nav {
+  display: grid;
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
+  gap: 0.3rem;
+  margin-top: 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-elev);
+  padding: 0.25rem;
+}
+
+.form-layout .form-hub-nav a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border-radius: 7px;
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.15;
+  padding: 0.35rem;
+  text-align: center;
+  text-decoration: none;
+}
+
+.form-layout .form-hub-nav a[aria-current="page"] {
+  background: var(--accent);
+  color: var(--bg);
+}
+
 .form-layout .form-page-links {
   display: flex;
   justify-content: space-between;
@@ -1077,6 +1109,243 @@ tbody tr:last-child td {
 
 .form-layout .entries-empty p {
   color: var(--text-soft);
+}
+
+/* Form template builder. Server round-trips remain usable without JavaScript. */
+.builder-layout {
+  max-width: 48rem;
+}
+
+.builder-layout .eyebrow {
+  margin: 0 0 0.25rem;
+  color: var(--text-soft);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.builder-layout .builder-revisions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin: 0 0 1rem;
+}
+
+.builder-layout .builder-revisions div {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-code);
+  padding: 0.7rem;
+}
+
+.builder-layout .builder-revisions dt {
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.builder-layout .builder-revisions dd {
+  margin: 0.2rem 0 0;
+  overflow-wrap: anywhere;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.builder-layout .builder-status,
+.builder-layout .builder-conflict,
+.builder-layout .builder-warning {
+  border-radius: 8px;
+  line-height: 1.45;
+  padding: 0.8rem;
+}
+
+.builder-layout .builder-status {
+  border: 1px solid var(--accent);
+  margin: 0 0 1rem;
+}
+
+.builder-layout .builder-conflict {
+  border: 2px solid var(--accent);
+  margin: 0 0 1rem;
+}
+
+.builder-layout .builder-warning {
+  border-left: 3px solid var(--accent);
+  background: var(--bg-code);
+  margin: 0 0 1.25rem;
+}
+
+.builder-layout .builder-basics,
+.builder-layout .builder-fields,
+.builder-layout .builder-publish {
+  margin-top: 1.5rem;
+}
+
+.builder-layout .builder-basics > h2,
+.builder-layout .builder-fields h2,
+.builder-layout .builder-publish h2 {
+  margin: 0;
+  font-family: var(--heading-font, inherit);
+  font-size: 1.15rem;
+}
+
+.builder-layout label > span:not(.checkbox-mark) {
+  display: block;
+  margin: 0 0 0.35rem;
+  color: var(--text-soft);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.builder-layout .builder-basics > label,
+.builder-layout .first-run-card form > label {
+  display: block;
+  margin-top: 1rem;
+}
+
+.builder-layout .builder-help {
+  margin: 0.55rem 0 0;
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.builder-layout .builder-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  margin-bottom: 0.75rem;
+}
+
+.builder-layout button:not(.form-primary-action):not(.builder-publish-action) {
+  min-height: 44px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--toolbar-btn-bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.55rem 0.7rem;
+}
+
+.builder-layout button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.builder-layout .builder-field {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin: 0 0 1rem;
+  padding: 0.85rem;
+}
+
+.builder-layout .builder-field legend {
+  color: var(--text-soft);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  padding: 0 0.3rem;
+  text-transform: uppercase;
+}
+
+.builder-layout .builder-grid {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.builder-layout .builder-check {
+  display: flex;
+  align-items: center;
+  min-height: 52px;
+  gap: 0.65rem;
+}
+
+.builder-layout .form-card .builder-check input[type="checkbox"] {
+  flex: 0 0 24px;
+  width: 24px;
+  min-height: 24px;
+  height: 24px;
+  margin: 0;
+}
+
+.builder-layout .builder-check > span {
+  margin: 0;
+  color: var(--text);
+}
+
+.builder-layout .builder-bounds,
+.builder-layout .builder-options {
+  border-top: 1px solid var(--border);
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+
+.builder-layout .builder-options h3 {
+  margin: 0;
+  font-family: var(--heading-font, inherit);
+  font-size: 1rem;
+}
+
+.builder-layout .builder-option {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-top: 0.8rem;
+  padding: 0.7rem;
+}
+
+.builder-layout .builder-row-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.builder-layout .builder-row-actions button {
+  min-width: 0;
+  padding-inline: 0.25rem;
+}
+
+.builder-layout .builder-remove {
+  border-color: var(--text-soft);
+}
+
+.builder-layout .builder-publish {
+  border-top: 1px solid var(--border);
+  padding-top: 1.25rem;
+}
+
+.builder-layout .builder-publish p {
+  color: var(--text-soft);
+  line-height: 1.5;
+}
+
+.builder-layout .builder-publish-action {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 52px;
+  border: 2px solid var(--accent);
+  background: transparent;
+  color: var(--link);
+  font: inherit;
+  font-weight: 700;
+}
+
+@media (min-width: 640px) {
+  .builder-layout .builder-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .builder-layout .builder-wide {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (min-width: 560px) {

--- a/server.js
+++ b/server.js
@@ -822,6 +822,7 @@ function createApp(options = {}) {
       registry: formsRegistry,
       store: formsStore,
       service: formsService,
+      destinationIds: Object.keys(destinationRoots),
       authorize: options.formsAuthorize,
       publicOrigin: options.formsPublicOrigin === undefined
         ? formsConfig.publicOrigins

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -1,0 +1,281 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const {Duplex} = require('node:stream');
+const {JSDOM} = require('jsdom');
+
+const {createApp} = require('../server');
+const {TemplateRegistry} = require('../lib/forms/template-registry');
+
+const ORIGIN = 'http://forms.example.test';
+
+function inject(app, route, init = {}) {
+  return new Promise((resolve, reject) => {
+    const socket = new Duplex({read() {}, write(_chunk, _encoding, callback) { callback(); }});
+    socket.remoteAddress = '127.0.0.1';
+    const request = new http.IncomingMessage(socket);
+    request.method = init.method || 'GET';
+    request.url = route;
+    request.headers = {host: 'forms.example.test'};
+    for (const [name, value] of Object.entries(init.headers || {})) request.headers[name.toLowerCase()] = value;
+    const body = init.body === undefined ? Buffer.alloc(0) : Buffer.from(String(init.body));
+    if (body.length && request.headers['content-length'] === undefined) request.headers['content-length'] = String(body.length);
+    const response = new http.ServerResponse(request);
+    response.assignSocket(socket);
+    const chunks = [];
+    response.write = (chunk, encoding) => {
+      if (chunk !== undefined && chunk !== null) chunks.push(Buffer.from(chunk, encoding));
+      return true;
+    };
+    response.end = (chunk, encoding) => {
+      if (chunk !== undefined && chunk !== null) chunks.push(Buffer.from(chunk, encoding));
+      response.finished = true;
+      response.emit('finish');
+      return response;
+    };
+    response.on('finish', () => {
+      const headers = response.getHeaders();
+      resolve({
+        status: response.statusCode,
+        headers: {get(name) {
+          const value = headers[String(name).toLowerCase()];
+          return Array.isArray(value) ? value.join(', ') : value ?? null;
+        }},
+        text: async () => Buffer.concat(chunks).toString('utf8'),
+      });
+    });
+    response.on('error', reject);
+    request.push(body);
+    request.push(null);
+    app.handle(request, response, reject);
+  });
+}
+
+function documentFor(html) {
+  return new JSDOM(html).window.document;
+}
+
+function formValues(form, action) {
+  const values = new URLSearchParams();
+  for (const control of form.querySelectorAll('input, select, textarea')) {
+    if (!control.name || control.disabled || (control.type === 'checkbox' && !control.checked)) continue;
+    values.append(control.name, control.value);
+  }
+  if (action) values.set('_action', action);
+  return values;
+}
+
+async function browserPage(response) {
+  const html = await response.text();
+  return {
+    html,
+    document: documentFor(html),
+    cookie: response.headers.get('set-cookie') && response.headers.get('set-cookie').split(';', 1)[0],
+  };
+}
+
+function browserPost(server, route, body, cookie, headers = {}) {
+  return server.request(route, {
+    method: 'POST',
+    headers: {
+      Origin: ORIGIN,
+      Cookie: cookie,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...headers,
+    },
+    body: body.toString(),
+  });
+}
+
+async function makeServer({empty = false} = {}) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-hub-builder-'));
+  const templatesPath = path.join(root, 'templates');
+  const defaultRoot = path.join(root, 'default');
+  const gymRoot = path.join(root, 'gym');
+  await fs.mkdir(templatesPath);
+  const registry = new TemplateRegistry({
+    templatesPath,
+    destinationIds: ['default', 'gym-log'],
+    clock: () => new Date('2026-07-21T12:00:00.000Z'),
+    logger: {warn() {}},
+  });
+  if (!empty) {
+    await registry.createDraft({
+      contractVersion: 1,
+      resourceKind: 'form-template',
+      templateId: 'training-log',
+      ownerId: 'operator',
+      revision: 1,
+      grammarVersion: 1,
+      destinationId: 'gym-log',
+      title: 'Training <log>',
+      fields: [
+        {
+          id: 'lift', type: 'select', label: 'Lift <name>', required: true,
+          options: [{id: 'squat', label: 'Squat <heavy>'}, {id: 'bench', label: 'Bench'}],
+        },
+        {id: 'notes', type: 'long-text', label: 'Notes', required: true},
+      ],
+    });
+  }
+  const app = createApp({
+    mappings: {},
+    formsConfig: {
+      enabled: true,
+      templatesPath,
+      destinations: {default: defaultRoot, 'gym-log': gymRoot},
+    },
+    formsRegistry: registry,
+    formsPublicOrigin: ORIGIN,
+    formsAudit: () => {},
+    formsAuthorize: ({req, capability}) => capability !== 'forms.manage' || req.get('x-no-manage') !== 'yes',
+  });
+  return {
+    root,
+    registry,
+    request: (route, init) => inject(app, route, init),
+    close: () => fs.rm(root, {recursive: true, force: true}),
+  };
+}
+
+test('hub navigation and builder lifecycle preserve snapshots, option IDs, CAS, aliases, and escaping', async () => {
+  const server = await makeServer();
+  try {
+    for (const route of ['/forms/training-log', '/forms/training-log/entries', '/forms/training-log/configure']) {
+      const response = await server.request(route);
+      assert.equal(response.status, 200, route);
+      const page = await browserPage(response);
+      assert.deepEqual(
+        [...page.document.querySelectorAll('.form-hub-nav a')].map((link) => link.textContent),
+        ['Log an entry', 'History', 'Configure'],
+      );
+    }
+
+    const deniedForm = await browserPage(await server.request('/forms/training-log', {headers: {'X-No-Manage': 'yes'}}));
+    assert.equal(deniedForm.document.querySelector('.configure-link'), null);
+    assert.equal((await server.request('/forms/training-log/configure', {headers: {'X-No-Manage': 'yes'}})).status, 404);
+
+    const formPage = await browserPage(await server.request('/forms/training-log'));
+    const submit = new URLSearchParams({
+      _csrf: formPage.document.querySelector('input[name="_csrf"]').value,
+      lift: 'squat',
+      notes: 'Earlier entry',
+    });
+    const accepted = await browserPost(server, '/forms/training-log', submit, formPage.cookie);
+    assert.equal(accepted.status, 303);
+    const receiptUrl = accepted.headers.get('location');
+
+    let configure = await browserPage(await server.request('/forms/training-log/configure'));
+    assert.doesNotMatch(configure.html, /Training <log>|Lift <name>|Squat <heavy>/);
+    assert.match(configure.html, /Training &lt;log&gt;/);
+    assert.deepEqual(
+      [...configure.document.querySelector('select[name="destinationId"]').options].map((option) => option.value),
+      ['default', 'gym-log'],
+    );
+    const cookie = configure.cookie;
+
+    let editForm = configure.document.querySelector('.builder-form');
+    let response = await browserPost(server, '/forms/training-log/configure', formValues(editForm, 'option-add:0'), cookie);
+    assert.equal(response.status, 200);
+    configure = await browserPage(response);
+    editForm = configure.document.querySelector('.builder-form');
+    response = await browserPost(server, '/forms/training-log/configure', formValues(editForm, 'field-add'), cookie);
+    assert.equal(response.status, 200);
+    configure = await browserPage(response);
+    editForm = configure.document.querySelector('.builder-form');
+    editForm.querySelector('[name="field.0.label"]').value = 'Movement';
+    editForm.querySelector('[name="field.0.option.0.label"]').value = 'Back squat';
+    editForm.querySelector('[name="field.0.option.2.label"]').value = 'Row';
+    editForm.querySelector('[name="field.2.label"]').value = 'Coach note';
+    response = await browserPost(server, '/forms/training-log/configure', formValues(editForm, 'save'), cookie);
+    assert.equal(response.status, 200);
+    configure = await browserPage(response);
+    assert.match(configure.document.querySelector('.builder-status').textContent, /Draft saved/);
+
+    const revised = await server.registry.getManagementTemplate('training-log');
+    assert.equal(revised.draft.revision, 4);
+    assert.equal(revised.draft.fields[0].options[0].id, 'squat');
+    assert.equal(revised.draft.fields[0].options[0].label, 'Back squat');
+    assert.equal(revised.draft.fields[0].options[2].label, 'Row');
+    assert.equal(revised.draft.fields[2].label, 'Coach note');
+
+    const receipt = await browserPage(await server.request(receiptUrl));
+    assert.match(receipt.document.body.textContent, /Lift <name>/);
+    assert.match(receipt.document.body.textContent, /Squat <heavy>/);
+    assert.doesNotMatch(receipt.document.body.textContent, /Back squat/);
+
+    const publishForm = configure.document.querySelector('.builder-publish form');
+    response = await browserPost(server, '/forms/training-log/configure/publish', formValues(publishForm), cookie);
+    assert.equal(response.status, 200);
+    const published = await server.registry.getManagementTemplate('training-log');
+    assert.equal(published.publishedVersion.templateVersion, 1);
+    assert.equal(published.publishedVersion.sourceRevision, 4);
+
+    const firstEditor = await browserPage(await server.request('/forms/training-log/configure'));
+    const secondEditor = await browserPage(await server.request('/forms/training-log/configure'));
+    const firstForm = firstEditor.document.querySelector('.builder-form');
+    firstForm.querySelector('[name="title"]').value = 'First editor wins';
+    response = await browserPost(server, '/forms/training-log/configure', formValues(firstForm, 'save'), firstEditor.cookie);
+    assert.equal(response.status, 200);
+    const secondForm = secondEditor.document.querySelector('.builder-form');
+    secondForm.querySelector('[name="title"]').value = 'Stale overwrite';
+    response = await browserPost(server, '/forms/training-log/configure', formValues(secondForm, 'save'), secondEditor.cookie);
+    assert.equal(response.status, 409);
+    const conflict = await browserPage(response);
+    assert.match(conflict.document.querySelector('.builder-conflict').textContent, /changed since you opened it/i);
+    assert.equal((await server.registry.getTemplate('training-log')).title, 'First editor wins');
+
+    const maliciousForm = conflict.document.querySelector('.builder-form');
+    maliciousForm.querySelector('[name="destinationId"]').value = '../outside';
+    const maliciousValues = formValues(maliciousForm, 'save');
+    maliciousValues.set('destinationId', '../outside');
+    response = await browserPost(server, '/forms/training-log/configure', maliciousValues, secondEditor.cookie);
+    assert.equal(response.status, 422);
+    const rejected = await browserPage(response);
+    assert.match(rejected.document.querySelector('.builder-errors').textContent, /destinationId/);
+    assert.deepEqual(
+      [...rejected.document.querySelector('select[name="destinationId"]').options].map((option) => option.value),
+      ['default', 'gym-log'],
+    );
+    assert.equal((await server.registry.getTemplate('training-log')).destinationId, 'gym-log');
+  } finally {
+    await server.close();
+  }
+});
+
+test('first-run hub offers API-backed creation only to managers and rejects path destinations', async () => {
+  const server = await makeServer({empty: true});
+  try {
+    assert.equal((await server.request('/forms/daily-log', {headers: {'X-No-Manage': 'yes'}})).status, 404);
+    let firstRun = await browserPage(await server.request('/forms/daily-log'));
+    const cookie = firstRun.cookie;
+    assert.match(firstRun.document.querySelector('h1').textContent, /Create your first form/);
+    assert.deepEqual(
+      [...firstRun.document.querySelector('select[name="destinationId"]').options].map((option) => option.value),
+      ['default', 'gym-log'],
+    );
+    const form = firstRun.document.querySelector('form');
+    form.querySelector('[name="title"]').value = 'Daily log';
+    let values = formValues(form);
+    values.set('destinationId', '../../tmp');
+    let response = await browserPost(server, '/forms/daily-log/configure/create', values, cookie);
+    assert.equal(response.status, 422);
+    assert.equal(await server.registry.getTemplate('daily-log'), null);
+
+    firstRun = await browserPage(response);
+    values = formValues(firstRun.document.querySelector('form'));
+    values.set('title', 'Daily log');
+    values.set('destinationId', 'default');
+    response = await browserPost(server, '/forms/daily-log/configure/create', values, cookie);
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get('location'), '/forms/daily-log/configure');
+    assert.equal((await server.registry.getTemplate('daily-log')).destinationId, 'default');
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
Adds the hub the operator asked for: navigation between the form, its history, and a browser-based field builder.

- `/forms/:id` stays the entry form (logging keeps zero extra clicks); `/entries` is History; `/configure` is the `forms.manage`-only builder. All three carry the same compact nav; Configure is omitted without the capability and its route returns a uniform 404.
- **Builder is a client of the template API from #171** — the JSON API and browser POST share one mutation controller, so there is no browser-specific write path. Draft saves and publish carry the rendered revision, so browser edits get the same CAS protection (publish gained an optional revision guard rather than inventing behavior the API could not express).
- Edit title, per-field label/type/help/required/bounds/component, add, remove, and reorder fields; publish is a distinct action from saving a draft.
- **Destination is a `<select>` of deployment-approved aliases only**, with the constraint stated in the UI: filesystem paths cannot be entered. Unknown aliases and path-like values fail validation without a write.
- Plain-language warning near destructive edits: removing a field or changing its type does not alter earlier submissions; they keep their captured values and labels.
- First-run: an authorized manager with no templates gets a creation form instead of a dead end.
- CHANGELOG and docs/CAPABILITIES.md updated in the same change.

161/161 tests; validate-raw-html, validate-editable-mode, skill-drift all exit 0. Rendered and reviewed at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)