### PR TITLE
feat(forms): choose a template theme from the builder

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -3,7 +3,7 @@
 const crypto = require('node:crypto');
 const express = require('express');
 
-const { baseHtml, themeScript, toolbarHtml } = require('../renderer');
+const { baseHtml, themeScript, toolbarHtml, getThemeList } = require('../renderer');
 const { storeForTemplate } = require('./destination-adapter');
 const { isDefinitionId } = require('./template-registry');
 
@@ -725,6 +725,16 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   const destinationOptions = destinationIds.map((destinationId) =>
     `<option value="${escapeHtml(destinationId)}"${(template.destinationId || 'default') === destinationId ? ' selected' : ''}>${escapeHtml(destinationId)}</option>`
   ).join('');
+  const currentTheme = (template.presentation && template.presentation.theme) || '';
+  const currentThemeMode = (template.presentation && template.presentation.themeMode) || '';
+  // Offered themes come from the running server, so the author can only ever pick
+  // one the deployment has actually installed.
+  const themeOptions = [{slug: '', label: 'Use the viewer theme'}, ...getThemeList()].map((theme) =>
+    `<option value="${escapeHtml(theme.slug)}"${currentTheme === theme.slug ? ' selected' : ''}>${escapeHtml(theme.label)}</option>`
+  ).join('');
+  const themeModeOptions = [['', 'Follow the viewer'], ['dark', 'Always dark'], ['light', 'Always light']].map(
+    ([value, label]) => `<option value="${value}"${currentThemeMode === value ? ' selected' : ''}>${label}</option>`
+  ).join('');
   const publishedText = published
     ? `Version ${published.templateVersion}, from draft revision ${published.sourceRevision}`
     : 'Not published yet';
@@ -750,6 +760,9 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
           <label><span>Destination</span><select name="destinationId" required>${destinationOptions}</select></label>
           <p class="builder-help">Destinations are deployment-approved aliases. Filesystem paths cannot be entered here.</p>
