### PR TITLE
feat(forms): templates index with create, clone, and archive

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -211,15 +211,19 @@ equality test intentionally does not cover them.
 
 | Route | Method | Effective auth | Enabled by | Notes |
 |---|---|---|---|---|
+| Forms index: `/forms` | `GET` | `forms.submit` or `forms.manage` | `forms.enabled` | Lists active submit-visible forms; managers also see lifecycle metadata, entry counts, actions, and archived templates in a collapsed section. |
+| Create template: `/forms/new`, `/forms` | `GET`, `POST` | `forms.manage` | `forms.enabled` | Single server-rendered creation flow backed by the template API controller; browser writes require exact Origin + CSRF. |
 | Form page: `/forms/:templateId` | `GET` | `forms.submit` or `forms.view` | `forms.enabled` | Server-rendered first-party form; issues the browser context cookie and synchronizer token. |
 | Native submit: `/forms/:templateId` | `POST` | `forms.submit` | `forms.enabled` | Requires exact configured Origin + `_csrf` token; Post/Redirect/Get to the receipt. Fails closed when no public origin is configured. |
 | Entry history: `/forms/:templateId/entries` | `GET` | `forms.submit` or `forms.read_submissions` | `forms.enabled` | Owner-scoped server-rendered history; shares persistent form navigation. |
 | Template builder: `/forms/:templateId/configure` | `GET`, `POST` | `forms.manage` | `forms.enabled` | Server-rendered builder. Browser writes require exact Origin + CSRF and use the template API mutation controller with revision CAS. |
-| First template: `/forms/:templateId/configure/create` | `POST` | `forms.manage` | `forms.enabled` | Available only when no templates exist; destination is selected from configured aliases. |
 | Publish template: `/forms/:templateId/configure/publish` | `POST` | `forms.manage` | `forms.enabled` | Creates an immutable version from the rendered draft revision; stale revisions conflict. |
-| Template collection: `/api/forms/templates` | `GET`, `POST` | `forms.manage` | `forms.enabled` | Lists visible templates or creates a draft. Browser writes require exact Origin + CSRF; bearer agents use JSON. |
+| Clone/lifecycle actions: `/forms/:templateId/clone`, `/forms/:templateId/archive`, `/forms/:templateId/restore` | `POST` | `forms.manage` | `forms.enabled` | Server-rendered actions backed by the JSON API controllers; lifecycle actions require revision CAS. |
+| Template collection: `/api/forms/templates` | `GET`, `POST` | `forms.submit` or `forms.manage` (`GET`); `forms.manage` (`POST`) | `forms.enabled` | Lists submit-visible templates with a minimal projection, lists management metadata for managers, or creates a draft. Browser writes require exact Origin + CSRF; bearer agents use JSON. |
 | Template item: `/api/forms/templates/:templateId` | `GET`, `PATCH` | `forms.manage` | `forms.enabled` | Reads management metadata or revises a draft with required revision CAS. Unauthorized item access is a uniform 404. |
 | Publish API: `/api/forms/templates/:templateId/publish` | `POST` | `forms.manage` | `forms.enabled` | Creates the next immutable version; accepts an optional positive draft revision CAS guard. |
+| Clone API: `/api/forms/templates/:templateId/clone` | `POST` | `forms.manage` | `forms.enabled` | Creates a revision-1 draft with a fresh identity and clone lineage; no submissions or published history are copied. |
+| Archive/restore API: `/api/forms/templates/:templateId/archive`, `/api/forms/templates/:templateId/restore` | `POST` | `forms.manage` | `forms.enabled` | CAS-guarded lifecycle changes. Archived forms refuse new submissions while history and receipts remain readable. |
 | JSON submit: `/api/forms/:templateId/submissions` | `POST` | `forms.submit` | `forms.enabled` | Same submission service as the native path. |
 | Receipt: `/forms/:templateId/receipts/:submissionId` | `GET` | Submitter (or `read_submissions`) | `forms.enabled` | Uniform 404 for non-owners and unknown IDs. |
 

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -22,6 +22,8 @@ const TEMPLATE_PATCH_KEYS = new Set([
   'lineage', 'presentation', 'fields',
 ]);
 const TEMPLATE_PUBLISH_KEYS = new Set(['revision']);
+const TEMPLATE_CLONE_KEYS = new Set(['templateId', 'templateVersion', 'title']);
+const TEMPLATE_LIFECYCLE_KEYS = new Set(['revision']);
 const FIELD_TYPES = [
   ['short-text', 'Short text'],
   ['long-text', 'Long text'],
@@ -756,32 +758,107 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   });
 }
 
-function renderFirstRunPage(templateId, csrfToken, destinationIds, options = {}) {
+function renderTemplateActions(template, csrfToken) {
+  const templateId = encodeURIComponent(template.templateId);
+  const lifecycle = template.state === 'archived' ? 'restore' : 'archive';
+  const lifecycleLabel = template.state === 'archived' ? 'Restore' : 'Archive';
+  return `<div class="forms-index-actions" aria-label="Actions for ${escapeHtml(template.title)}">
+    <a href="/forms/${templateId}">Open</a>
+    <a href="/forms/${templateId}/entries">History</a>
+    <a href="/forms/${templateId}/configure">Configure</a>
+    <form method="post" action="/forms/${templateId}/clone">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <button type="submit">Clone</button>
+    </form>
+    <form method="post" action="/forms/${templateId}/${lifecycle}">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+      <button type="submit">${lifecycleLabel}</button>
+    </form>
+  </div>`;
+}
+
+function renderManagedTemplate(template, csrfToken) {
+  const published = template.publishedVersion === null ? 'Not published' : `Version ${template.publishedVersion}`;
+  const stateLabel = template.state === 'archived'
+    ? 'Archived'
+    : template.state === 'published' ? 'Published' : 'Draft';
+  return `<article class="forms-index-item${template.state === 'archived' ? ' is-archived' : ''}">
+    <div class="forms-index-title"><h2><a href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}</a></h2><span class="forms-index-state">${stateLabel}</span></div>
+    <dl class="forms-index-meta">
+      <div><dt>Draft</dt><dd>r${escapeHtml(template.revision)}</dd></div>
+      <div><dt>Published</dt><dd>${escapeHtml(published)}</dd></div>
+      <div><dt>Destination</dt><dd>${escapeHtml(template.destinationId || 'default')}</dd></div>
+      <div><dt>Entries</dt><dd>${escapeHtml(template.entryCount)}</dd></div>
+    </dl>
+    ${renderTemplateActions(template, csrfToken)}
+  </article>`;
+}
+
+function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
+  const managed = templates.some((template) => template.management === true);
+  const active = templates.filter((template) => template.state !== 'archived');
+  const archived = templates.filter((template) => template.state === 'archived');
+  const activeHtml = active.length
+    ? active.map((template) => template.management
+      ? renderManagedTemplate(template, csrfToken)
+      : `<a class="forms-index-simple" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}<span aria-hidden="true">›</span></a>`).join('')
+    : `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first template' : 'No forms available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active forms you can submit to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New template</a>' : ''}</div>`;
+  const archivedHtml = managed && archived.length
+    ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken)).join('')}</div></details>`
+    : '';
+  const body = `${toolbarHtml()}
+  <main class="layout form-layout forms-index-layout">
+    <header class="topbar forms-index-header"><div><p class="eyebrow">Forms</p><h1>Templates</h1><p class="subtitle">${managed ? 'Create, configure, and review your forms.' : 'Choose a form to log an entry.'}</p></div>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New template</a>' : ''}</header>
+    <section class="forms-index-list" aria-label="Active templates">${activeHtml}</section>
+    ${archivedHtml}
+  </main>
+  ${themeScript(options.cspNonce)}`;
+  return baseHtml({
+    title: 'Forms',
+    body,
+    customThemeCss: options.customThemeCss,
+    cspNonce: options.cspNonce,
+  });
+}
+
+function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
   const destinationOptions = destinationIds.map((destinationId) =>
-    `<option value="${escapeHtml(destinationId)}">${escapeHtml(destinationId)}</option>`
+    `<option value="${escapeHtml(destinationId)}"${options.destinationId === destinationId ? ' selected' : ''}>${escapeHtml(destinationId)}</option>`
   ).join('');
   const body = `${toolbarHtml()}
   <main class="layout form-layout builder-layout">
