### PR TITLE
feat(forms): let a template choose its own theme

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -393,14 +393,29 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
     </section>
   </main>
   ${datetimeCaptureScript(options.cspNonce)}
-  ${themeScript(options.cspNonce)}`;
+  ${themeScript(options.cspNonce, themeDefaults(template))}`;
 
   return baseHtml({
     title: template.title,
     body,
     customThemeCss: options.customThemeCss,
     cspNonce: options.cspNonce,
+    defaultScheme: themeDefaults(template).scheme || null,
+    defaultMode: themeDefaults(template).mode || null,
   });
+}
+
+// A template may name a theme in presentation.theme / presentation.themeMode.
+// It is a SELECTION from operator-installed themes, not a definition -- the same
+// indirection destinationId uses. An unknown slug degrades to the viewer default
+// rather than failing the form, because a theme is cosmetic, not a write path.
+function themeDefaults(template) {
+  const presentation = template && template.presentation;
+  if (!presentation) return {};
+  const out = {};
+  if (typeof presentation.theme === 'string') out.scheme = presentation.theme;
+  if (presentation.themeMode === 'dark' || presentation.themeMode === 'light') out.mode = presentation.themeMode;
+  return out;
 }
 
 function displayValue(entry) {
@@ -448,9 +463,11 @@ function renderReceiptPage(template, record, options = {}) {
       <p class="receipt-meta">Logged ${escapeHtml(received)}<br><span>Receipt ID ${escapeHtml(record.submissionId)}</span></p>
     </section>
   </main>
-  ${themeScript(options.cspNonce)}`;
+  ${themeScript(options.cspNonce, themeDefaults(template))}`;
 
   return baseHtml({
+    defaultScheme: themeDefaults(template).scheme || null,
+    defaultMode: themeDefaults(template).mode || null,
     title: 'Submission receipt',
     body,
     customThemeCss: options.customThemeCss,
@@ -582,8 +599,10 @@ function renderEntriesPage(template, records, options = {}) {
     </header>
     <section class="content form-card entries-card">${content}</section>
   </main>
-  ${themeScript(options.cspNonce)}`;
+  ${themeScript(options.cspNonce, themeDefaults(template))}`;
   return baseHtml({
+    defaultScheme: themeDefaults(template).scheme || null,
+    defaultMode: themeDefaults(template).mode || null,
     title: `${template.title} entries`,
     body,
     customThemeCss: options.customThemeCss,
@@ -749,8 +768,10 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
       </section>
     </section>
   </main>
-  ${themeScript(options.cspNonce)}`;
+  ${themeScript(options.cspNonce, themeDefaults(template))}`;
   return baseHtml({
+    defaultScheme: themeDefaults(template).scheme || null,
+    defaultMode: themeDefaults(template).mode || null,
     title: `Configure ${template.title}`,
     body,
     customThemeCss: options.customThemeCss,
@@ -857,8 +878,8 @@ function renderArchivedFormPage(template, options = {}) {
     <header class="topbar"><p class="eyebrow">Archived form</p><h1>${escapeHtml(template.title)}</h1>${formHubNav(template.templateId, 'log', options.canManage)}</header>
     <section class="content form-card archived-form-state"><h2>This form is archived</h2><p>It is not accepting new entries. Existing history and receipts are still available.</p><a class="button-link" href="/forms/${encodeURIComponent(template.templateId)}/entries">View history</a></section>
   </main>
-  ${themeScript(options.cspNonce)}`;
-  return baseHtml({title: `${template.title} is archived`, body, customThemeCss: options.customThemeCss, cspNonce: options.cspNonce});
+  ${themeScript(options.cspNonce, themeDefaults(template))}`;
+  return baseHtml({title: `${template.title} is archived`, body, customThemeCss: options.customThemeCss, cspNonce: options.cspNonce, defaultScheme: themeDefaults(template).scheme || null, defaultMode: themeDefaults(template).mode || null});
 }
 
 function postedString(body, name, fallback = '') {

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -393,9 +393,17 @@ function validatePresentation(presentation, errors) {
     addError(errors, 'presentation', 'must be an object');
     return;
   }
-  rejectUnknownKeys(presentation, new Set(['submitLabel', 'component']), 'presentation', errors);
+  rejectUnknownKeys(presentation, new Set(['submitLabel', 'component', 'theme', 'themeMode']), 'presentation', errors);
   if (own(presentation, 'submitLabel')) validateText(presentation.submitLabel, 'presentation.submitLabel', errors, {minimum: 1, maximum: 80});
   if (own(presentation, 'component')) validateId(presentation.component, 'presentation.component', errors);
+  // A theme is named, never defined here: the template selects an operator-installed
+  // theme slug, and the deployment decides what that slug means. Same indirection as
+  // destinationId. Unknown slugs are cosmetic rather than dangerous, so the renderer
+  // falls back to the viewer default instead of refusing to serve the form.
+  if (own(presentation, 'theme')) validateId(presentation.theme, 'presentation.theme', errors);
+  if (own(presentation, 'themeMode') && presentation.themeMode !== 'dark' && presentation.themeMode !== 'light') {
+    addError(errors, 'presentation.themeMode', 'must equal dark or light');
+  }
 }
 
 function validateTemplate(doc) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1307,7 +1307,13 @@ function nonceAttribute(cspNonce) {
   return cspNonce ? ` nonce="${escapeHtml(cspNonce)}"` : '';
 }
 
-function themeScript(cspNonce = null) {
+function themeScript(cspNonce = null, defaults = {}) {
+  // A page may declare its own theme (form templates do). It wins over the stored
+  // preference on this page only, and never overwrites the viewer's global choice.
+  const pageScheme = typeof defaults.scheme === 'string' && /^[a-z0-9-]+$/.test(defaults.scheme)
+    ? defaults.scheme
+    : null;
+  const pageMode = defaults.mode === 'light' || defaults.mode === 'dark' ? defaults.mode : null;
   return `
   <script${nonceAttribute(cspNonce)}>
     (function () {
@@ -1331,8 +1337,10 @@ function themeScript(cspNonce = null) {
         }
       }
 
-      var savedScheme = localStorage.getItem('lookie-link-color-scheme') || 'slate';
-      var savedTheme = localStorage.getItem('lookie-link-theme') || 'dark';
+      var pageScheme = ${pageScheme ? JSON.stringify(pageScheme) : 'null'};
+      var pageMode = ${pageMode ? JSON.stringify(pageMode) : 'null'};
+      var savedScheme = pageScheme || localStorage.getItem('lookie-link-color-scheme') || 'slate';
+      var savedTheme = pageMode || localStorage.getItem('lookie-link-theme') || 'dark';
       applyColorScheme(savedScheme);
       applyTheme(savedTheme);
 
@@ -1370,7 +1378,9 @@ function themeScript(cspNonce = null) {
   </script>`;
 }
 
-function baseHtml({ title, body, customThemeCss, cspNonce = null }) {
+function baseHtml({ title, body, customThemeCss, cspNonce = null, defaultScheme = null, defaultMode = null }) {
+  const headScheme = typeof defaultScheme === 'string' && /^[a-z0-9-]+$/.test(defaultScheme) ? defaultScheme : null;
+  const headMode = defaultMode === 'light' || defaultMode === 'dark' ? defaultMode : null;
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -1385,8 +1395,10 @@ function baseHtml({ title, body, customThemeCss, cspNonce = null }) {
   <script${nonceAttribute(cspNonce)}>
     (function () {
       var root = document.documentElement;
-      root.setAttribute('data-color-scheme', localStorage.getItem('lookie-link-color-scheme') || 'slate');
-      if (localStorage.getItem('lookie-link-theme') === 'light') root.setAttribute('data-theme', 'light');
+      var pageScheme = ${headScheme ? JSON.stringify(headScheme) : 'null'};
+      var pageMode = ${headMode ? JSON.stringify(headMode) : 'null'};
+      root.setAttribute('data-color-scheme', pageScheme || localStorage.getItem('lookie-link-color-scheme') || 'slate');
+      if ((pageMode || localStorage.getItem('lookie-link-theme')) === 'light') root.setAttribute('data-theme', 'light');
     }());
   </script>
 </head>

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -1774,3 +1774,40 @@ test('registry keeps last-known-good data and rejects non-definition IDs without
     await cleanup(fixture, null);
   }
 });
+
+test('a template theme reaches the page and does not leak into other forms', () => {
+  const themed = {
+    ...everyTypeTemplate,
+    templateId: 'themed-form',
+    presentation: { submitLabel: 'Submit', theme: 'the-bic', themeMode: 'light' },
+  };
+  const record = {
+    contractVersion: 1, resourceKind: 'form-submission', submissionId: 'sub-1',
+    templateId: 'themed-form', templateRevision: 1, receiptAt: '2026-07-21T12:00:00.000Z',
+    values: [],
+  };
+
+  const themedHtml = renderReceiptPage(themed, record, {});
+  assert.ok(themedHtml.includes('"the-bic"'), 'themed receipt carries the slug');
+  assert.ok(themedHtml.includes('"light"'), 'themed receipt carries the mode');
+
+  // An unthemed template must not inherit it -- the default stays the viewer preference.
+  const plainHtml = renderReceiptPage(everyTypeTemplate, {...record, templateId: 'every-field'}, {});
+  assert.ok(!plainHtml.includes('"the-bic"'), 'unthemed receipt has no page theme');
+});
+
+test('a template cannot smuggle a script through the theme slug', () => {
+  // Defence in depth: schema rejects this shape, and the renderer must too.
+  const hostile = {
+    ...everyTypeTemplate,
+    templateId: 'hostile-form',
+    presentation: { submitLabel: 'Submit', theme: '"};alert(1);//' },
+  };
+  const record = {
+    contractVersion: 1, resourceKind: 'form-submission', submissionId: 'sub-2',
+    templateId: 'hostile-form', templateRevision: 1, receiptAt: '2026-07-21T12:00:00.000Z',
+    values: [],
+  };
+  const html = renderReceiptPage(hostile, record, {});
+  assert.ok(!html.includes('alert(1)'), 'hostile slug is not emitted into the page');
+});

--- a/test/forms-schema.test.js
+++ b/test/forms-schema.test.js
@@ -216,3 +216,28 @@ test('selection fields require exactly one option source and non-selection field
   const extra = validateTemplate(templateWith([field('text', 'short-text', {options: [{id: 'one', label: 'One'}]})]));
   assert.ok(paths(extra).includes('fields[0].options'));
 });
+
+test('presentation accepts an operator-installed theme slug and a dark or light mode', () => {
+  const withTheme = templateWith([field('note', 'short-text')]);
+  withTheme.presentation = {theme: 'the-bic', themeMode: 'dark'};
+  assert.equal(validateTemplate(withTheme).valid, true);
+
+  const modeOnly = templateWith([field('note', 'short-text')]);
+  modeOnly.presentation = {themeMode: 'light'};
+  assert.equal(validateTemplate(modeOnly).valid, true);
+});
+
+test('presentation rejects a theme that is a path rather than a slug, and a bogus mode', () => {
+  // The template SELECTS a theme; it must never be able to name a location.
+  const pathy = templateWith([field('note', 'short-text')]);
+  pathy.presentation = {theme: '../../etc/passwd'};
+  assert.ok(paths(validateTemplate(pathy)).includes('presentation.theme'));
+
+  const urlish = templateWith([field('note', 'short-text')]);
+  urlish.presentation = {theme: 'https://example.com/theme.css'};
+  assert.ok(paths(validateTemplate(urlish)).includes('presentation.theme'));
+
+  const badMode = templateWith([field('note', 'short-text')]);
+  badMode.presentation = {themeMode: 'sepia'};
+  assert.ok(paths(validateTemplate(badMode)).includes('presentation.themeMode'));
+});


### PR DESCRIPTION
## What

Adds optional `presentation.theme` and `presentation.themeMode` to the form template contract, so each form can carry its own look instead of inheriting whatever the viewer last picked.

```yaml
presentation:
  submitLabel: Submit
  theme: planet-fitness      # an operator-installed theme slug
  themeMode: dark            # optional: dark | light
```

## Contract shape

The template **selects** a theme; it never defines one. Same indirection as `destinationId`: authored artifacts name things from a registry the deployment controls, so a template can never point at a location or ship its own CSS. Validation reuses `validateId`, which rejects paths, URLs, and anything that is not a plain slug.

**Unknown slugs degrade to the viewer default** rather than refusing to serve the form. This deliberately differs from `destinationId`, where an unknown alias fails closed. A storage alias is a write path; a theme is cosmetic, and renaming a theme should not take a working form offline. Called out here because it is an intentional asymmetry, not an oversight.

## Scope

Applies to the template's own pages: form, receipt, entries, configure, archived. The forms hub and new-template page are unthemed — they have no single template. Set in the `<head>` script as well as the theme script, so the page does not flash the wrong palette before settling.

The viewer's global preference is untouched; a themed form does not overwrite it for the rest of the viewer.

## Tests

- Schema accepts a slug plus `dark`/`light`; rejects path-shaped (`../../etc/passwd`), URL-shaped, and bogus-mode values
- Render tests assert the slug reaches the page, an unthemed template does **not** inherit it, and a hostile slug (`"};alert(1);//`) cannot break out into script
- **Mutation-checked**: deleting the theme validation makes the suite fail (14/15), confirming the assertions actually ring

`forms-schema` 15/15, `forms-runner` 35/36, `forms-hub-builder` 4/4, `forms-template-api` 5/5, `forms-canonical` 7/7, `forms-submission-store` 10/10. The single runner failure is the pre-existing `google-chrome ENOENT` browser canary — Chrome is not on PATH on this host — and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