+          <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
+          <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
+          <p class="builder-help">Themes are installed by the deployment and read from the server. Leave both alone and this form follows whatever theme the viewer has chosen.</p>
         </section>
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
@@ -1011,10 +1024,24 @@ function applyBuilderAction(fields, action) {
 function builderPatch(current, body) {
   const fields = postedFields(current, body);
   applyBuilderAction(fields, postedString(body, '_action', 'save'));
+  // reviseDraft REPLACES presentation wholesale, so rebuild it from the existing
+  // object rather than the posted fields alone -- otherwise saving from the builder
+  // would silently drop submitLabel and component.
+  const presentation = {};
+  const existing = (current && current.presentation) || {};
+  if (typeof existing.submitLabel === 'string') presentation.submitLabel = existing.submitLabel;
+  if (typeof existing.component === 'string') presentation.component = existing.component;
+  const theme = postedString(body, 'theme');
+  const themeMode = postedString(body, 'themeMode');
+  if (theme) presentation.theme = theme;
+  if (themeMode === 'dark' || themeMode === 'light') presentation.themeMode = themeMode;
+
   return {
     revision: Number(postedString(body, 'revision')),
     title: postedString(body, 'title'),
     destinationId: postedString(body, 'destinationId'),
+    // null removes the key entirely, which is how "no presentation at all" is expressed.
+    presentation: Object.keys(presentation).length ? presentation : null,
     fields,
   };
 }
@@ -1719,7 +1746,16 @@ function createFormsRouter(options) {
   function validBuilderBody(body, create = false) {
     const fixed = create
       ? new Set(['_csrf', 'templateId', 'title', 'destinationId'])
-      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId']);
+      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode']);
+    // An author SELECTS an installed theme; they can never introduce one. Anything
+    // outside the server's list is refused rather than quietly ignored.
+    if (!create && body && typeof body === 'object') {
+      const theme = body.theme;
+      if (typeof theme === 'string' && theme !== ''
+        && !getThemeList().some((entry) => entry.slug === theme)) return false;
+      const mode = body.themeMode;
+      if (typeof mode === 'string' && mode !== '' && mode !== 'dark' && mode !== 'light') return false;
+    }
     const fieldKey = /^field\.\d+\.(?:id|type|label|required|help|component|showInList|isDestroyed|minimum|maximum|step|integer|providerSlot|option\.\d+\.(?:id|label))$/;
     return body && typeof body === 'object' && !Array.isArray(body)
       && Object.entries(body).every(([key, value]) => typeof value === 'string'

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2576,6 +2576,7 @@ module.exports = {
   renderEditPage,
   renderPreviewHtml,
   setThemeList,
+  getThemeList,
   themeScript,
   toolbarHtml,
 };

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -458,3 +458,61 @@ test('forms index separates archived templates and removes management detail for
     await server.close();
   }
 });
+
+test('builder offers server-installed themes, saves the choice, and refuses one the server does not offer', async () => {
+  const {setThemeList} = require('../lib/renderer');
+  setThemeList([
+    {slug: 'slate', label: 'Slate'},
+    {slug: 'planet-fitness', label: 'Planet Fitness'},
+    {slug: 'the-bic', label: 'The BIC'},
+  ]);
+
+  const server = await makeServer();
+  try {
+    // A submitLabel set outside the builder must survive a builder save.
+    const before = await server.registry.getManagementTemplate('training-log');
+    await server.registry.reviseDraft('training-log', before.draft.revision, {
+      presentation: {submitLabel: 'Log it'},
+    });
+
+    let configure = await browserPage(await server.request('/forms/training-log/configure'));
+    const themeSelect = configure.document.querySelector('select[name="theme"]');
+    assert.ok(themeSelect, 'builder exposes a theme control');
+    assert.deepEqual(
+      [...themeSelect.options].map((option) => option.value),
+      ['', 'slate', 'planet-fitness', 'the-bic'],
+      'options come from the server theme list, plus an explicit no-override choice'
+    );
+    assert.deepEqual(
+      [...configure.document.querySelector('select[name="themeMode"]').options].map((option) => option.value),
+      ['', 'dark', 'light']
+    );
+
+    const cookie = configure.cookie;
+    const values = formValues(configure.document.querySelector('.builder-form'), 'save');
+    values.set('theme', 'planet-fitness');
+    values.set('themeMode', 'dark');
+    const saved = await browserPost(server, '/forms/training-log/configure', values, cookie);
+    assert.equal(saved.status, 200);
+    assert.match((await browserPage(saved)).document.querySelector('.builder-status').textContent, /Draft saved/);
+
+    const after = await server.registry.getManagementTemplate('training-log');
+    assert.equal(after.draft.presentation.theme, 'planet-fitness');
+    assert.equal(after.draft.presentation.themeMode, 'dark');
+    assert.equal(after.draft.presentation.submitLabel, 'Log it', 'submitLabel survived the save');
+
+    configure = await browserPage(await server.request('/forms/training-log/configure'));
+    assert.equal(configure.document.querySelector('select[name="theme"]').value, 'planet-fitness');
+
+    // A slug the server never offered is refused, not silently stored.
+    const hostile = formValues(configure.document.querySelector('.builder-form'), 'save');
+    hostile.set('theme', 'not-installed');
+    const refused = await browserPost(server, '/forms/training-log/configure', hostile, configure.cookie);
+    assert.equal(refused.status, 400);
+    const unchanged = await server.registry.getManagementTemplate('training-log');
+    assert.equal(unchanged.draft.presentation.theme, 'planet-fitness', 'rejected save changed nothing');
+  } finally {
+    setThemeList(null);
+    await server.close();
+  }
+});


### PR DESCRIPTION
Adds **Theme** and **Theme mode** controls to the form builder, populated from the running server so an author only ever sees themes this deployment has actually installed.

## Behaviour

- Options come from the server theme list (built-ins + custom), so no slug knowledge is needed
- Both controls lead with an explicit *use the viewer theme* / *follow the viewer* option, making "no override" a visible choice
- A posted theme outside the server list is refused with 400, not stored — the builder can select a theme, never introduce one

## One non-obvious fix

`reviseDraft` **replaces** `presentation` rather than merging it. `builderPatch` previously omitted the key entirely, which is why nothing broke before. Now that it sets it, it has to rebuild the object from the existing one — otherwise the first builder save would silently drop a `submitLabel` set outside the builder, which is exactly what the live gym templates use.

Also exports `getThemeList` from the renderer; it existed but was never exported.

## Tests

Builder exposes both controls populated from the server list · saving persists theme + mode and preserves an existing `submitLabel` · the saved choice returns selected · an uninstalled slug is refused and changes nothing.

**Mutation-checked twice**: removing the membership check, and removing the `submitLabel` carry-through, each make the suite fail.

forms-hub-builder 5/5, forms-schema 15/15, forms-canonical 7/7, forms-submission-store 10/10, forms-template-api 5/5. Pre-existing unrelated failures unchanged: forms-runner 35/36 (`google-chrome ENOENT`) and access-control 13/14 (verified identical with this change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)