### PR TITLE
fix(forms): stamp session time at submit, not at page load

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -218,8 +218,8 @@ function renderOptions(field, value, multiple) {
   }).join('');
 }
 
-function renderControl(field, values, describedBy = [], invalid = false) {
-  const value = rawValue(values, field);
+function renderControl(field, values, describedBy = [], invalid = false, options = {}) {
+  const value = options.autoStamp ? options.datetimeSeed : rawValue(values, field);
   const description = describedBy.length ? ` aria-describedby="${describedBy.map(escapeHtml).join(' ')}"` : '';
   const common = `id="field-${escapeHtml(field.id)}" name="${escapeHtml(field.id)}"${field.required ? ' required' : ''}${invalid ? ' aria-invalid="true"' : ''}${description}`;
   if (field.type === 'select') {
@@ -251,10 +251,13 @@ function renderControl(field, values, describedBy = [], invalid = false) {
     datetime: 'datetime-local',
   };
   const datetimeCapture = field.type === 'datetime'
-    ? ` data-datetime-local data-offset-field="${escapeHtml(field.id)}__offset" data-timezone-field="${escapeHtml(field.id)}__timezone"><input type="hidden" name="${escapeHtml(field.id)}__offset"><input type="hidden" name="${escapeHtml(field.id)}__timezone"`
+    ? ` data-datetime-local data-offset-field="${escapeHtml(field.id)}__offset" data-timezone-field="${escapeHtml(field.id)}__timezone"${options.autoStamp ? ` data-auto-stamp data-seed-field="${escapeHtml(field.id)}__seed" data-stamp-field="${escapeHtml(field.id)}__stamp"` : ''}`
+    : '';
+  const datetimeMetadata = field.type === 'datetime'
+    ? `<input type="hidden" name="${escapeHtml(field.id)}__offset"><input type="hidden" name="${escapeHtml(field.id)}__timezone">${options.autoStamp ? `<input type="hidden" name="${escapeHtml(field.id)}__seed" value="${escapeHtml(options.datetimeSeed)}"><input type="hidden" name="${escapeHtml(field.id)}__stamp" value="seed">` : ''}`
     : '';
   const placeholder = field.type === 'number' ? ' placeholder="\u2014"' : '';
-  const input = `<input ${common} type="${inputTypes[field.type]}" value="${escapeHtml(value)}"${placeholder}${field.type === 'number' || field.type === 'date' ? constraintAttributes(field) : ''}${datetimeCapture}>`;
+  const input = `<input ${common} type="${inputTypes[field.type]}" value="${escapeHtml(value)}"${placeholder}${field.type === 'number' || field.type === 'date' ? constraintAttributes(field) : ''}${datetimeCapture}>${datetimeMetadata}`;
   const unit = field.type === 'number' ? unitFromLabel(field.label) : null;
   return unit
     ? `<div class="readout-control">${input}<span class="readout-unit" id="field-${escapeHtml(field.id)}-unit">${escapeHtml(unit)}</span></div>`
@@ -266,18 +269,31 @@ function datetimeCaptureScript(cspNonce) {
 (() => {
   const pad = (value) => String(value).padStart(2, '0');
   const localValue = (date) => date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate()) + 'T' + pad(date.getHours()) + ':' + pad(date.getMinutes());
-  const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   for (const input of document.querySelectorAll('input[data-datetime-local]')) {
     const offset = input.form.elements[input.dataset.offsetField];
     const timezone = input.form.elements[input.dataset.timezoneField];
+    const stamp = input.dataset.stampField ? input.form.elements[input.dataset.stampField] : null;
+    let dirty = !input.hasAttribute('data-auto-stamp');
     const sync = () => {
       const instant = new Date(input.value);
       if (offset && Number.isFinite(instant.getTime())) offset.value = String(-instant.getTimezoneOffset());
+      const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
       if (timezone && zone) timezone.value = zone;
     };
-    if (!input.value) input.value = localValue(new Date());
-    input.addEventListener('input', sync);
-    input.form.addEventListener('submit', sync);
+    const override = () => {
+      dirty = true;
+      if (stamp) stamp.value = 'dirty';
+      sync();
+    };
+    input.addEventListener('input', override);
+    input.addEventListener('change', override);
+    input.form.addEventListener('submit', () => {
+      if (!dirty) {
+        input.value = localValue(new Date());
+        if (stamp) stamp.value = 'stamped';
+      }
+      sync();
+    });
     sync();
   }
 })();
@@ -299,6 +315,13 @@ function renderRecentEntries(template, records, timezone) {
 }
 
 function renderFormPage(template, csrfToken, values = {}, errors = [], options = {}) {
+  const editing = Boolean(options.correctionRecord);
+  const autoStampDatetimeIds = options.autoStampDatetimeIds || new Set((template.fields || [])
+    .filter((field) => !editing && field.type === 'datetime'
+      && !hasRawValue(values, field.id) && (field.default === undefined || field.default === ''))
+    .map((field) => field.id));
+  const renderNow = options.now instanceof Date ? options.now : new Date(options.now || Date.now());
+  const datetimeSeed = localDatetimeInZone(renderNow, options.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone);
   const errorsByField = errorMap(errors);
   const errorSummary = errors.length
     ? `<div class="errors" role="alert"><strong>Please correct the highlighted fields.</strong><ul>${errors.map((error) => {
@@ -332,14 +355,15 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
         field.type === 'number' ? 'field-readout' : '',
         fieldErrors.length ? 'invalid' : '',
       ].filter(Boolean).join(' ');
-      return `<div class="${classes}"><label for="field-${escapeHtml(field.id)}">${escapeHtml(label)}${required}</label>${description}${renderControl(field, values, describedBy, fieldErrors.length > 0)}${inlineErrors}</div>`;
+      const autoStamp = autoStampDatetimeIds.has(field.id);
+      const seed = autoStamp && hasRawValue(values, field.id) ? values[field.id] : datetimeSeed;
+      return `<div class="${classes}"><label for="field-${escapeHtml(field.id)}">${escapeHtml(label)}${required}</label>${description}${renderControl(field, values, describedBy, fieldErrors.length > 0, { autoStamp, datetimeSeed: seed })}${inlineErrors}</div>`;
     }).join('');
     return `<section class="form-section form-section-${group.key}" aria-labelledby="form-section-${group.key}">
           <h2 id="form-section-${group.key}">${group.title}</h2>
           <div class="form-section-fields">${fields}</div>
         </section>`;
   }).join('');
-  const editing = Boolean(options.correctionRecord);
   const configuredSubmitLabel = template.presentation && template.presentation.submitLabel;
   const submitLabel = editing
     ? 'Save correction'
@@ -840,6 +864,36 @@ function zonedParts(timestamp, timeZone) {
   return Object.fromEntries(parts.filter((part) => part.type !== 'literal').map((part) => [part.type, Number(part.value)]));
 }
 
+function localDatetimeInZone(timestamp, timeZone) {
+  const parts = zonedParts(timestamp, timeZone);
+  const pad = (value) => String(value).padStart(2, '0');
+  return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}T${pad(parts.hour)}:${pad(parts.minute)}`;
+}
+
+function prepareNativeDatetimeStamps(template, body, serverTimezone, timestamp, correcting) {
+  const untouchedDatetimeIds = new Set();
+  if (correcting) return untouchedDatetimeIds;
+  const submitSeed = localDatetimeInZone(timestamp, serverTimezone);
+  for (const field of template.fields) {
+    if (field.type !== 'datetime') continue;
+    const value = body[field.id];
+    const seed = body[`${field.id}__seed`];
+    const stamp = body[`${field.id}__stamp`];
+    if (stamp === 'seed' && typeof seed === 'string' && value === seed) {
+      body[field.id] = submitSeed;
+      body[`${field.id}__offset`] = '';
+      body[`${field.id}__timezone`] = '';
+      untouchedDatetimeIds.add(field.id);
+    } else if (stamp === 'stamped' && localDateTimeParts(value)
+        && /^-?\d+$/.test(String(body[`${field.id}__offset`] ?? ''))
+        && typeof body[`${field.id}__timezone`] === 'string'
+        && body[`${field.id}__timezone`]) {
+      untouchedDatetimeIds.add(field.id);
+    }
+  }
+  return untouchedDatetimeIds;
+}
+
 function normalizeNativeDatetime(value, offsetValue, timezoneValue, serverTimezone) {
   const parts = localDateTimeParts(value);
   if (!parts) return null;
@@ -956,6 +1010,7 @@ function createFormsRouter(options) {
   const publicOrigins = configuredOrigins(options.publicOrigin);
   const destinationIds = [...(options.destinationIds || registry.destinationIds || ['default'])].sort();
   const serverTimezone = options.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const clock = options.clock || (() => new Date());
   try {
     new Intl.DateTimeFormat('en-US', { timeZone: serverTimezone }).format(new Date());
   } catch (_error) {
@@ -965,6 +1020,13 @@ function createFormsRouter(options) {
   const formParser = express.urlencoded({ extended: false, limit: '256kb', parameterLimit: 500 });
   const builderParser = express.urlencoded({ extended: false, limit: '2mb', parameterLimit: 10000 });
   const apiParser = express.json({ limit: '2mb' });
+
+  function currentDate() {
+    const value = clock();
+    const date = value instanceof Date ? value : new Date(value);
+    if (!Number.isFinite(date.getTime())) throw new Error('The forms clock returned an invalid time.');
+    return date;
+  }
 
   if (publicOrigins.length === 0) {
     logger.warn('Forms are enabled without an explicit valid public origin; browser mutations will be refused.');
@@ -1535,6 +1597,7 @@ function createFormsRouter(options) {
         recentRecords,
         timezone: serverTimezone,
         canManage,
+        now: currentDate(),
       }));
     } catch (error) {
       next(error);
@@ -1638,7 +1701,7 @@ function createFormsRouter(options) {
         '_csrf',
         '_supersedes',
         ...template.fields.flatMap((field) => field.type === 'datetime'
-          ? [field.id, `${field.id}__offset`, `${field.id}__timezone`]
+          ? [field.id, `${field.id}__offset`, `${field.id}__timezone`, `${field.id}__seed`, `${field.id}__stamp`]
           : [field.id]),
       ]);
       if (Object.keys(req.body || {}).some((key) => !allowedKeys.has(key))) {
@@ -1646,6 +1709,13 @@ function createFormsRouter(options) {
         res.status(400).type('text/plain').send('Invalid form body.');
         return;
       }
+      const untouchedDatetimeIds = prepareNativeDatetimeStamps(
+        template,
+        req.body || {},
+        serverTimezone,
+        currentDate(),
+        req.body._supersedes !== undefined
+      );
       const submitted = nativeValues(template, req.body || {}, serverTimezone);
       let predecessor = null;
       let correctionAuthorized = false;
@@ -1697,6 +1767,8 @@ function createFormsRouter(options) {
             recentRecords,
             timezone: serverTimezone,
             canManage,
+            autoStampDatetimeIds: untouchedDatetimeIds,
+            now: currentDate(),
           }
         ));
         return;

--- a/server.js
+++ b/server.js
@@ -828,6 +828,7 @@ function createApp(options = {}) {
         ? formsConfig.publicOrigins
         : options.formsPublicOrigin,
       timezone: options.formsTimezone === undefined ? formsConfig.timezone : options.formsTimezone,
+      clock: options.formsClock,
       contexts: options.formsCsrfContexts,
       audit: formsAudit,
       logger,

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -178,6 +178,43 @@ async function getBrowserContext(server, templateId = 'gym-session-entry') {
   return browserContext(response, html);
 }
 
+function scriptedForm(html, clockState) {
+  return new JSDOM(html, {
+    url: PUBLIC_ORIGIN,
+    runScripts: 'dangerously',
+    beforeParse(window) {
+      const NativeDate = window.Date;
+      class ControlledDate extends NativeDate {
+        constructor(...args) {
+          super(...(args.length ? args : [clockState.now.getTime()]));
+        }
+
+        static now() {
+          return clockState.now.getTime();
+        }
+
+        getFullYear() { return this.getUTCFullYear(); }
+        getMonth() { return this.getUTCMonth(); }
+        getDate() { return this.getUTCDate(); }
+        getHours() { return this.getUTCHours(); }
+        getMinutes() { return this.getUTCMinutes(); }
+        getTimezoneOffset() { return clockState.offsetMinutes; }
+      }
+      window.Date = ControlledDate;
+      const NativeDateTimeFormat = window.Intl.DateTimeFormat;
+      const ControlledDateTimeFormat = function (...args) {
+        const formatter = new NativeDateTimeFormat(...args);
+        const resolvedOptions = formatter.resolvedOptions.bind(formatter);
+        formatter.resolvedOptions = () => ({ ...resolvedOptions(), timeZone: clockState.timezone });
+        return formatter;
+      };
+      ControlledDateTimeFormat.prototype = NativeDateTimeFormat.prototype;
+      ControlledDateTimeFormat.supportedLocalesOf = NativeDateTimeFormat.supportedLocalesOf.bind(NativeDateTimeFormat);
+      window.Intl.DateTimeFormat = ControlledDateTimeFormat;
+    },
+  });
+}
+
 function nativeBody(token, overrides = {}) {
   return new URLSearchParams({
     _csrf: token,
@@ -272,8 +309,11 @@ test('GET renders every field type, required markers, constraints, and a CSRF to
     assert.equal(document.querySelector('#field-entry-date').type, 'date');
     assert.equal(document.querySelector('#field-entry-time').type, 'time');
     assert.equal(document.querySelector('#field-recorded-at').type, 'datetime-local');
+    assert.ok(document.querySelector('#field-recorded-at').value);
+    assert.equal(document.querySelector('#field-recorded-at').hasAttribute('data-auto-stamp'), true);
     assert.ok(document.querySelector('input[name="recorded-at__offset"]'));
     assert.ok(document.querySelector('input[name="recorded-at__timezone"]'));
+    assert.equal(document.querySelector('input[name="recorded-at__stamp"]').value, 'seed');
     assert.match(html, /getTimezoneOffset/);
     assert.equal(document.querySelector('#field-choice').tagName, 'SELECT');
     assert.equal(document.querySelector('#field-choice option').textContent, 'Select…');
@@ -413,6 +453,155 @@ test('native datetime capture records an explicit offset and uses the configured
       { eventAt: '2026-01-20T09:30:00-05:00', timezone: 'America/New_York', clientOffsetMinutes: -300 }
     );
     assert.equal(winter.values.find((entry) => entry.fieldId === 'session-date').value, winter.eventAt);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('untouched datetime is stamped at browser submit with freshly recomputed offset and timezone', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {
+    formsClock: () => new Date('2026-07-20T13:30:00.000Z'),
+    formsTimezone: 'America/New_York',
+  });
+  try {
+    const response = await server.request('/forms/gym-session-entry');
+    const html = await response.text();
+    const context = browserContext(response, html);
+    const clockState = {
+      now: new Date('2026-07-20T09:30:00.000Z'),
+      offsetMinutes: 240,
+      timezone: 'Etc/GMT+4',
+    };
+    const dom = scriptedForm(html, clockState);
+    const { document } = dom.window;
+    const input = document.querySelector('#field-session-date');
+    const seed = input.value;
+    assert.equal(seed, '2026-07-20T09:30');
+    assert.equal(document.querySelector('input[name="session-date__stamp"]').value, 'seed');
+
+    clockState.now = new Date('2026-07-20T09:42:00.000Z');
+    clockState.offsetMinutes = 300;
+    clockState.timezone = 'Etc/GMT+5';
+    const form = input.form;
+    form.addEventListener('submit', (event) => event.preventDefault());
+    form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+
+    assert.equal(input.value, '2026-07-20T09:42');
+    assert.equal(document.querySelector('input[name="session-date__offset"]').value, '-300');
+    assert.equal(document.querySelector('input[name="session-date__timezone"]').value, 'Etc/GMT+5');
+    assert.equal(document.querySelector('input[name="session-date__stamp"]').value, 'stamped');
+
+    const body = nativeBody(context.token, {
+      'session-date': input.value,
+      'session-date__offset': '-300',
+      'session-date__timezone': 'Etc/GMT+5',
+      'session-date__seed': seed,
+      'session-date__stamp': 'stamped',
+    });
+    const accepted = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body,
+    });
+    assert.equal(accepted.status, 303);
+    const [fileName] = await submissionFiles(fixture.submissionsPath);
+    const record = JSON.parse(await fs.readFile(path.join(fixture.submissionsPath, fileName), 'utf8'));
+    assert.deepEqual(
+      { eventAt: record.eventAt, timezone: record.timezone, clientOffsetMinutes: record.clientOffsetMinutes },
+      { eventAt: '2026-07-20T09:42:00-05:00', timezone: 'Etc/GMT+5', clientOffsetMinutes: -300 }
+    );
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('datetime input events preserve deliberate overrides, including retyping the identical seed', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {
+    formsClock: () => new Date('2026-07-20T13:30:00.000Z'),
+    formsTimezone: 'America/New_York',
+  });
+  try {
+    const response = await server.request('/forms/gym-session-entry');
+    const html = await response.text();
+    const context = browserContext(response, html);
+    const clockState = {
+      now: new Date('2026-07-20T09:30:00.000Z'),
+      offsetMinutes: 240,
+      timezone: 'Etc/GMT+4',
+    };
+    const dom = scriptedForm(html, clockState);
+    const { document } = dom.window;
+    const input = document.querySelector('#field-session-date');
+    const seed = input.value;
+    input.value = seed;
+    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    assert.equal(document.querySelector('input[name="session-date__stamp"]').value, 'dirty');
+
+    clockState.now = new Date('2026-07-20T10:15:00.000Z');
+    input.form.addEventListener('submit', (event) => event.preventDefault());
+    input.form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+    assert.equal(input.value, seed);
+
+    input.value = '2026-07-19T08:05';
+    input.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    clockState.now = new Date('2026-07-20T11:00:00.000Z');
+    input.form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+    assert.equal(input.value, '2026-07-19T08:05');
+
+    const accepted = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: nativeBody(context.token, {
+        'session-date': input.value,
+        'session-date__offset': document.querySelector('input[name="session-date__offset"]').value,
+        'session-date__timezone': document.querySelector('input[name="session-date__timezone"]').value,
+        'session-date__seed': seed,
+        'session-date__stamp': 'dirty',
+      }),
+    });
+    assert.equal(accepted.status, 303);
+    const [fileName] = await submissionFiles(fixture.submissionsPath);
+    const record = JSON.parse(await fs.readFile(path.join(fixture.submissionsPath, fileName), 'utf8'));
+    assert.equal(record.eventAt, '2026-07-19T08:05:00-04:00');
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('no-JS untouched datetime seed is stamped by the server at submit', async () => {
+  const fixture = await makeFixture();
+  let now = new Date('2026-07-20T13:30:00.000Z');
+  const server = await startServer(fixture, {
+    formsClock: () => now,
+    formsTimezone: 'America/New_York',
+  });
+  try {
+    const response = await server.request('/forms/gym-session-entry');
+    const html = await response.text();
+    const context = browserContext(response, html);
+    const document = context.document;
+    const seed = document.querySelector('#field-session-date').value;
+    assert.equal(seed, '2026-07-20T09:30');
+
+    now = new Date('2026-07-20T13:47:00.000Z');
+    const accepted = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: nativeBody(context.token, {
+        'session-date': seed,
+        'session-date__seed': seed,
+        'session-date__stamp': 'seed',
+      }),
+    });
+    assert.equal(accepted.status, 303);
+    const [fileName] = await submissionFiles(fixture.submissionsPath);
+    const record = JSON.parse(await fs.readFile(path.join(fixture.submissionsPath, fileName), 'utf8'));
+    assert.deepEqual(
+      { eventAt: record.eventAt, timezone: record.timezone, clientOffsetMinutes: record.clientOffsetMinutes },
+      { eventAt: '2026-07-20T09:47:00-04:00', timezone: 'America/New_York', clientOffsetMinutes: -240 }
+    );
   } finally {
     await cleanup(fixture, server);
   }
@@ -1076,11 +1265,17 @@ test('receipt edit prefills values and saves an immutable superseding correction
     const editDocument = new JSDOM(await edit.text()).window.document;
     assert.equal(editDocument.querySelector('#field-top-weight').value, '225');
     assert.equal(editDocument.querySelector('#field-notes').value, 'Smooth reps');
+    assert.equal(editDocument.querySelector('#field-session-date').hasAttribute('data-auto-stamp'), false);
+    assert.equal(editDocument.querySelector('input[name="session-date__stamp"]'), null);
     assert.equal(editDocument.querySelector('input[name="_supersedes"]').value, originalId);
     assert.match(editDocument.querySelector('.correction-note').textContent, /earlier version stays preserved/i);
     const editToken = editDocument.querySelector('input[name="_csrf"]').value;
 
-    const correctionBody = nativeBody(editToken, { notes: 'Corrected form', 'top-weight': '230' });
+    const correctionBody = nativeBody(editToken, {
+      notes: 'Corrected form',
+      'top-weight': '230',
+      'session-date': '2026-07-19T08:15',
+    });
     correctionBody.set('_supersedes', originalId);
     const correctedResponse = await server.request('/forms/gym-session-entry', {
       method: 'POST',
@@ -1100,6 +1295,8 @@ test('receipt edit prefills values and saves an immutable superseding correction
     ));
     assert.deepEqual(corrected.supersedesRecord, { resourceKind: 'form-submission', id: originalId });
     assert.equal(corrected.values.find((entry) => entry.fieldId === 'top-weight').value, 230);
+    assert.equal(corrected.eventAt, '2026-07-19T08:15:00-04:00');
+    assert.equal(corrected.values.find((entry) => entry.fieldId === 'session-date').value, corrected.eventAt);
     assert.equal((await submissionFiles(fixture.submissionsPath)).length, 2);
 
     const receipt = await server.request(correctedResponse.headers.get('location'), {


### PR DESCRIPTION
Datetime fields were prefilled when the page RENDERED. Open the form, do your workout, submit ten minutes later, and the record captured the time you *opened* it — silently wrong data that looks plausible.

- **Auto-stamp at submit**: an untouched datetime control is rewritten to the current local minute in the form's submit listener, and the paired offset/timezone hidden fields are recomputed at the same moment so a DST/zone change between load and submit cannot produce an inconsistent triple.
- **Deliberate overrides respected**: dirty tracking is event-based (`input`/`change`), not value-equality, so deleting and retyping the identical seed still counts as an override and is never rewritten.
- **Works without JavaScript**: the field carries a valid server-rendered seed; the server stamps with its own submit-time clock only when the posted value still exactly matches that seed. A no-JS user who edits the value is treated as an override, and a missing marker never causes rejection.
- **Corrections keep their time**: correction forms get no auto-stamp metadata, so editing an old entry preserves its original time unless you change it.

164/164 tests; validate-raw-html, validate-editable-mode, skill-drift all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)