### PR TITLE
feat(viewer): give rendered documents the kit component vocabulary

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2418,3 +2418,150 @@ tbody tr:last-child td {
 }
 
 
+
+/* ============================================================================
+   Document components
+   ----------------------------------------------------------------------------
+   The Ops HTML Kit's component vocabulary, made available to rendered documents
+   so a markdown file can use a card or a stat tile without carrying its own
+   <style> block.
+
+   Two rules make this safe:
+
+   1. Scoped to .content, where rendered documents live, so a class in a document
+      can never restyle viewer chrome.
+   2. Every colour resolves from a theme token. Documents borrow the kit's
+      COMPONENT VOCABULARY, not its palette -- the reader still owns the colours
+      and the theme picker keeps working. A hardcoded colour here would be an
+      author-side decision leaking into reader-controlled chrome, which is the
+      merge the theme architecture deliberately avoids.
+   ========================================================================== */
+
+.content .eyebrow {
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-soft);
+  margin: 0 0 0.4rem;
+}
+
+.content .lead {
+  color: var(--text-soft);
+  margin: 0.2rem 0 0;
+}
+
+.content .grid-2,
+.content .grid-3 {
+  display: grid;
+  gap: 14px;
+  margin: 0 0 14px;
+}
+
+.content .grid-2 {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.content .grid-3 {
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+}
+
+.content .card,
+.content .tile {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+
+.content .tile .stat {
+  font-size: 1.9rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--accent);
+}
+
+.content .tile .stat small {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-soft);
+}
+
+.content .callout {
+  border-left: 3px solid var(--accent);
+  background: var(--bg-elev);
+  border-radius: 0 10px 10px 0;
+  padding: 12px 14px;
+  margin: 0 0 14px;
+}
+
+.content .badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 14px;
+}
+
+.content .badge,
+.content .pill,
+.content .chip {
+  display: inline-block;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.18rem 0.6rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.content .pill {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.content .chip {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+
+.content .scorebar {
+  height: 9px;
+  border-radius: 999px;
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  overflow: hidden;
+  margin: 0.4rem 0 0.9rem;
+}
+
+.content .scorebar > i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+
+.content .timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-left: 2px solid var(--border);
+}
+
+.content .timeline li {
+  position: relative;
+  padding: 0 0 1rem 1.1rem;
+}
+
+.content .timeline li::before {
+  content: "";
+  position: absolute;
+  left: -6px;
+  top: 0.35rem;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.content .timeline .when {
+  color: var(--text-soft);
+  font-size: 0.8rem;
+}

--- a/test/document-components.test.js
+++ b/test/document-components.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const STYLESHEET = path.join(__dirname, '..', 'public', 'style.css');
+const SECTION_MARKER = 'Document components';
+
+// Components a rendered document may use. Names match the Ops HTML Kit so the
+// vocabulary is shared rather than forked.
+const COMPONENTS = [
+  'eyebrow', 'lead', 'grid-2', 'grid-3', 'card', 'tile', 'stat',
+  'callout', 'badges', 'badge', 'pill', 'chip', 'scorebar', 'timeline',
+];
+
+function documentComponentSection() {
+  const css = fs.readFileSync(STYLESHEET, 'utf8');
+  const marker = css.indexOf(SECTION_MARKER);
+  assert.notEqual(marker, -1, `stylesheet must contain the "${SECTION_MARKER}" section`);
+  // Start at the opening of the comment block that introduces the section, not at
+  // the marker itself -- slicing mid-comment leaves an unterminated /* that the
+  // comment stripper cannot match, so prose leaks into the selector parsing.
+  const start = css.lastIndexOf('/*', marker);
+  return css.slice(start === -1 ? marker : start);
+}
+
+test('document components are defined and scoped to rendered content', () => {
+  const section = documentComponentSection();
+  for (const component of COMPONENTS) {
+    assert.match(
+      section,
+      new RegExp(`\\.content\\s[^{]*\\.${component.replace('-', '\\-')}\\b`),
+      `.${component} must be defined and scoped under .content`
+    );
+  }
+});
+
+test('document components never hardcode a colour', () => {
+  // The load-bearing rule. Documents borrow the kit's component vocabulary, not
+  // its palette: every colour must resolve from the active theme so the reader
+  // keeps control and the theme picker keeps working. A hardcoded colour here
+  // silently breaks theming for every document that uses the component, which is
+  // exactly the kind of regression a reviewer skims past.
+  const section = documentComponentSection();
+  const withoutComments = section.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  const offenders = [];
+  for (const [index, line] of withoutComments.split('\n').entries()) {
+    const declaration = line.split('/*')[0];
+    if (/#[0-9a-fA-F]{3,8}\b/.test(declaration)) offenders.push(`hex on line ${index + 1}: ${line.trim()}`);
+    if (/\b(?:rgba?|hsla?)\s*\(/.test(declaration)) offenders.push(`function colour on line ${index + 1}: ${line.trim()}`);
+    // Named colours are only a problem where a colour is expected; `transparent`
+    // and `currentColor` are theme-neutral and allowed.
+    const named = declaration.match(/:\s*(red|blue|green|black|white|grey|gray|orange|purple|yellow|pink|silver|navy|teal)\b/i);
+    if (named) offenders.push(`named colour on line ${index + 1}: ${line.trim()}`);
+  }
+
+  assert.deepEqual(offenders, [], 'document component colours must all come from var(--…) theme tokens');
+});
+
+test('document components cannot restyle viewer chrome', () => {
+  // Every selector in the section must begin at .content. A bare `.card { … }`
+  // would leak into the toolbar and breadcrumbs.
+  const section = documentComponentSection();
+  const withoutComments = section.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  const selectors = withoutComments
+    .split('}')
+    .map((block) => block.split('{')[0].trim())
+    .filter(Boolean)
+    .flatMap((selector) => selector.split(',').map((part) => part.trim()))
+    .filter(Boolean);
+
+  assert.ok(selectors.length > 0, 'expected component selectors');
+  const unscoped = selectors.filter((selector) => !selector.startsWith('.content'));
+  assert.deepEqual(unscoped, [], 'every document component selector must be scoped under .content');
+});


### PR DESCRIPTION
A markdown document that wanted a card, stat tile, callout or timeline had to carry its own `<style>` block — so authored HTML looked designed while the same content as markdown looked plain. These are now defined once in the viewer stylesheet.

Names match the Ops HTML Kit so the vocabulary is **shared, not forked**: `card`, `tile` + `stat`, `callout`, `badge`/`pill`/`chip`, `grid-2`, `grid-3`, `timeline`, `eyebrow`, `lead`, `scorebar`.

## Two rules, both enforced by tests rather than review

**Scoped to `.content`.** Rendered documents live there, so a class inside a document can never restyle the toolbar or breadcrumbs. Verified beforehand that none of these names collide with existing viewer CSS.

**Every colour resolves from a theme token.** This is load-bearing. Documents borrow the kit's *component vocabulary*, not its palette — the reader still owns the colours and the theme picker keeps working. That is what keeps this on the correct side of the standing decision that reader-controlled viewer chrome and author-controlled artifact design remain separate systems. **Documents are not rendered through the kit pipeline.**

A hardcoded colour would silently break theming for every document using that component — the kind of thing a reviewer skims past — so it fails the build.

## Mutation-verified

- Introducing a hex colour → fails
- Unscoping a selector from `.content` → fails
- Restored → 3/3 pass

179/179 unit tests, 4/4 browser, validators green.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)