### PR TITLE
feat(viewer): collapse the document header and move file facts to Properties

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1485,6 +1485,41 @@ function jsonForInlineScript(value) {
   return JSON.stringify(value).replace(/</g, '\\u003c');
 }
 
+// File FACTS, as distinct from the frontmatter panel's CLAIMS. The two may disagree
+// -- a document declaring "Last Updated: 2026-07-21" beside a file modified today is
+// telling you something -- so this deliberately does not deduplicate against it.
+function propertiesPanel({ repo, relativePath, size, mtime, kind, queryToken }) {
+  const parent = path.posix.dirname(relativePath);
+  const encodeRel = (rel) => rel.split('/').map(encodeURIComponent).join('/');
+  const repoHref = appendQueryToken(`/view/${encodeURIComponent(repo)}`, queryToken);
+  const dirHref = parent === '.'
+    ? repoHref
+    : appendQueryToken(`/view/${encodeURIComponent(repo)}/${encodeRel(parent)}`, queryToken);
+  const rows = [
+    ['File', escapeHtml(path.basename(relativePath))],
+    ['Size', escapeHtml(String(size))],
+    ['Modified', escapeHtml(String(mtime))],
+    ['Type', escapeHtml(String(kind))],
+    ['Repo', `<a href="${escapeHtml(repoHref)}">${escapeHtml(repo)}</a>`],
+    ['Folder', `<a href="${escapeHtml(dirHref)}">${escapeHtml(parent === '.' ? '/' : parent)}</a>`],
+  ];
+  return `<details class="doc-properties">
+      <summary>Properties</summary>
+      <dl class="doc-properties-grid">${rows
+        .map(([label, value]) => `<div><dt>${label}</dt><dd>${value}</dd></div>`)
+        .join('')}</dl>
+    </details>`;
+}
+
+function documentHeader(options) {
+  return `<header class="topbar">
+      ${breadcrumbs(options.repo, options.relativePath, options.queryToken)}
+      ${options.showTitle ? `<h1>${escapeHtml(path.basename(options.relativePath))}</h1>` : ''}
+      ${propertiesPanel(options)}
+      ${options.extra || ''}
+    </header>`;
+}
+
 function breadcrumbs(repo, relativePath, queryToken) {
   const segments = relativePath ? relativePath.split('/') : [];
   const items = [
@@ -1662,13 +1697,9 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
     ].filter(Boolean).join('\n    ');
     const body = `${toolbarHtml(extraButtons)}
   <main class="layout">
-    <header class="topbar">
-      <h1>${escapeHtml(path.basename(relativePath))}</h1>
-      <p class="subtitle">${escapeHtml(heading)}</p>
-      ${breadcrumbs(repo, relativePath, queryToken)}
-      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · embedded html</p>
-      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
-    </header>
+    ${documentHeader({
+      repo, relativePath, queryToken, size, mtime, kind: 'embedded html', showTitle: true,
+    })}
 
     ${contentHtml}
   </main>`;
@@ -1706,13 +1737,11 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
     annotationModeAvailable: annotationsEnabled,
   })}
   <main class="layout">
-    <header class="topbar">
-      <h1>${escapeHtml(path.basename(relativePath))}</h1>
-      <p class="subtitle">${escapeHtml(heading)}</p>
-      ${breadcrumbs(repo, relativePath, queryToken)}
-      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · ${escapeHtml(rendered.kind)}</p>
-      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
-    </header>
+    ${documentHeader({
+      repo, relativePath, queryToken, size, mtime,
+      kind: rendered.kind,
+      showTitle: true,
+    })}
 
     ${contentHtml}
     ${annotationsEnabled ? '<section class="lookie-line-range-root" data-annotations-line-range-root hidden></section>' : ''}
