### PR TITLE
fix(forms): scale numeric dropdown values down

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -801,7 +801,7 @@ tbody tr:last-child td {
   height: 4rem;
   padding: 0.5rem 2.2rem 0.5rem 0.6rem;
   font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
-  font-size: clamp(1.05rem, 4.5vw, 1.5rem);
+  font-size: clamp(0.95rem, 3.6vw, 1.2rem);
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   letter-spacing: -0.02em;


### PR DESCRIPTION
Follow-up to the dropdown sizing fix — the operator reports the values still read oversized. The readout treatment earns its size for a typed number, but in a dropdown the value shares the control with a chevron and a unit chip. Scaled to a proportionate size that stays tabular and bold. Verified by rendering with real values (150 lb / 3 / 12) at 390px.

170 unit + 4 browser tests green; both validators exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)