### PR TITLE
feat(viewer): add a Go menu for top-level navigation

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1264,6 +1264,19 @@ function renderPreviewHtml({
   return rendered.html;
 }
 
+let _navLinks = [];
+
+// Top-level destinations for the toolbar's Go menu. Registered once at app
+// construction from config, the same way the theme list is, so the 18 toolbar
+// call sites do not each have to thread navigation state through.
+function setNavLinks(links) {
+  _navLinks = Array.isArray(links) ? links.filter((link) => link && link.href && link.label) : [];
+}
+
+function getNavLinks() {
+  return _navLinks;
+}
+
 let _themeList = null;
 
 function setThemeList(themes) {
@@ -1294,7 +1307,16 @@ function toolbarHtml(extraButtons = '', options = {}) {
   const annotationModeButton = options.annotationModeAvailable
     ? '<button type="button" class="toolbar-btn" data-annotation-mode-toggle aria-label="Show annotation targets" aria-pressed="false" title="Show annotation targets">💬 Annotate</button>'
     : '';
+  const navLinks = getNavLinks();
+  // <details> gives a dropdown with no JavaScript, which keeps this working under
+  // the strict CSP and inside pages that strip scripts.
+  const navMenu = navLinks.length > 1
+    ? `<details class="toolbar-nav"><summary class="toolbar-btn" title="Go to">Go</summary><div class="toolbar-nav-panel">${
+      navLinks.map((link) => `<a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a>`).join('')
+    }</div></details>`
+    : '';
   return `<div class="viewer-toolbar" role="toolbar" aria-label="Viewer controls">
+    ${navMenu}
     ${extraButtons}
     ${annotationModeButton}
     ${annotationChip}
@@ -2576,6 +2598,8 @@ module.exports = {
   renderEditPage,
   renderPreviewHtml,
   setThemeList,
+  setNavLinks,
+  getNavLinks,
   getThemeList,
   themeScript,
   toolbarHtml,

--- a/public/style.css
+++ b/public/style.css
@@ -2415,3 +2415,55 @@ tbody tr:last-child td {
     grid-template-columns: 1fr;
   }
 }
+
+
+.toolbar-nav {
+  position: relative;
+}
+
+.toolbar-nav > summary {
+  list-style: none;
+  cursor: pointer;
+  /* Matches .toolbar-select: appearance:none strips the marker, so supply one. */
+  padding-right: 1.45rem;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%23888888' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  background-size: 0.62rem auto;
+}
+
+.toolbar-nav > summary::-webkit-details-marker,
+.toolbar-nav > summary::marker {
+  display: none;
+  content: "";
+}
+
+.toolbar-nav-panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.4rem);
+  z-index: 40;
+  min-width: 9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.3rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+.toolbar-nav-panel a {
+  padding: 0.4rem 0.6rem;
+  border-radius: 7px;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.toolbar-nav-panel a:hover,
+.toolbar-nav-panel a:focus-visible {
+  background: var(--toolbar-btn-hover);
+}

--- a/server.js
+++ b/server.js
@@ -66,6 +66,7 @@ const {
   renderEditPage,
   renderPreviewHtml,
   setThemeList,
+  setNavLinks,
 } = require('./lib/renderer');
 const {
   readAnnotationDocument,
@@ -631,6 +632,11 @@ function createApp(options = {}) {
   const rawManagedReposConfig = options.managedReposConfig === undefined ? getManagedReposConfig() : options.managedReposConfig;
   const rawPublishConfig = options.publishConfig === undefined ? getPublishConfig() : options.publishConfig;
   const formsConfig = options.formsConfig === undefined ? getFormsConfig() : options.formsConfig;
+  // Forms only appears when the deployment actually serves them.
+  setNavLinks([
+    { href: '/', label: 'Files' },
+    ...(formsConfig && formsConfig.enabled === true ? [{ href: '/forms', label: 'Forms' }] : []),
+  ]);
   const accessConfig = parseAccessConfig(rawAccessConfig);
   const apiKeyStore = options.apiKeyStore === undefined
     ? ApiKeyStore.fromAccessConfig(rawAccessConfig.apiKeys)

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -516,3 +516,35 @@ test('builder offers server-installed themes, saves the choice, and refuses one 
     await server.close();
   }
 });
+
+test('toolbar Go menu offers Files and Forms, and disappears when there is nowhere to choose between', async () => {
+  const {setNavLinks, toolbarHtml} = require('../lib/renderer');
+
+  const server = await makeServer();
+  try {
+    // Reachable from a form page and from a document page alike.
+    const page = await browserPage(await server.request('/forms/training-log'));
+    const links = [...page.document.querySelectorAll('.toolbar-nav-panel a')];
+    assert.deepEqual(links.map((link) => link.textContent), ['Files', 'Forms']);
+    assert.deepEqual(links.map((link) => link.getAttribute('href')), ['/', '/forms']);
+    // No inline handler: the dropdown is a native <details>, so it survives CSP.
+    assert.match(page.html, /<details class="toolbar-nav">/);
+    assert.doesNotMatch(page.html, /onclick=/i);
+  } finally {
+    await server.close();
+  }
+
+  // A deployment with forms disabled registers only Files. One destination is not
+  // a choice, so the menu is omitted rather than rendered with a single entry.
+  setNavLinks([{href: '/', label: 'Files'}]);
+  assert.ok(!toolbarHtml().includes('toolbar-nav'), 'single destination renders no menu');
+
+  setNavLinks([{href: '/', label: 'Files'}, {href: '/forms', label: 'Forms'}]);
+  assert.ok(toolbarHtml().includes('toolbar-nav'), 'two destinations render the menu');
+
+  // Malformed entries are dropped rather than emitted as broken links.
+  setNavLinks([{href: '/', label: 'Files'}, {label: 'No href'}, {href: '/forms', label: 'Forms'}]);
+  const html = toolbarHtml();
+  assert.doesNotMatch(html, /No href/);
+  setNavLinks([]);
+});


### PR DESCRIPTION
Adds a **Go** dropdown to the viewer toolbar so you can move between Files and Forms without editing the URL. Forms only appears when the deployment serves them.

Native `<details>` — no JavaScript, so it works under the strict CSP and on script-stripped pages.

Destinations are registered once in `createApp` via `setNavLinks`, following the existing `setThemeList` pattern. `toolbarHtml` has 18 call sites; threading nav state through all of them for one dropdown would have been the wrong trade.

Two deliberate behaviours: the menu is **omitted** when there is only one destination (a menu of one is not a choice), and malformed entries are dropped rather than rendered as broken links.

Tests cover both, plus absence of inline handlers. **Mutation-checked twice** — rendering for a single destination, and skipping the malformed-entry filter, each make the suite fail.

forms-hub-builder 6/6. Pre-existing unrelated failures unchanged (forms-runner `google-chrome ENOENT`, access-control html-sanitize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)