### PR TITLE
fix(forms): stepped-select dropdowns clipped their own placeholder

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -794,18 +794,23 @@ tbody tr:last-child td {
 }
 
 .form-layout .field-readout .stepped-select {
-  height: 5rem;
-  padding: 0.5rem 2.4rem 0.5rem 0.6rem;
+  /* A dropdown must fit its widest OPTION TEXT, not just a number. At readout
+     size the placeholder ("Select...") overflowed and was clipped mid-word.
+     Keep the numerals prominent and tabular, but sized so the empty state and
+     any option label still fit inside the control. */
+  height: 4rem;
+  padding: 0.5rem 2.2rem 0.5rem 0.6rem;
   font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
-  font-size: clamp(1.6rem, 7.5vw, 2.5rem);
+  font-size: clamp(1.05rem, 4.5vw, 1.5rem);
   font-variant-numeric: tabular-nums;
   font-weight: 700;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.02em;
   line-height: 1;
+  text-overflow: ellipsis;
 }
 
 .form-layout .readout-control-select .stepped-select {
-  padding-right: 5rem;
+  padding-right: 4rem;
 }
 
 .form-layout .readout-control-select .readout-unit {


### PR DESCRIPTION
The operator flagged the strength form's dropdowns as oversized. They were worse than oversized — clipped: the weight field rendered as `Selec` with the unit chip overlapping the truncated word.

Cause: the console-readout styling (2.5rem tabular numerals) is right for a typed number, and still looks good for captured values in the entries list, but it was inherited by the `stepped-select` control after numeric fields became dropdowns. A dropdown must fit its widest option text, not just a numeral, and the empty state was never re-checked after that change.

Fix: keep the numerals prominent and tabular, size the control so the placeholder and any option label fit, and reclaim the unit-chip gutter. Verified by rendering **both** the empty and filled states at 390px — empty now shows the subtle em-dash placeholder, filled reads `225 lb / 3 / 12` cleanly.

169/169 tests; validate-raw-html and validate-editable-mode exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)