-    <header class="topbar"><p class="eyebrow">Forms</p><h1>Create your first form</h1></header>
+    <header class="topbar"><p class="eyebrow"><a href="/forms">Forms</a></p><h1>New template</h1></header>
     <section class="content form-card builder-card first-run-card">
-      <p>No form templates exist yet. Create <strong>${escapeHtml(templateId)}</strong> to start logging entries.</p>
+      <p>Create a draft with one starter field. You can edit its fields immediately afterward.</p>
       ${builderErrors(options.errors)}
-      <form method="post" action="/forms/${encodeURIComponent(templateId)}/configure/create">
+      <form method="post" action="/forms">
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-        <label><span>Title</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required autofocus></label>
+        <label><span>Template ID</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*" required autofocus></label>
+        <label><span>Title</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required></label>
         <label><span>Destination</span><select name="destinationId" required>${destinationOptions}</select></label>
         <p class="builder-help">Only deployment-approved destination aliases are available; a filesystem path is never accepted.</p>
-        <button class="button-link button-link-primary form-primary-action" type="submit">Create form</button>
+        <button class="button-link button-link-primary form-primary-action" type="submit">Create template</button>
       </form>
     </section>
   </main>
   ${themeScript(options.cspNonce)}`;
   return baseHtml({
-    title: 'Create your first form',
+    title: 'New form template',
     body,
     customThemeCss: options.customThemeCss,
     cspNonce: options.cspNonce,
   });
+}
+
+function renderArchivedFormPage(template, options = {}) {
+  const body = `${toolbarHtml()}
+  <main class="layout form-layout">
+    <header class="topbar"><p class="eyebrow">Archived form</p><h1>${escapeHtml(template.title)}</h1>${formHubNav(template.templateId, 'log', options.canManage)}</header>
+    <section class="content form-card archived-form-state"><h2>This form is archived</h2><p>It is not accepting new entries. Existing history and receipts are still available.</p><a class="button-link" href="/forms/${encodeURIComponent(template.templateId)}/entries">View history</a></section>
+  </main>
+  ${themeScript(options.cspNonce)}`;
+  return baseHtml({title: `${template.title} is archived`, body, customThemeCss: options.customThemeCss, cspNonce: options.cspNonce});
 }
 
 function postedString(body, name, fallback = '') {
@@ -1323,6 +1400,84 @@ function createFormsRouter(options) {
     return registry.publishDraft(templateId, principalFor(req), body.revision);
   }
 
+  function routeValidationError(path, message) {
+    const error = new Error('Template validation failed.');
+    error.code = 'EVALIDATION';
+    error.details = [{path, message}];
+    return error;
+  }
+
+  async function availableCloneId(sourceId) {
+    const suffix = '-copy';
+    const base = `${sourceId.slice(0, 64 - suffix.length).replace(/-+$/, '')}${suffix}`;
+    for (let index = 1; index <= 1000; index += 1) {
+      const candidate = index === 1
+        ? base
+        : `${base.slice(0, 64 - String(index).length - 1).replace(/-+$/, '')}-${index}`;
+      if (!await registry.getTemplate(candidate)) return candidate;
+    }
+    throw new Error('Could not allocate a template ID for the clone.');
+  }
+
+  async function cloneTemplateThroughApi(req, sourceRecord, body) {
+    let source = sourceRecord.draft;
+    if (body.templateVersion !== undefined) {
+      if (!Number.isSafeInteger(body.templateVersion) || body.templateVersion < 1) {
+        throw routeValidationError('templateVersion', 'must be a positive integer');
+      }
+      source = await registry.getTemplateVersion(sourceRecord.draft.templateId, body.templateVersion);
+      if (!source) throw routeValidationError('templateVersion', 'does not identify a published version');
+    }
+    const templateId = body.templateId === undefined
+      ? await availableCloneId(sourceRecord.draft.templateId)
+      : body.templateId;
+    const destinationId = sourceRecord.draft.destinationId;
+    const derivedTitle = `${[...source.title].slice(0, 195).join('')} copy`;
+    return createTemplateThroughApi(req, {
+      templateId,
+      grammarVersion: source.grammarVersion,
+      ...(destinationId === undefined ? {} : {destinationId}),
+      title: body.title === undefined ? derivedTitle : body.title,
+      ...(source.description === undefined ? {} : {description: structuredClone(source.description)}),
+      ...(source.tags === undefined ? {} : {tags: structuredClone(source.tags)}),
+      lineage: {
+        relation: 'clone',
+        templateId: sourceRecord.draft.templateId,
+        ...(body.templateVersion === undefined ? {} : {templateVersion: body.templateVersion}),
+      },
+      ...(source.presentation === undefined ? {} : {presentation: structuredClone(source.presentation)}),
+      fields: structuredClone(source.fields),
+    });
+  }
+
+  async function setTemplateArchivedThroughApi(templateId, body, archived) {
+    return registry.setArchived(templateId, body.revision, archived);
+  }
+
+  async function listTemplatesThroughApi(req) {
+    const records = await registry.listManagementTemplates();
+    const templates = [];
+    for (const record of records) {
+      if (await allowed(req, 'forms.manage', record.draft)) {
+        const destinationStore = storeForTemplate(store, record.draft);
+        const entryCount = await destinationStore.countSubmissions({templateId: record.draft.templateId});
+        templates.push({
+          management: true,
+          templateId: record.draft.templateId,
+          title: record.draft.title,
+          revision: record.draft.revision,
+          publishedVersion: record.publishedVersion && record.publishedVersion.templateVersion,
+          destinationId: record.draft.destinationId || 'default',
+          state: record.state,
+          entryCount,
+        });
+      } else if (record.state !== 'archived' && await allowed(req, 'forms.submit', record.draft)) {
+        templates.push({templateId: record.draft.templateId, title: record.draft.title});
+      }
+    }
+    return templates;
+  }
+
   function sendTemplateMutationError(req, res, error, type) {
     if (error && error.code === 'EVALIDATION') {
       emitAudit(req, type, 'rejected_validation');
@@ -1375,20 +1530,12 @@ function createFormsRouter(options) {
     const type = 'form.template.list';
     try {
       if (!managementEnvelope(req, res, false, type)) return;
-      const records = await registry.listManagementTemplates();
-      const templates = [];
-      for (const record of records) {
-        if (!await allowed(req, 'forms.manage', record.draft)) continue;
-        templates.push({
-          templateId: record.draft.templateId,
-          title: record.draft.title,
-          revision: record.draft.revision,
-          publishedVersion: record.publishedVersion && record.publishedVersion.templateVersion,
-          state: record.state,
-        });
-      }
+      const templates = await listTemplatesThroughApi(req);
       emitAudit(req, type, 'accepted');
-      res.status(200).json({ ok: true, templates });
+      res.status(200).json({
+        ok: true,
+        templates: templates.map(({management: _management, ...template}) => template),
+      });
     } catch (error) {
       next(error);
     }
@@ -1489,6 +1636,52 @@ function createFormsRouter(options) {
     }
   });
 
+  router.post('/api/forms/templates/:templateId/clone', async (req, res, next) => {
+    const type = 'form.template.clone';
+    try {
+      if (!managementEnvelope(req, res, true, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, type);
+      const source = await registry.getManagementTemplate(req.params.templateId);
+      if (!source || !await allowed(req, 'forms.manage', source.draft)) return apiNotFound(req, res, type);
+      if (!managementContentType(req, res, type)) return;
+      const body = managementBody(req, res, TEMPLATE_CLONE_KEYS, type);
+      if (!body) return;
+      const cloned = await cloneTemplateThroughApi(req, source, body);
+      emitAudit(req, type, 'accepted', cloned.draft);
+      res.status(201).json({ok: true, ...templateProjection(cloned)});
+    } catch (error) {
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  for (const [action, archived] of [['archive', true], ['restore', false]]) {
+    router.post(`/api/forms/templates/:templateId/${action}`, async (req, res, next) => {
+      const type = `form.template.${action}`;
+      try {
+        if (!managementEnvelope(req, res, true, type)) return;
+        if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, type);
+        const current = await registry.getManagementTemplate(req.params.templateId);
+        if (!current || !await allowed(req, 'forms.manage', current.draft)) return apiNotFound(req, res, type);
+        if (!managementContentType(req, res, type)) return;
+        const body = managementBody(req, res, TEMPLATE_LIFECYCLE_KEYS, type);
+        if (!body) return;
+        if (!Number.isSafeInteger(body.revision) || body.revision < 1) {
+          emitAudit(req, type, 'rejected_validation', current.draft);
+          res.status(400).json({
+            ok: false,
+            error: {code: 'invalid_request', message: 'revision is required.', details: [{path: 'revision', message: 'must be a positive integer'}]},
+          });
+          return;
+        }
+        const changed = await setTemplateArchivedThroughApi(req.params.templateId, body, archived);
+        emitAudit(req, type, 'accepted', changed.draft);
+        res.status(200).json({ok: true, ...templateProjection(changed)});
+      } catch (error) {
+        if (!sendTemplateMutationError(req, res, error, type)) next(error);
+      }
+    });
+  }
+
   function parseBuilder(req, res, next) {
     if (!req.is('application/x-www-form-urlencoded')) {
       emitAudit(req, 'form.template.revise', 'rejected_validation');
@@ -1504,7 +1697,7 @@ function createFormsRouter(options) {
 
   function validBuilderBody(body, create = false) {
     const fixed = create
-      ? new Set(['_csrf', 'title', 'destinationId'])
+      ? new Set(['_csrf', 'templateId', 'title', 'destinationId'])
       : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId']);
     const fieldKey = /^field\.\d+\.(?:id|type|label|required|help|component|showInList|isDestroyed|minimum|maximum|step|integer|providerSlot|option\.\d+\.(?:id|label))$/;
     return body && typeof body === 'object' && !Array.isArray(body)
@@ -1520,10 +1713,10 @@ function createFormsRouter(options) {
     return Boolean(resource && await allowed(req, 'forms.manage', resource));
   }
 
-  function sendFirstRun(res, templateId, csrfToken, responseOptions = {}, status = 200) {
+  function sendCreateTemplate(res, csrfToken, responseOptions = {}, status = 200) {
     const cspNonce = crypto.randomBytes(18).toString('base64url');
     formHeaders(res, cspNonce);
-    res.status(status).type('html').send(renderFirstRunPage(templateId, csrfToken, destinationIds, {
+    res.status(status).type('html').send(renderCreateTemplatePage(csrfToken, destinationIds, {
       customThemeCss,
       cspNonce,
       ...responseOptions,
@@ -1540,42 +1733,56 @@ function createFormsRouter(options) {
     }));
   }
 
-  router.get('/forms/:templateId/configure', async (req, res, next) => {
-    const type = 'form.template.read';
+  router.get('/forms', async (req, res, next) => {
+    const type = 'form.template.list';
     try {
       if (!browserAuthenticated(req, res, type)) return;
-      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
-      const record = await registry.getManagementTemplate(req.params.templateId);
-      if (!record) {
-        const records = await registry.listManagementTemplates();
-        if (records.length !== 0 || !await canCreateTemplate(req)) return formNotFound(req, res, type);
-        emitAudit(req, type, 'accepted', {templateId: req.params.templateId});
-        sendFirstRun(res, req.params.templateId, issueContext(req, res));
-        return;
-      }
-      if (!await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
-      emitAudit(req, type, 'accepted', record.draft);
-      sendConfigure(res, record, issueContext(req, res));
+      const templates = await listTemplatesThroughApi(req);
+      const canCreate = await canCreateTemplate(req);
+      const cspNonce = crypto.randomBytes(18).toString('base64url');
+      formHeaders(res, cspNonce);
+      emitAudit(req, type, 'accepted');
+      res.status(200).type('html').send(renderFormsIndexPage(
+        templates,
+        canCreate,
+        issueContext(req, res),
+        {customThemeCss, cspNonce},
+      ));
     } catch (error) {
       next(error);
     }
   });
 
-  router.post('/forms/:templateId/configure/create', parseBuilder, async (req, res, next) => {
+  router.get('/forms/new', async (req, res, next) => {
+    const type = 'form.template.create';
+    try {
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!await canCreateTemplate(req)) return formNotFound(req, res, type);
+      emitAudit(req, type, 'accepted');
+      sendCreateTemplate(res, issueContext(req, res));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/forms', parseBuilder, async (req, res, next) => {
     const type = 'form.template.create';
     try {
       if (!browserEnvelope(req, res, req.body && req.body._csrf, type)) return;
       if (!browserAuthenticated(req, res, type)) return;
-      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
-      const records = await registry.listManagementTemplates();
-      if (records.length !== 0 || !await canCreateTemplate(req)) return formNotFound(req, res, type);
+      if (!await canCreateTemplate(req)) {
+        emitAudit(req, type, 'rejected_authz');
+        res.status(403).type('text/plain').send('Forbidden.');
+        return;
+      }
       if (!validBuilderBody(req.body, true)) {
         emitAudit(req, type, 'rejected_validation');
         res.status(400).type('text/plain').send('Invalid form body.');
         return;
       }
+      const templateId = postedString(req.body, 'templateId');
       const body = {
-        templateId: req.params.templateId,
+        templateId,
         grammarVersion: 1,
         destinationId: postedString(req.body, 'destinationId'),
         title: postedString(req.body, 'title'),
@@ -1583,17 +1790,84 @@ function createFormsRouter(options) {
       };
       const record = await createTemplateThroughApi(req, body);
       emitAudit(req, type, 'accepted', record.draft);
-      res.redirect(303, `/forms/${encodeURIComponent(req.params.templateId)}/configure`);
+      res.redirect(303, `/forms/${encodeURIComponent(templateId)}/configure`);
     } catch (error) {
-      if (error && error.code === 'EVALIDATION') {
+      if (error && (error.code === 'EVALIDATION' || error.code === 'ECONFLICT')) {
         emitAudit(req, type, 'rejected_validation');
-        sendFirstRun(res, req.params.templateId, issueContext(req, res), {
-          errors: error.details,
+        sendCreateTemplate(res, issueContext(req, res), {
+          errors: error.details || [{path: 'templateId', message: error.message}],
+          templateId: postedString(req.body, 'templateId'),
           title: postedString(req.body, 'title'),
-        }, 422);
+          destinationId: postedString(req.body, 'destinationId'),
+        }, error.code === 'ECONFLICT' ? 409 : 422);
         return;
       }
       if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  router.post('/forms/:templateId/clone', parseBuilder, async (req, res, next) => {
+    const type = 'form.template.clone';
+    try {
+      if (!browserEnvelope(req, res, req.body && req.body._csrf, type)) return;
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+      const source = await registry.getManagementTemplate(req.params.templateId);
+      if (!source || !await allowed(req, 'forms.manage', source.draft)) return formNotFound(req, res, type);
+      if (!req.body || Object.keys(req.body).some((key) => key !== '_csrf')) {
+        emitAudit(req, type, 'rejected_validation', source.draft);
+        res.status(400).type('text/plain').send('Invalid form body.');
+        return;
+      }
+      const cloned = await cloneTemplateThroughApi(req, source, {});
+      emitAudit(req, type, 'accepted', cloned.draft);
+      res.redirect(303, `/forms/${encodeURIComponent(cloned.draft.templateId)}/configure`);
+    } catch (error) {
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  for (const [action, archived] of [['archive', true], ['restore', false]]) {
+    router.post(`/forms/:templateId/${action}`, parseBuilder, async (req, res, next) => {
+      const type = `form.template.${action}`;
+      try {
+        if (!browserEnvelope(req, res, req.body && req.body._csrf, type)) return;
+        if (!browserAuthenticated(req, res, type)) return;
+        if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+        const current = await registry.getManagementTemplate(req.params.templateId);
+        if (!current || !await allowed(req, 'forms.manage', current.draft)) return formNotFound(req, res, type);
+        if (!req.body || Object.keys(req.body).some((key) => !['_csrf', 'revision'].includes(key))
+            || !Number.isSafeInteger(Number(req.body.revision)) || Number(req.body.revision) < 1) {
+          emitAudit(req, type, 'rejected_validation', current.draft);
+          res.status(400).type('text/plain').send('Invalid form body.');
+          return;
+        }
+        const changed = await setTemplateArchivedThroughApi(req.params.templateId, {revision: Number(req.body.revision)}, archived);
+        emitAudit(req, type, 'accepted', changed.draft);
+        res.redirect(303, '/forms');
+      } catch (error) {
+        if (error && error.code === 'ESTALE') {
+          emitAudit(req, type, 'rejected_validation');
+          res.status(409).type('text/plain').send('Template revision is stale. Reload the templates page and try again.');
+          return;
+        }
+        if (!sendTemplateMutationError(req, res, error, type)) next(error);
+      }
+    });
+  }
+
+  router.get('/forms/:templateId/configure', async (req, res, next) => {
+    const type = 'form.template.read';
+    try {
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+      const record = await registry.getManagementTemplate(req.params.templateId);
+      if (!record) return formNotFound(req, res, type);
+      if (!await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
+      emitAudit(req, type, 'accepted', record.draft);
+      sendConfigure(res, record, issueContext(req, res));
+    } catch (error) {
+      next(error);
     }
   });
 
@@ -1669,17 +1943,18 @@ function createFormsRouter(options) {
       if (!browserAuthenticated(req, res, 'form.render')) return;
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.render');
       const template = await registry.getTemplate(req.params.templateId);
-      if (!template) {
-        const records = await registry.listManagementTemplates();
-        if (records.length !== 0 || !await canCreateTemplate(req)) return formNotFound(req, res, 'form.render');
-        emitAudit(req, 'form.render', 'accepted', {templateId: req.params.templateId});
-        sendFirstRun(res, req.params.templateId, issueContext(req, res));
-        return;
-      }
+      if (!template) return formNotFound(req, res, 'form.render');
       const canRender = await allowed(req, 'forms.submit', template)
         || await allowed(req, 'forms.view', template);
       if (!canRender) return formNotFound(req, res, 'form.render');
       const canManage = await allowed(req, 'forms.manage', template);
+      if (template.archived === true) {
+        const cspNonce = crypto.randomBytes(18).toString('base64url');
+        formHeaders(res, cspNonce);
+        emitAudit(req, 'form.render', 'accepted', template);
+        res.status(200).type('html').send(renderArchivedFormPage(template, {customThemeCss, cspNonce, canManage}));
+        return;
+      }
       const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
       const csrfToken = issueContext(req, res);
       const cspNonce = crypto.randomBytes(18).toString('base64url');
@@ -2072,7 +2347,7 @@ function createFormsRouter(options) {
         || await allowed(req, 'forms.read_submissions', record);
       if (!canRead) return formNotFound(req, res, 'form.receipt.read');
       const latest = await destinationStore.resolveLatest(record.submissionId);
-      const canEdit = Boolean(template && latest && latest.submissionId === record.submissionId
+      const canEdit = Boolean(template && template.archived !== true && latest && latest.submissionId === record.submissionId
         && await allowed(req, 'forms.submit', template));
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
@@ -2096,9 +2371,11 @@ function createFormsRouter(options) {
 
 module.exports = {
   createFormsRouter,
+  renderArchivedFormPage,
   renderConfigurePage,
+  renderCreateTemplatePage,
   renderEntriesPage,
-  renderFirstRunPage,
   renderFormPage,
+  renderFormsIndexPage,
   renderReceiptPage,
 };

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -21,7 +21,7 @@ const CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/u;
 const TEMPLATE_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision',
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields',
+  'presentation', 'fields', 'archived',
 ]);
 const TEMPLATE_VERSION_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'templateVersion',
@@ -410,6 +410,7 @@ function validateTemplate(doc) {
   if (own(doc, 'ownerId')) validateId(doc.ownerId, 'ownerId', errors);
   if (own(doc, 'revision')) validateInteger(doc.revision, 'revision', errors, 1, Number.MAX_SAFE_INTEGER);
   if (own(doc, 'grammarVersion') && doc.grammarVersion !== 1) addError(errors, 'grammarVersion', 'must equal 1');
+  if (own(doc, 'archived') && doc.archived !== true) addError(errors, 'archived', 'must equal true when present');
   if (own(doc, 'destinationId')) validateId(doc.destinationId, 'destinationId', errors);
   if (own(doc, 'title')) validateText(doc.title, 'title', errors, {minimum: 1, maximum: 200});
   if (own(doc, 'description')) validateText(doc.description, 'description', errors, {maximum: 2000});

--- a/lib/forms/submission-service.js
+++ b/lib/forms/submission-service.js
@@ -53,6 +53,15 @@ class SubmissionService {
     const registered = await this.registry.getTemplate(input.templateId);
     if (!registered) return { error: { code: 'not_found', message: 'Form not found.' } };
     const { schemaDigest, ...template } = registered;
+    if (template.archived === true) {
+      return {
+        error: {
+          code: 'archived',
+          message: 'This form is archived and is not accepting new entries.',
+          details: [],
+        },
+      };
+    }
     const destinationStore = storeForTemplate(this.store, template);
     let predecessor = null;
     if (input.supersedesRecord !== undefined) {

--- a/lib/forms/submission-store.js
+++ b/lib/forms/submission-store.js
@@ -704,6 +704,16 @@ class SubmissionStore {
       .slice(0, limit)
       .map(metadataFor);
   }
+
+  async countSubmissions({templateId} = {}) {
+    if (templateId !== undefined) assertDefinitionId(templateId, 'templateId');
+    const records = await this.allRecords();
+    const superseded = new Set(records
+      .filter((record) => record.supersedesRecord)
+      .map((record) => `${record.supersedesRecord.resourceKind}:${record.supersedesRecord.id}`));
+    return records.filter((record) => (templateId === undefined || record.templateId === templateId)
+      && !superseded.has(`form-submission:${record.submissionId}`)).length;
+  }
 }
 
 module.exports = {

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -273,7 +273,9 @@ class TemplateRegistry {
     const publishedVersions = entry.versions.map(versionMetadata);
     return {
       draft: clone(entry.template),
-      state: publishedVersions.length ? 'published' : 'draft',
+      state: entry.template.archived === true
+        ? 'archived'
+        : publishedVersions.length ? 'published' : 'draft',
       publishedVersion: publishedVersions.length ? clone(publishedVersions.at(-1)) : null,
       publishedVersions,
     };
@@ -303,6 +305,13 @@ class TemplateRegistry {
   async getManagementTemplate(templateId) {
     const entry = await this.entryFor(templateId);
     return entry ? this.managementEntry(entry) : null;
+  }
+
+  async getTemplateVersion(templateId, templateVersion) {
+    if (!Number.isSafeInteger(templateVersion) || templateVersion < 1) return null;
+    const entry = await this.entryFor(templateId);
+    const version = entry && entry.versions[templateVersion - 1];
+    return version && version.templateVersion === templateVersion ? clone(version) : null;
   }
 
   async listManagementTemplates() {
@@ -425,6 +434,33 @@ class TemplateRegistry {
           })));
         }
       }
+      revised.revision += 1;
+      this.validateDraft(revised);
+      await this.durableReplace(entry.draftPath, canonicalize(revised));
+      entry.template = revised;
+      entry.schemaDigest = schemaDigest(revised);
+      this.files.set(entry.key, entry);
+      return this.managementEntry(entry);
+    });
+  }
+
+  async setArchived(templateId, expectedRevision, archived) {
+    if (typeof archived !== 'boolean') {
+      throw validationError([{path: 'archived', message: 'must be a boolean'}]);
+    }
+    return this.withMutationLock(templateId, async () => {
+      const entry = await this.entryFor(templateId);
+      if (!entry) throw codedError('ENOTFOUND', 'Template not found.');
+      if (entry.template.revision !== expectedRevision) {
+        throw codedError('ESTALE', 'Template revision is stale.');
+      }
+      const currentlyArchived = entry.template.archived === true;
+      if (currentlyArchived === archived) {
+        throw codedError('ECONFLICT', archived ? 'Template is already archived.' : 'Template is already active.');
+      }
+      const revised = clone(entry.template);
+      if (archived) revised.archived = true;
+      else delete revised.archived;
       revised.revision += 1;
       this.validateDraft(revised);
       await this.durableReplace(entry.draftPath, canonicalize(revised));

--- a/public/style.css
+++ b/public/style.css
@@ -1499,6 +1499,218 @@ tbody tr:last-child td {
   font-weight: 700;
 }
 
+.forms-index-layout {
+  max-width: 48rem;
+}
+
+.forms-index-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.forms-index-header .subtitle {
+  margin-bottom: 0;
+}
+
+.forms-index-header > .button-link {
+  flex: 0 0 auto;
+  min-height: 46px;
+}
+
+.forms-index-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.forms-index-item,
+.forms-index-empty,
+.forms-index-simple {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-elev);
+}
+
+.forms-index-item,
+.forms-index-empty {
+  padding: 1rem;
+}
+
+.forms-index-title {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.forms-index-title h2,
+.forms-index-empty h2,
+.archived-form-state h2 {
+  margin: 0;
+  font-family: var(--heading-font, inherit);
+  font-size: 1.08rem;
+}
+
+.forms-index-title h2 {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.forms-index-state {
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-soft);
+  font-size: 0.7rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  padding: 0.28rem 0.48rem;
+  text-transform: uppercase;
+}
+
+.forms-index-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin: 0.9rem 0;
+}
+
+.forms-index-meta div {
+  min-width: 0;
+}
+
+.forms-index-meta dt {
+  color: var(--text-soft);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.forms-index-meta dd {
+  margin: 0.16rem 0 0;
+  overflow-wrap: anywhere;
+  font-size: 0.9rem;
+}
+
+.forms-index-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.forms-index-actions form {
+  display: contents;
+}
+
+.forms-index-actions a,
+.forms-index-actions button {
+  display: flex;
+  min-width: 0;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-code);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.79rem;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0.4rem 0.25rem;
+  text-decoration: none;
+}
+
+.forms-index-actions a:first-child {
+  border-color: var(--accent);
+  color: var(--link);
+}
+
+.forms-index-actions a:hover,
+.forms-index-actions button:hover,
+.forms-index-simple:hover {
+  background: var(--toolbar-btn-hover);
+  text-decoration: none;
+}
+
+.forms-index-simple {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--text);
+  font-weight: 700;
+  padding: 0.8rem 1rem;
+}
+
+.forms-index-simple span {
+  color: var(--link);
+  font-size: 1.4rem;
+}
+
+.forms-index-empty {
+  text-align: center;
+}
+
+.forms-index-empty p,
+.archived-form-state p {
+  color: var(--text-soft);
+  line-height: 1.5;
+}
+
+.forms-index-archived {
+  margin-top: 1rem;
+  border-top: 1px solid var(--border);
+  padding-top: 0.75rem;
+}
+
+.forms-index-archived > summary {
+  display: flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text-soft);
+  cursor: pointer;
+  font-weight: 700;
+  list-style: none;
+  padding: 0 0.25rem;
+}
+
+.forms-index-archived > summary::-webkit-details-marker {
+  display: none;
+}
+
+.forms-index-archived > summary span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  min-width: 1.7rem;
+  padding: 0.18rem 0.42rem;
+  text-align: center;
+}
+
+.forms-index-archived[open] > summary {
+  margin-bottom: 0.75rem;
+}
+
+.forms-index-item.is-archived {
+  border-style: dashed;
+}
+
+.archived-form-state {
+  text-align: center;
+}
+
+.forms-index-actions a:focus-visible,
+.forms-index-actions button:focus-visible,
+.forms-index-simple:focus-visible,
+.forms-index-archived > summary:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
 @media (min-width: 640px) {
   .builder-layout .builder-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1506,6 +1718,17 @@ tbody tr:last-child td {
 
   .builder-layout .builder-wide {
     grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 430px) {
+  .forms-index-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .forms-index-header > .button-link {
+    align-self: flex-start;
   }
 }
 

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -355,33 +355,105 @@ test('collapsed field rows reorder with CAS and soft-delete identities can only 
   }
 });
 
-test('first-run hub offers API-backed creation only to managers and rejects path destinations', async () => {
+test('forms index offers its single API-backed creation path only to managers and rejects path destinations', async () => {
   const server = await makeServer({empty: true});
   try {
     assert.equal((await server.request('/forms/daily-log', {headers: {'X-No-Manage': 'yes'}})).status, 404);
-    let firstRun = await browserPage(await server.request('/forms/daily-log'));
+    const deniedIndex = await browserPage(await server.request('/forms', {headers: {'X-No-Manage': 'yes'}}));
+    assert.equal(deniedIndex.document.querySelector('a[href="/forms/new"]'), null);
+    assert.equal((await server.request('/forms/new', {headers: {'X-No-Manage': 'yes'}})).status, 404);
+    const emptyIndex = await browserPage(await server.request('/forms'));
+    assert.match(emptyIndex.document.body.textContent, /Create your first template/);
+    assert.ok(emptyIndex.document.querySelector('a[href="/forms/new"]'));
+    let firstRun = await browserPage(await server.request('/forms/new'));
     const cookie = firstRun.cookie;
-    assert.match(firstRun.document.querySelector('h1').textContent, /Create your first form/);
+    assert.match(firstRun.document.querySelector('h1').textContent, /New template/);
     assert.deepEqual(
       [...firstRun.document.querySelector('select[name="destinationId"]').options].map((option) => option.value),
       ['default', 'gym-log'],
     );
     const form = firstRun.document.querySelector('form');
+    form.querySelector('[name="templateId"]').value = 'daily-log';
     form.querySelector('[name="title"]').value = 'Daily log';
     let values = formValues(form);
     values.set('destinationId', '../../tmp');
-    let response = await browserPost(server, '/forms/daily-log/configure/create', values, cookie);
+    let response = await browserPost(server, '/forms', values, cookie);
     assert.equal(response.status, 422);
     assert.equal(await server.registry.getTemplate('daily-log'), null);
 
     firstRun = await browserPage(response);
     values = formValues(firstRun.document.querySelector('form'));
+    values.set('templateId', 'daily-log');
     values.set('title', 'Daily log');
     values.set('destinationId', 'default');
-    response = await browserPost(server, '/forms/daily-log/configure/create', values, cookie);
+    response = await browserPost(server, '/forms', values, cookie);
     assert.equal(response.status, 303);
     assert.equal(response.headers.get('location'), '/forms/daily-log/configure');
     assert.equal((await server.registry.getTemplate('daily-log')).destinationId, 'default');
+  } finally {
+    await server.close();
+  }
+});
+
+test('forms index separates archived templates and removes management detail for submit-only callers', async () => {
+  const server = await makeServer();
+  try {
+    const base = {
+      contractVersion: 1,
+      resourceKind: 'form-template',
+      ownerId: 'operator',
+      revision: 1,
+      grammarVersion: 1,
+      destinationId: 'default',
+      fields: [{id: 'entry', type: 'short-text', label: 'Entry', required: true}],
+    };
+    await server.registry.createDraft({...base, templateId: 'daily-log', title: 'Daily log'});
+    await server.registry.createDraft({...base, templateId: 'old-log', title: 'Old log'});
+    await server.registry.setArchived('old-log', 1, true);
+
+    const formPage = await browserPage(await server.request('/forms/training-log'));
+    const submitted = await browserPost(server, '/forms/training-log', new URLSearchParams({
+      _csrf: formPage.document.querySelector('input[name="_csrf"]').value,
+      lift: 'bench',
+      notes: 'Counted entry',
+    }), formPage.cookie);
+    assert.equal(submitted.status, 303);
+
+    const managerIndex = await browserPage(await server.request('/forms'));
+    assert.equal(managerIndex.document.querySelectorAll('.forms-index-list[aria-label="Active templates"] > .forms-index-item').length, 2);
+    assert.ok(managerIndex.document.querySelector('a[href="/forms/new"]'));
+    const trainingCard = [...managerIndex.document.querySelectorAll('.forms-index-item')]
+      .find((card) => /Training <log>/.test(card.textContent));
+    assert.ok(trainingCard);
+    assert.match(trainingCard.textContent, /Draft\s*r1/);
+    assert.match(trainingCard.textContent, /Destination\s*gym-log/);
+    assert.match(trainingCard.textContent, /Entries\s*1/);
+    assert.deepEqual(
+      [...trainingCard.querySelectorAll('.forms-index-actions a, .forms-index-actions button')].map((node) => node.textContent.trim()),
+      ['Open', 'History', 'Configure', 'Clone', 'Archive'],
+    );
+    const archived = managerIndex.document.querySelector('.forms-index-archived');
+    assert.ok(archived);
+    assert.equal(archived.open, false);
+    assert.match(archived.querySelector('summary').textContent, /Show archived\s*1/);
+    assert.match(archived.textContent, /Old log/);
+
+    const submitOnly = await browserPage(await server.request('/forms', {headers: {'X-No-Manage': 'yes'}}));
+    assert.equal(submitOnly.document.querySelector('a[href="/forms/new"]'), null);
+    assert.equal(submitOnly.document.querySelector('.forms-index-actions'), null);
+    assert.equal(submitOnly.document.querySelector('.forms-index-meta'), null);
+    assert.equal(submitOnly.document.querySelector('.forms-index-archived'), null);
+    assert.deepEqual(
+      [...submitOnly.document.querySelectorAll('.forms-index-simple')].map((link) => link.textContent.trim().replace(/›$/, '')),
+      ['Daily log', 'Training <log>'],
+    );
+    assert.doesNotMatch(submitOnly.document.body.textContent, /Old log|Entries|Destination|Configure|Archive/);
+
+    const cloneForm = trainingCard.querySelector('form[action$="/clone"]');
+    const clonedResponse = await browserPost(server, cloneForm.getAttribute('action'), formValues(cloneForm), managerIndex.cookie);
+    assert.equal(clonedResponse.status, 303);
+    assert.match(clonedResponse.headers.get('location'), /^\/forms\/training-log-copy\/configure$/);
+    assert.equal((await server.registry.getTemplate('training-log-copy')).revision, 1);
   } finally {
     await server.close();
   }

--- a/test/forms-template-api.test.js
+++ b/test/forms-template-api.test.js
@@ -111,8 +111,9 @@ async function makeServer() {
     formsRegistry: registry,
     formsPublicOrigin: PUBLIC_ORIGIN,
     formsAudit: () => {},
-    formsAuthorize: ({req, capability}) => req.get('x-manage') === 'yes'
-      && (capability === 'forms.manage' || capability === 'forms.submit'),
+    formsAuthorize: ({req, capability}) => (req.get('x-manage') === 'yes'
+      && (capability === 'forms.manage' || capability === 'forms.submit'))
+      || (req.get('x-submit') === 'yes' && capability === 'forms.submit'),
   });
   return {
     root,
@@ -257,7 +258,9 @@ test('template API lifecycle uses CAS and preserves immutable versions and old r
       title: 'Strength training log',
       revision: 3,
       publishedVersion: 2,
+      destinationId: 'gym-log',
       state: 'published',
+      entryCount: 1,
     }]);
     const fetchedResponse = await server.request('/api/forms/templates/training-log', {headers: AGENT_HEADERS});
     assert.equal(fetchedResponse.status, 200);
@@ -381,6 +384,123 @@ test('managed drafts and version metadata retain their last-known-good registry 
     assert.equal(retained.publishedVersion.templateVersion, 1);
     assert.equal(retained.state, 'published');
     await fs.writeFile(versionPath, versionBytes);
+  } finally {
+    await server.close();
+  }
+});
+
+test('clone and archive APIs preserve source history, receipts, CAS, and authorization boundaries', async () => {
+  const server = await makeServer();
+  try {
+    assert.equal((await server.request('/api/forms/templates', jsonMutation(draftBody()))).status, 201);
+    assert.equal((await server.request(
+      '/api/forms/templates/training-log/publish',
+      jsonMutation({revision: 1}),
+    )).status, 201);
+    const submitted = await server.request('/api/forms/training-log/submissions', jsonMutation({
+      values: {lift: 'bench', notes: 'Keep this receipt'},
+    }));
+    assert.equal(submitted.status, 201);
+    const receiptUrl = (await submitted.json()).receiptUrl;
+    const sourceDraftBefore = await fs.readFile(path.join(server.templatesPath, 'training-log', 'draft.json'));
+    const sourceVersionBefore = await fs.readFile(path.join(server.templatesPath, 'training-log', 'versions', '1.json'));
+
+    const cloneResponse = await server.request(
+      '/api/forms/templates/training-log/clone',
+      jsonMutation({templateVersion: 1}),
+    );
+    assert.equal(cloneResponse.status, 201);
+    const cloned = await cloneResponse.json();
+    assert.notEqual(cloned.template.templateId, 'training-log');
+    assert.equal(cloned.template.revision, 1);
+    assert.equal(cloned.template.title, 'Training log copy');
+    assert.equal(cloned.template.destinationId, 'gym-log');
+    assert.deepEqual(cloned.template.fields, draftBody().fields);
+    assert.deepEqual(cloned.template.lineage, {
+      relation: 'clone',
+      templateId: 'training-log',
+      templateVersion: 1,
+    });
+    assert.equal(cloned.publishedVersion, null);
+    assert.deepEqual(cloned.publishedVersions, []);
+    const cloneSubmissions = await server.request(
+      `/api/forms/${cloned.template.templateId}/submissions`,
+      {headers: AGENT_HEADERS},
+    );
+    assert.deepEqual((await cloneSubmissions.json()).submissions, []);
+    assert.equal(Buffer.compare(sourceDraftBefore, await fs.readFile(path.join(server.templatesPath, 'training-log', 'draft.json'))), 0);
+    assert.equal(Buffer.compare(sourceVersionBefore, await fs.readFile(path.join(server.templatesPath, 'training-log', 'versions', '1.json'))), 0);
+
+    const archivedResponse = await server.request(
+      '/api/forms/templates/training-log/archive',
+      jsonMutation({revision: 1}),
+    );
+    assert.equal(archivedResponse.status, 200);
+    const archived = await archivedResponse.json();
+    assert.equal(archived.state, 'archived');
+    assert.equal(archived.template.archived, true);
+    assert.equal(archived.template.revision, 2);
+
+    const archivedPage = await server.request('/forms/training-log', {headers: AGENT_HEADERS});
+    assert.equal(archivedPage.status, 200);
+    assert.match(await archivedPage.text(), /This form is archived/);
+    const refused = await server.request('/api/forms/training-log/submissions', jsonMutation({
+      values: {lift: 'squat', notes: 'Must not be written'},
+    }));
+    assert.equal(refused.status, 422);
+    assert.equal((await refused.json()).error.code, 'archived');
+    assert.equal((await server.request(receiptUrl, {headers: AGENT_HEADERS})).status, 200);
+    const entries = await server.request('/forms/training-log/entries', {headers: AGENT_HEADERS});
+    assert.equal(entries.status, 200);
+    assert.match(await entries.text(), /Keep this receipt/);
+
+    const staleRestore = await server.request(
+      '/api/forms/templates/training-log/restore',
+      jsonMutation({revision: 1}),
+    );
+    assert.equal(staleRestore.status, 409);
+    assert.equal((await staleRestore.json()).error.code, 'revision_conflict');
+    const restoredResponse = await server.request(
+      '/api/forms/templates/training-log/restore',
+      jsonMutation({revision: 2}),
+    );
+    assert.equal(restoredResponse.status, 200);
+    const restored = await restoredResponse.json();
+    assert.equal(restored.state, 'published');
+    assert.equal(restored.template.archived, undefined);
+    assert.equal(restored.template.revision, 3);
+    assert.equal((await server.request('/api/forms/training-log/submissions', jsonMutation({
+      values: {lift: 'squat', notes: 'Accepted after restore'},
+    }))).status, 201);
+
+    const templatesBeforeDenied = await diskSnapshot(server.templatesPath);
+    const submitOnly = {Authorization: 'Bearer template-secret', 'X-Submit': 'yes'};
+    const deniedClone = await server.request(
+      '/api/forms/templates/training-log/clone',
+      jsonMutation({}, submitOnly),
+    );
+    assert.equal(deniedClone.status, 404);
+    const deniedArchive = await server.request(
+      '/api/forms/templates/training-log/archive',
+      jsonMutation({revision: 3}, submitOnly),
+    );
+    assert.equal(deniedArchive.status, 404);
+    const deniedCreate = await server.request(
+      '/api/forms/templates',
+      jsonMutation(draftBody('denied-clone'), submitOnly),
+    );
+    assert.equal(deniedCreate.status, 403);
+    assert.deepEqual(await diskSnapshot(server.templatesPath), templatesBeforeDenied);
+
+    const submitOnlyList = await server.request('/api/forms/templates', {headers: submitOnly});
+    assert.deepEqual((await submitOnlyList.json()).templates.map((template) => Object.keys(template).sort()), [
+      ['templateId', 'title'],
+      ['templateId', 'title'],
+    ]);
+    assert.equal((await server.request('/api/forms/templates/training-log', {
+      method: 'DELETE',
+      headers: AGENT_HEADERS,
+    })).status, 404);
   } finally {
     await server.close();
   }


### PR DESCRIPTION
`/forms` was a catch-all 404, and the create-a-template flow only appeared when zero templates existed — so with any templates present it was unreachable.

- **`GET /forms`** — templates index sharing the same list controller as the JSON API. Managers see title, state, draft revision, published version, destination alias, entry count, and per-row Open / History / Configure / Clone / Archive. Submit-only callers see just active forms they can submit to as links: no management actions, destinations, revisions, publish metadata, or counts.
- Archived templates sit behind a closed "Show archived" control for managers and are absent entirely for submit-only callers.
- **One creation path**: `GET /forms/new` + `POST /forms` in the browser, `POST /api/forms/templates` for agents. The orphaned first-run route was removed rather than left to drift.
- **Clone** (`POST /api/forms/templates/:id/clone`) copies fields, presentation, description/tags and the approved destination into a new template with a fresh ID, revision 1, and `lineage: {relation: 'clone', templateId}`. It carries over **no submissions, no published versions, no lifecycle state**, and tests compare source bytes before and after to prove the source is untouched.
- **Archive/Restore instead of delete.** Submissions reference their template and pinned schema version, so hard delete would orphan real history. Archiving hides the form and refuses new submissions with a clear archived state, while receipts, entries, and history still resolve. No hard-delete route exists.

171/171 tests; validate-raw-html, validate-editable-mode, skill-drift all exit 0. Index rendered and reviewed at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)