### PR TITLE
fix(viewer): show a pressed state on the Annotate toggle

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2266,7 +2266,8 @@ tbody tr:last-child td {
 .lookie-annotate-btn:hover, .lookie-annotate-btn:focus {
   opacity: 1; color: var(--accent); border-color: var(--accent);
 }
-.toolbar-btn-annotation-count[aria-pressed="true"] {
+.toolbar-btn-annotation-count[aria-pressed="true"],
+[data-annotation-mode-toggle][aria-pressed="true"] {
   border-color: var(--accent);
   color: var(--accent);
 }


### PR DESCRIPTION
Clicking **Annotate** turned annotation targeting on, but the button looked identical either way — nothing in the toolbar told you which mode you were in.

The state was already tracked correctly: the toolbar script flips `aria-pressed` and toggles `lookie-annotations-active` on the root. So it was exposed to assistive technology and simply never drawn. The sibling annotation-count chip already had exactly the missing rule, so this extends that selector rather than inventing a second treatment.

## Verified in a real browser, across two themes

| theme | off | on | changed |
|---|---|---|---|
| The BIC | `rgb(236,246,242)` | `rgb(88,255,102)` — brand green | ✓ |
| Planet Fitness | `rgb(244,239,247)` | `rgb(249,247,46)` — brand yellow | ✓ |

Asserted on **computed style**, not a class name, and the active colour resolves from `--accent` rather than a fixed value.

## No regression test, deliberately

The Playwright fixture serves forms only (`mappings: {}`, annotations disabled), so covering this needs the fixture extended to serve a document with annotations enabled. That is worth doing next time someone touches that fixture; it was more surgery than a two-line CSS fix warranted. Noted on the issue so it is not forgotten.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
