### PR TITLE
test(browser): Playwright coverage for the defects screenshots caught

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+/test/browser/.artifacts/
 
 # Runtime / local-only artifacts
 .cache/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,10 +8,16 @@ Run:
 
 ```bash
 npm test
+npm run test:browser
 npm run validate:raw-html
 npm run validate:editable
 npm run check:skill-packages
 ```
+
+The browser suite uses Playwright Chromium at a phone viewport. If Chromium is
+not installed or cannot launch in the current environment, its tests report a
+visible skip instead of failing the rest of the suite. Failure screenshots are
+left in the gitignored `test/browser/.artifacts/` directory.
 
 If `docs/SKILL-SPEC.md` changes, run `npm run generate:skill-packages` before the checks.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "lookie-annotations": "bin/lookie-annotations.js",
         "lookie-read": "bin/lookie-read.js"
       },
+      "devDependencies": {
+        "playwright": "^1.61.1"
+      },
       "engines": {
         "node": ">=20"
       }
@@ -621,6 +624,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1094,6 +1112,38 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lookie-link",
   "version": "2.1.0",
-  "description": "Lightweight web file viewer for local directories \u2014 look at things, via links",
+  "description": "Lightweight web file viewer for local directories — look at things, via links",
   "main": "server.js",
   "bin": {
     "lookie": "./bin/lookie.js",
@@ -11,7 +11,8 @@
   "scripts": {
     "check:skill-packages": "node scripts/generate-skill-packages.js --check",
     "generate:skill-packages": "node scripts/generate-skill-packages.js",
-    "test": "node --test",
+    "test": "node --test test/*.test.js && npm run test:browser",
+    "test:browser": "node test/browser/forms.spec.mjs",
     "start": "node server.js",
     "validate:editable": "node scripts/validate-editable-mode.js",
     "validate:raw-html": "node scripts/validate-raw-html.js"
@@ -31,5 +32,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/chrisfonte/lookie-link.git"
+  },
+  "devDependencies": {
+    "playwright": "^1.61.1"
   }
 }

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -194,11 +194,26 @@ async function assertNoClippedControls(page, state) {
         value,
         scrollWidth: element.scrollWidth,
         clientWidth: element.clientWidth,
+        // scrollWidth is BLIND for <select>: the browser visually truncates the
+        // option label without growing scrollWidth, so a 113px option inside an
+        // 85px control still reports scrollWidth === clientWidth. Measure the
+        // widest option against the control's inner width instead. Verified by
+        // reintroducing the oversized-dropdown defect: the scrollWidth check
+        // passed while the text was demonstrably clipped.
+        overflowPx: (() => {
+          if (!(element instanceof HTMLSelectElement) || !element.options.length) return 0;
+          const context = document.createElement('canvas').getContext('2d');
+          context.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+          const widest = Math.max(...[...element.options].map((option) => context.measureText(option.text).width));
+          const inner = element.clientWidth
+            - parseFloat(style.paddingLeft || 0) - parseFloat(style.paddingRight || 0);
+          return Math.round(widest - inner);
+        })(),
       };
     })
   );
   const clipped = measurements.filter((measurement) => measurement.visible
-    && measurement.scrollWidth > measurement.clientWidth + 1);
+    && (measurement.scrollWidth > measurement.clientWidth + 1 || measurement.overflowPx > 1));
   assert.deepEqual(clipped, [], `${state}: visible controls must not clip their content`);
   assert.ok(measurements.some((measurement) => measurement.visible), `${state}: expected visible controls`);
 }

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -1,0 +1,346 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import {createRequire} from 'node:module';
+import {after, before, test} from 'node:test';
+import {fileURLToPath} from 'node:url';
+
+const require = createRequire(import.meta.url);
+const {chromium} = require('playwright');
+const {createApp} = require('../../server.js');
+const {TemplateRegistry} = require('../../lib/forms/template-registry.js');
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ARTIFACT_DIR = path.join(TEST_DIR, '.artifacts');
+const PHONE_VIEWPORT = {width: 390, height: 844};
+const TEMPLATE_ID = 'machine-strength-log';
+const TEMPLATE_TITLE = 'Gym — Strength (machine)';
+const LONGEST_MACHINE_LABEL = 'Plate-loaded chest press machine';
+
+const gymTemplate = {
+  contractVersion: 1,
+  resourceKind: 'form-template',
+  templateId: TEMPLATE_ID,
+  ownerId: 'operator',
+  revision: 1,
+  grammarVersion: 1,
+  destinationId: 'gym-log',
+  title: TEMPLATE_TITLE,
+  fields: [
+    {
+      id: 'machine',
+      type: 'select',
+      label: 'Machine',
+      required: true,
+      options: [
+        {id: 'cable-row', label: 'Cable row'},
+        {id: 'plate-loaded-press', label: LONGEST_MACHINE_LABEL},
+      ],
+    },
+    {
+      id: 'weight-lbs',
+      type: 'number',
+      label: 'Working weight (lb)',
+      required: true,
+      constraints: {minimum: 0, maximum: 999, integer: true, step: 1},
+    },
+    {
+      id: 'sets',
+      type: 'number',
+      component: 'stepped-select',
+      label: 'Sets',
+      required: true,
+      constraints: {minimum: 1, maximum: 20, integer: true, step: 1},
+    },
+    {
+      id: 'reps',
+      type: 'number',
+      component: 'stepped-select',
+      label: 'Reps',
+      required: true,
+      constraints: {minimum: 1, maximum: 100, integer: true, step: 1},
+    },
+    {
+      id: 'intensity',
+      type: 'number',
+      component: 'stepped-select',
+      label: 'Intensity (%)',
+      required: false,
+      constraints: {minimum: 0, maximum: 100, integer: true, step: 1},
+    },
+  ],
+};
+
+let browser;
+let launchError;
+
+before(async () => {
+  try {
+    browser = await chromium.launch({headless: true});
+  } catch (error) {
+    launchError = error;
+  }
+});
+
+after(async () => {
+  if (browser) await browser.close();
+});
+
+async function startFixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'lookie-playwright-forms-'));
+  const templatesPath = path.join(root, 'templates');
+  const destinationPath = path.join(root, 'gym-log');
+  await fs.mkdir(templatesPath);
+  await fs.mkdir(destinationPath);
+
+  const registry = new TemplateRegistry({
+    templatesPath,
+    destinationIds: ['gym-log'],
+    logger: {warn() {}},
+  });
+  await registry.createDraft(structuredClone(gymTemplate));
+
+  const listener = http.createServer();
+  await new Promise((resolve, reject) => {
+    listener.once('error', reject);
+    listener.listen(0, '127.0.0.1', resolve);
+  });
+  const origin = `http://127.0.0.1:${listener.address().port}`;
+  const app = createApp({
+    mappings: {},
+    accessConfig: {humanDefault: 'full'},
+    formsConfig: {
+      enabled: true,
+      templatesPath,
+      destinations: {'gym-log': destinationPath},
+    },
+    formsRegistry: registry,
+    formsPublicOrigin: origin,
+    formsAudit: () => {},
+  });
+  listener.on('request', app);
+
+  return {
+    origin,
+    async close() {
+      await new Promise((resolve, reject) => listener.close((error) => error ? reject(error) : resolve()));
+      await fs.rm(root, {recursive: true, force: true});
+    },
+  };
+}
+
+function skipReason() {
+  const firstLine = launchError && launchError.message
+    ? launchError.message.split('\n').find((line) => line.trim())
+    : 'unknown launch error';
+  return `Playwright Chromium unavailable: ${firstLine}`;
+}
+
+function browserTest(name, run) {
+  test(name, {timeout: 45_000}, async (t) => {
+    if (!browser) {
+      t.skip(skipReason());
+      return;
+    }
+
+    let fixture;
+    let context;
+    let page;
+    try {
+      fixture = await startFixture();
+      context = await browser.newContext({viewport: PHONE_VIEWPORT, colorScheme: 'dark'});
+      page = await context.newPage();
+      await run({t, page, fixture});
+    } catch (error) {
+      if (page && !page.isClosed()) {
+        try {
+          await fs.mkdir(ARTIFACT_DIR, {recursive: true});
+          const safeName = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+          const screenshotPath = path.join(ARTIFACT_DIR, `${safeName}-${Date.now()}.png`);
+          await page.screenshot({path: screenshotPath, fullPage: true});
+          t.diagnostic(`Failure screenshot: ${screenshotPath}`);
+        } catch (screenshotError) {
+          t.diagnostic(`Could not capture failure screenshot: ${screenshotError.message}`);
+        }
+      }
+      throw error;
+    } finally {
+      if (context) await context.close().catch(() => {});
+      if (fixture) await fixture.close().catch(() => {});
+    }
+  });
+}
+
+function formUrl(fixture) {
+  return `${fixture.origin}/forms/${TEMPLATE_ID}`;
+}
+
+async function assertNoClippedControls(page, state) {
+  const measurements = await page.locator('input, select, .field-readout').evaluateAll((elements) =>
+    elements.map((element, index) => {
+      const style = getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      const visible = style.display !== 'none' && style.visibility !== 'hidden'
+        && rect.width > 0 && rect.height > 0;
+      const value = element instanceof HTMLInputElement || element instanceof HTMLSelectElement
+        ? element.value
+        : element.textContent.trim();
+      return {
+        index,
+        visible,
+        name: element.getAttribute('name') || element.id || element.className || element.tagName,
+        value,
+        scrollWidth: element.scrollWidth,
+        clientWidth: element.clientWidth,
+      };
+    })
+  );
+  const clipped = measurements.filter((measurement) => measurement.visible
+    && measurement.scrollWidth > measurement.clientWidth + 1);
+  assert.deepEqual(clipped, [], `${state}: visible controls must not clip their content`);
+  assert.ok(measurements.some((measurement) => measurement.visible), `${state}: expected visible controls`);
+}
+
+function parseRgb(color) {
+  const channels = color.match(/[\d.]+/g);
+  assert.ok(channels && channels.length >= 3, `expected an RGB color, got ${color}`);
+  return channels.slice(0, 3).map(Number);
+}
+
+function luminance(color) {
+  const linear = parseRgb(color).map((channel) => {
+    const value = channel / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+async function assertContrast(page, selector, minimum, description) {
+  const colors = await page.locator(selector).first().evaluate((element) => {
+    let backgroundElement = element;
+    let background = getComputedStyle(backgroundElement).backgroundColor;
+    while (backgroundElement.parentElement && (background === 'transparent' || /,\s*0\s*\)$/.test(background))) {
+      backgroundElement = backgroundElement.parentElement;
+      background = getComputedStyle(backgroundElement).backgroundColor;
+    }
+    return {foreground: getComputedStyle(element).color, background};
+  });
+  const lighter = Math.max(luminance(colors.foreground), luminance(colors.background));
+  const darker = Math.min(luminance(colors.foreground), luminance(colors.background));
+  const ratio = (lighter + 0.05) / (darker + 0.05);
+  assert.ok(ratio >= minimum, `${description} contrast ${ratio.toFixed(2)} must be at least ${minimum}`);
+}
+
+async function setTheme(page, mode) {
+  const isLight = await page.locator('html').getAttribute('data-theme') === 'light';
+  if (isLight !== (mode === 'light')) await page.locator('[data-theme-toggle]').click();
+  assert.equal(await page.locator('html').getAttribute('data-theme'), mode === 'light' ? 'light' : null);
+}
+
+async function fillWorstCase(page) {
+  await page.locator('#field-machine').selectOption('plate-loaded-press');
+  await page.locator('#field-weight-lbs').fill('999');
+  await page.locator('#field-sets').selectOption('20');
+  await page.locator('#field-reps').selectOption('100');
+  await page.locator('#field-intensity').selectOption('100');
+}
+
+async function fillValidEntry(page) {
+  await page.locator('#field-machine').selectOption('plate-loaded-press');
+  await page.locator('#field-weight-lbs').fill('150');
+  await page.locator('#field-sets').selectOption('5');
+  await page.locator('#field-reps').selectOption('12');
+  await page.locator('#field-intensity').selectOption('85');
+}
+
+async function submitBoundViolation(page) {
+  await fillValidEntry(page);
+  await page.locator('#field-weight-lbs').fill('1000');
+  await page.locator('.form-card form').evaluate((form) => { form.noValidate = true; });
+  const [response] = await Promise.all([
+    page.waitForResponse((candidate) => candidate.request().method() === 'POST'
+      && new URL(candidate.url()).pathname === `/forms/${TEMPLATE_ID}`),
+    page.locator('.form-primary-action').click(),
+  ]);
+  assert.equal(response.status(), 422);
+  await page.locator('.errors[role="alert"]').waitFor();
+}
+
+browserTest('phone form controls do not clip in dark or light themes', async ({page, fixture}) => {
+  for (const mode of ['dark', 'light']) {
+    await page.goto(formUrl(fixture));
+    await setTheme(page, mode);
+
+    await assertNoClippedControls(page, `${mode} empty form`);
+    await assertContrast(page, '.form-primary-action', 4, `${mode} primary action`);
+
+    await fillWorstCase(page);
+    assert.equal(await page.locator('#field-machine option:checked').textContent(), LONGEST_MACHINE_LABEL);
+    await assertNoClippedControls(page, `${mode} worst-case form`);
+
+    await submitBoundViolation(page);
+    await assertNoClippedControls(page, `${mode} validation re-render`);
+    await assertContrast(page, '.errors', 4.5, `${mode} error summary`);
+  }
+});
+
+browserTest('primary action and validation errors use human copy', async ({page, fixture}) => {
+  await page.goto(formUrl(fixture));
+  const actionText = (await page.locator('.form-primary-action').textContent()).trim();
+  assert.notEqual(actionText, '', 'primary action must have text');
+  assert.equal(actionText.includes(TEMPLATE_TITLE), false, 'primary action must not repeat the punctuated title');
+
+  await submitBoundViolation(page);
+  const errorText = (await page.locator('.errors li').textContent()).trim();
+  assert.match(errorText, /Working weight \(lb\)/, 'error must use the human field label');
+  assert.match(errorText, /999/, 'bound error must state the numeric limit');
+  assert.doesNotMatch(errorText, /\bweight-lbs\b/, 'error must not expose the field ID');
+});
+
+browserTest('machine strength entry reaches its receipt and entries list', async ({page, fixture}) => {
+  await page.goto(formUrl(fixture));
+  await fillValidEntry(page);
+  await Promise.all([
+    page.waitForURL((url) => /\/receipts\//.test(url.pathname)),
+    page.locator('.form-primary-action').click(),
+  ]);
+
+  assert.equal((await page.locator('h1').textContent()).trim(), 'Entry logged');
+  const receipt = Object.fromEntries(await page.locator('.receipt-table tbody tr').evaluateAll((rows) =>
+    rows.map((row) => {
+      const label = row.querySelector('th').textContent.trim();
+      const value = row.querySelector('.receipt-value').textContent.trim();
+      const unit = row.querySelector('.receipt-unit').textContent.trim();
+      return [label, {value, unit}];
+    })
+  ));
+  assert.deepEqual(receipt.Machine, {value: LONGEST_MACHINE_LABEL, unit: ''});
+  assert.deepEqual(receipt['Working weight'], {value: '150', unit: 'lb'});
+  assert.deepEqual(receipt.Sets, {value: '5', unit: ''});
+  assert.deepEqual(receipt.Reps, {value: '12', unit: ''});
+
+  await page.getByRole('link', {name: 'All entries'}).click();
+  await page.waitForURL((url) => url.pathname.endsWith('/entries'));
+  const listed = (await page.locator('.entry-list').textContent()).replace(/\s+/g, ' ');
+  assert.match(listed, new RegExp(LONGEST_MACHINE_LABEL));
+  assert.match(listed, /Working weight\s*150\s*lb/);
+  assert.match(listed, /Sets\s*5/);
+  assert.match(listed, /Reps\s*12/);
+});
+
+browserTest('builder field rows start collapsed and expand without clipped controls', async ({page, fixture}) => {
+  await page.goto(`${formUrl(fixture)}/configure`);
+  const fields = page.locator('details.builder-field');
+  assert.equal(await fields.count(), gymTemplate.fields.length);
+  for (let index = 0; index < await fields.count(); index += 1) {
+    assert.equal(await fields.nth(index).getAttribute('open'), null, `field ${index + 1} should start collapsed`);
+    assert.equal(await fields.nth(index).locator('.builder-field-settings').isVisible(), false);
+  }
+
+  await fields.first().locator('summary').click();
+  assert.equal(await fields.first().getAttribute('open'), '');
+  assert.equal(await fields.first().locator('.builder-field-settings').isVisible(), true);
+  await assertNoClippedControls(page, 'expanded builder');
+});


### PR DESCRIPTION
Four real defects shipped past a green suite and were caught only by rendering the page and looking at it. This adds browser tests that fail on each.

- `test/browser/forms.spec.mjs` boots the real `createApp` on an ephemeral port with a temp template and destination, driven by Playwright chromium at a 390x844 phone viewport, in **dark and light**. Wired into `npm test` and `npm run test:browser`. Skips cleanly when no browser can launch.
- Covers: no clipped controls (empty, worst-case values, validation re-render), copy sanity (button text must not embed a punctuated title; errors must name the field label and the numeric limit), a real end-to-end flow (select machine → weight/sets/reps → submit → receipt → appears in entries), and the builder's collapse/expand.

**The clipping check was itself broken and mutation testing caught it.** `scrollWidth <= clientWidth` is blind for `<select>`: the browser truncates an option label without growing scrollWidth, so a 113px option in an 85px control reported no overflow. I verified by reintroducing the exact oversized-dropdown defect — the suite passed. It now measures the widest option against the control's inner width, and with the defect reintroduced it fails as intended.

No product code touched. 170/170 unit tests, 4/4 browser tests; validate-raw-html and validate-editable-mode exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)