@@ -2113,13 +2142,9 @@ function renderImagePage({ repo, relativePath, parentHref, imageHref, mtime, siz
   const heading = `${repo}/${relativePath}`;
   const body = `${toolbarHtml()}
   <main class="layout">
-    <header class="topbar">
-      <h1>${escapeHtml(path.basename(relativePath))}</h1>
-      <p class="subtitle">${escapeHtml(heading)}</p>
-      ${breadcrumbs(repo, relativePath, queryToken)}
-      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · image</p>
-      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
-    </header>
+    ${documentHeader({
+      repo, relativePath, queryToken, size, mtime, kind: 'image', showTitle: true,
+    })}
 
     <article class="content image-view">
       <img src="${escapeHtml(imageHref)}" alt="${escapeHtml(relativePath)}" />
@@ -2139,13 +2164,9 @@ function renderAudioPage({ repo, relativePath, parentHref, audioHref, mimeType, 
   const safeMime = mimeType || 'audio/mpeg';
   const body = `${toolbarHtml()}
   <main class="layout">
-    <header class="topbar">
-      <h1>${escapeHtml(path.basename(relativePath))}</h1>
-      <p class="subtitle">${escapeHtml(heading)}</p>
-      ${breadcrumbs(repo, relativePath, queryToken)}
-      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · audio</p>
-      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
-    </header>
+    ${documentHeader({
+      repo, relativePath, queryToken, size, mtime, kind: 'audio', showTitle: true,
+    })}
 
     <article class="content audio-view">
       <audio controls preload="metadata" src="${escapeHtml(audioHref)}" type="${escapeHtml(safeMime)}">
@@ -2169,13 +2190,9 @@ function renderVideoPage({ repo, relativePath, parentHref, videoHref, mimeType, 
   const safeMime = mimeType || 'video/mp4';
   const body = `${toolbarHtml()}
   <main class="layout">
-    <header class="topbar">
-      <h1>${escapeHtml(path.basename(relativePath))}</h1>
-      <p class="subtitle">${escapeHtml(heading)}</p>
-      ${breadcrumbs(repo, relativePath, queryToken)}
-      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · video</p>
-      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
-    </header>
+    ${documentHeader({
+      repo, relativePath, queryToken, size, mtime, kind: 'video', showTitle: true,
+    })}
 
     <article class="content video-view">
       <video controls preload="metadata" src="${escapeHtml(videoHref)}" type="${escapeHtml(safeMime)}">
@@ -2198,13 +2215,9 @@ function renderPdfPage({ repo, relativePath, parentHref, pdfHref, mtime, size, c
   const heading = `${repo}/${relativePath}`;
   const body = `${toolbarHtml()}
   <main class="layout">
-    <header class="topbar">
-      <h1>${escapeHtml(path.basename(relativePath))}</h1>
-      <p class="subtitle">${escapeHtml(heading)}</p>
-      ${breadcrumbs(repo, relativePath, queryToken)}
-      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · pdf</p>
-      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
-    </header>
+    ${documentHeader({
+      repo, relativePath, queryToken, size, mtime, kind: 'pdf', showTitle: true,
+    })}
 
     <article class="content pdf-view">
       <iframe
@@ -2402,14 +2415,10 @@ function renderCsvPage({ repo, relativePath, source, parentHref, rawHref, mtime,
 
   const body = `${toolbarHtml(extraButtons)}
   <main class="layout">
-    <header class="topbar">
-      <h1>${escapeHtml(path.basename(relativePath))}</h1>
-      <p class="subtitle">${escapeHtml(heading)}</p>
-      ${breadcrumbs(repo, relativePath, queryToken)}
-      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · ${escapeHtml(summary)}</p>
-      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
-      <p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>
-    </header>
+    ${documentHeader({
+      repo, relativePath, queryToken, size, mtime, kind: summary, showTitle: true,
+      extra: `<p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>`,
+    })}
 
     <article class="content csv-view" data-rendered-view hidden aria-hidden="true">
       ${tableHtml}
@@ -2501,14 +2510,10 @@ function renderJsonPage({ repo, relativePath, source, parentHref, rawHref, mtime
 
   const body = `${toolbarHtml(extraButtons)}
   <main class="layout">
-    <header class="topbar">
-      <h1>${escapeHtml(path.basename(relativePath))}</h1>
-      <p class="subtitle">${escapeHtml(heading)}</p>
-      ${breadcrumbs(repo, relativePath, queryToken)}
-      <p class="doc-meta">${escapeHtml(size)} · ${escapeHtml(mtime)} · ${escapeHtml(summary)}</p>
-      ${parentHref ? `<p><a class="back" href="${parentHref}">Back to directory</a></p>` : ''}
-      <p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>
-    </header>
+    ${documentHeader({
+      repo, relativePath, queryToken, size, mtime, kind: summary, showTitle: true,
+      extra: `<p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>`,
+    })}
 
     <article class="content json-view" data-rendered-view hidden aria-hidden="true">
       ${treeHtml}

--- a/public/style.css
+++ b/public/style.css
@@ -2419,6 +2419,68 @@ tbody tr:last-child td {
 
 
 
+/* Properties: file facts, collapsed by default. Same disclosure interaction as the
+   frontmatter panel, because they are the same kind of thing to a reader. */
+.doc-properties {
+  margin: 0.5rem 0 0;
+}
+
+.doc-properties > summary {
+  list-style: none;
+  cursor: pointer;
+  display: inline-block;
+  border: 1px solid var(--border);
+  background-color: var(--toolbar-btn-bg);
+  color: var(--text-soft);
+  border-radius: 999px;
+  padding: 0.16rem 0.7rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.doc-properties > summary::-webkit-details-marker,
+.doc-properties > summary::marker {
+  display: none;
+  content: "";
+}
+
+.doc-properties > summary:hover,
+.doc-properties > summary:focus-visible {
+  background-color: var(--toolbar-btn-hover);
+  color: var(--text);
+}
+
+.doc-properties-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.7rem 1.2rem;
+  margin: 0.7rem 0 0;
+  padding: 0.85rem 0.95rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.doc-properties-grid dt {
+  color: var(--text-soft);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 0.15rem;
+}
+
+.doc-properties-grid dd {
+  margin: 0;
+  font-size: 0.86rem;
+  word-break: break-word;
+}
+
+.doc-properties-grid a {
+  color: var(--link);
+}
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/access-control.test.js
+++ b/test/access-control.test.js
@@ -413,7 +413,7 @@ test('html and htm files render as sanitized documents with raw toggle and edit 
     assert.doesNotMatch(viewHtml, /<script>alert\(1\)<\/script>/);
     assert.match(viewHtml, /data-raw-toggle/);
     assert.match(viewHtml, /language-xml" data-raw-code/);
-    assert.match(viewHtml, /· html<\/p>/);
+    assert.match(viewHtml, /<dt>Type<\/dt><dd>html<\/dd>/);
 
     const editResponse = await server.request('/edit/alpha/docs/landing.htm');
     assert.equal(editResponse.status, 200);
@@ -532,7 +532,7 @@ test('pdf files render in a dedicated viewer page and stream from the asset rout
     assert.match(viewHtml, /class="content pdf-view"/);
     assert.match(viewHtml, /<iframe[\s\S]*class="pdf-frame"/);
     assert.match(viewHtml, /\/asset\/alpha\/docs\/manual\.pdf\?token=viewer-token#view=FitH/);
-    assert.match(viewHtml, /· pdf<\/p>/);
+    assert.match(viewHtml, /<dt>Type<\/dt><dd>pdf<\/dd>/);
     assert.doesNotMatch(viewHtml, />Edit</);
 
     const assetResponse = await server.request('/asset/alpha/docs/manual.pdf?token=viewer-token');

--- a/test/document-header.test.js
+++ b/test/document-header.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { renderDocumentPage } = require("../lib/renderer");
+
+const OPTIONS = {
+  repo: 'alpha',
+  relativePath: 'docs/guide.md',
+  source: '# Guide\n\nBody text.\n',
+  size: '4.1 KB',
+  mtime: '2026-07-21',
+  parentHref: '/view/alpha/docs',
+};
+
+function render(extra = {}) {
+  return renderDocumentPage({ ...OPTIONS, ...extra });
+}
+
+test('the header no longer repeats the location three times', () => {
+  const html = render();
+
+  // Breadcrumbs are the one context line. The duplicate subtitle path and the
+  // separate "Back to directory" link both said the same thing.
+  assert.match(html, /<nav class="breadcrumbs">/);
+  assert.doesNotMatch(html, /<p class="subtitle">/);
+  assert.doesNotMatch(html, /Back to directory/);
+});
+
+test('file facts move out of the header into Properties', () => {
+  const html = render();
+
+  // The old meta line is gone...
+  assert.doesNotMatch(html, /<p class="doc-meta">/);
+  // ...and the same facts are available, collapsed, in Properties.
+  assert.match(html, /<details class="doc-properties">/);
+  assert.match(html, /<summary>Properties<\/summary>/);
+  assert.match(html, /<dt>Size<\/dt><dd>4\.1 KB<\/dd>/);
+  assert.match(html, /<dt>Modified<\/dt><dd>2026-07-21<\/dd>/);
+  assert.match(html, /<dt>File<\/dt><dd>guide\.md<\/dd>/);
+});
+
+test('Properties renders repo and folder as links, not printed paths', () => {
+  const html = render();
+  assert.match(html, /<dd><a href="\/view\/alpha">alpha<\/a><\/dd>/);
+  assert.match(html, /<dd><a href="\/view\/alpha\/docs">docs<\/a><\/dd>/);
+});
+
+test('Properties links carry the query token when one is in play', () => {
+  // A tokenised session must not drop the token on these links, or following one
+  // silently downgrades the caller.
+  const html = render({ queryToken: 'read-only' });
+  assert.match(html, /href="\/view\/alpha\?token=read-only"/);
+  assert.match(html, /href="\/view\/alpha\/docs\?token=read-only"/);
+});
+
+test('Properties escapes hostile path and repo values', () => {
+  const html = render({
+    repo: 'alpha',
+    relativePath: 'docs/<script>alert(1)</script>.md',
+  });
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>\.md/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;\.md/);
+});
+
+test('Properties is collapsed by default so it costs no vertical space', () => {
+  const html = render();
+  // <details> without an `open` attribute renders collapsed.
+  assert.doesNotMatch(html, /<details class="doc-properties" open/);
+});

--- a/test/video-routes.test.js
+++ b/test/video-routes.test.js
@@ -133,7 +133,10 @@ test('video page renderer builds a dedicated player with escaped metadata', () =
   assert.match(html, /<article class="content video-view">/);
   assert.match(html, /<video controls preload="metadata" src="\/asset\/demo\/media\/demo%3Cclip%3E\.webm\?token=read-only" type="video\/webm">/);
   assert.match(html, /demo&lt;clip&gt;\.webm/);
-  assert.match(html, /12 KB · 2026-07-20 · video/);
+  // File facts now live in the Properties disclosure rather than a meta line.
+  assert.match(html, /<dt>Size<\/dt><dd>12 KB<\/dd>/);
+  assert.match(html, /<dt>Modified<\/dt><dd>2026-07-20<\/dd>/);
+  assert.match(html, /<dt>Type<\/dt><dd>video<\/dd>/);
 });
 
 test('document renderer embeds linked and authored video with asset URLs', async () => {


### PR DESCRIPTION
The header stacked five blocks before a single word of content, three of them the same fact written three ways — a filename heading, a subtitle holding the full path, breadcrumbs holding it again, then a size/date/type line and a "Back to directory" link the breadcrumbs already provided.

Now: **breadcrumbs, filename, and a collapsed Properties disclosure.**

## Frontmatter is a claim; Properties are facts

Properties holds size, modified, type, file, repo, folder. It **deliberately does not deduplicate** against the frontmatter panel, which still renders in full. The two may disagree, and that is worth seeing — a document declaring `Last Updated: 2026-07-21` beside a file modified today is telling you something.

Repo and folder render as **links**, and carry the query token when one is in play; following one otherwise silently downgrades the caller. There is a test for that specifically.

## Scope

Eleven near-identical header blocks collapse into one `documentHeader` helper. Media, PDF and CSV views keep the filename heading because their content has no title of its own. The directory index and edit view are untouched — their headings say something the content does not.

## On the three failing tests

`access-control` and `video-routes` pinned the old `12 KB · 2026-07-20 · video` meta line. They were **right to fail** — that is the format changing, not a regression — and now assert the Properties rows.

185/185 unit tests, 4/4 browser, all validators green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)