### PR TITLE
fix(ui): give the theme picker a visible dropdown affordance

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2150,21 +2150,36 @@ tbody tr:last-child td {
 
 .toolbar-select {
   border: 1px solid var(--border);
-  background: var(--toolbar-btn-bg);
+  /* background-color, not the `background` shorthand: the shorthand resets
+     background-image and would erase the chevron below. */
+  background-color: var(--toolbar-btn-bg);
   color: var(--text);
   border-radius: 999px;
-  padding: 0.2rem 0.5rem;
+  padding: 0.2rem 1.45rem 0.2rem 0.6rem;
   font-size: 0.82rem;
   font-weight: 600;
   line-height: 1.3;
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
+  -moz-appearance: none;
   outline: none;
+  /* appearance:none strips the native dropdown arrow. Without a replacement the
+     control renders as a plain pill and reads as a static label -- users cannot
+     tell the theme picker is a picker at all. */
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%23888888' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.55rem center;
+  background-size: 0.62rem auto;
 }
 
 .toolbar-select:hover {
-  background: var(--toolbar-btn-hover);
+  background-color: var(--toolbar-btn-hover);
+}
+
+.toolbar-select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .content.toc-view {


### PR DESCRIPTION
## Problem

The theme picker (`select.toolbar-select`) sets `appearance: none` with no replacement chevron, so it renders as a plain rounded pill containing the current theme name. It looks like a status label, not a control.

Reported as "I don't see where I can change the theme" from Firefox; reproduced identically in Chromium and Firefox, so this is a styling gap rather than an engine bug.

## Fix

- Inline SVG chevron via `background-image`, plus right padding to seat it
- `-moz-appearance: none` alongside the existing `-webkit-appearance: none`
- `:focus-visible` outline so the control is keyboard-discoverable

## Note for reviewers

`.toolbar-select:hover` previously used the `background` shorthand, which resets `background-image` and would have erased the chevron on hover. Changed to `background-color`.

## Testing

Rendered in real Firefox and Chromium; chevron visible in both, in dark and light, across the built-in and custom themes.

The suite was run before and after: 49 failures both on this branch and on clean `main` in this checkout — all pre-existing and environmental (the deployed checkout resolves the live `~/.config` config, and macOS `/private/var` symlink paths). No delta from this change. CI is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)