### PR TITLE
fix(viewer): stop the breadcrumb running under the floating toolbar

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -431,6 +431,18 @@ a:hover {
 
 .topbar {
   margin-bottom: 1rem;
+  /* The viewer toolbar is position:fixed at the top right and floats over content.
+     The header used to lead with a short filename heading that fit beside it; it now
+     leads with breadcrumbs, which are long enough to run underneath. Reserve the
+     toolbar's height so the first line of the header always clears it. */
+  padding-top: 2.9rem;
+}
+
+/* The toolbar wraps to a second row on narrow viewports, so it needs more clearance. */
+@media (max-width: 640px) {
+  .topbar {
+    padding-top: 5rem;
+  }
 }
 
 .topbar h1 {

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -102,6 +102,17 @@ async function startFixture() {
   });
   await registry.createDraft(structuredClone(gymTemplate));
 
+  // A mapped repo with a document, so browser tests can cover document pages too.
+  // Without this the fixture serves forms only, and a header assertion written
+  // against a form page passes vacuously when the document header is broken.
+  const docsPath = path.join(root, 'docs-repo');
+  await fs.mkdir(path.join(docsPath, 'guides'), {recursive: true});
+  await fs.writeFile(
+    path.join(docsPath, 'guides', 'a-fairly-long-document-name.md'),
+    '---\nTitle: Sample\n---\n\n# Sample\n\nBody.\n',
+    'utf8'
+  );
+
   const listener = http.createServer();
   await new Promise((resolve, reject) => {
     listener.once('error', reject);
@@ -109,7 +120,12 @@ async function startFixture() {
   });
   const origin = `http://127.0.0.1:${listener.address().port}`;
   const app = createApp({
-    mappings: {},
+    mappings: {docs: docsPath},
+    // Match production's toolbar: annotations and editing add buttons, which makes
+    // the toolbar taller and wider. A fixture with fewer buttons never reproduces
+    // the overlap it is meant to guard against.
+    annotationsEnabled: true,
+    editingEnabled: true,
     accessConfig: {humanDefault: 'full'},
     formsConfig: {
       enabled: true,
@@ -370,4 +386,34 @@ browserTest('builder field rows start collapsed and expand without clipped contr
   assert.equal(await fields.first().getAttribute('open'), '');
   assert.equal(await fields.first().locator('.builder-field-settings').isVisible(), true);
   await assertNoClippedControls(page, 'expanded builder');
+});
+
+browserTest('the header clears the floating toolbar instead of running underneath it', async ({page, fixture}) => {
+  // The toolbar is position:fixed at the top right and floats over content. The
+  // header must start below it -- a long first line (breadcrumbs on document
+  // pages) otherwise disappears under the controls. Caught by screenshot once;
+  // asserted here so it stays caught.
+  await page.goto(`${fixture.origin}/view/docs/guides/a-fairly-long-document-name.md`, {waitUntil: 'networkidle'});
+
+  const geometry = await page.evaluate(() => {
+    const toolbar = document.querySelector('.viewer-toolbar');
+    const topbar = document.querySelector('.topbar');
+    if (!toolbar || !topbar) return null;
+    const t = toolbar.getBoundingClientRect();
+    const h = topbar.getBoundingClientRect();
+    const first = topbar.firstElementChild;
+    const f = first ? first.getBoundingClientRect() : null;
+    return {
+      toolbarBottom: t.bottom,
+      topbarTop: h.top,
+      firstChildTop: f ? f.top : null,
+      firstChildTag: first ? first.tagName : null,
+    };
+  });
+
+  assert.ok(geometry, 'expected a toolbar and a header');
+  assert.ok(
+    geometry.firstChildTop >= geometry.toolbarBottom,
+    `header content must start below the toolbar (${geometry.firstChildTag} top ${geometry.firstChildTop} vs toolbar bottom ${geometry.toolbarBottom})`
+  );
 });


### PR DESCRIPTION
The header now leads with breadcrumbs rather than a short filename heading. The toolbar is `position: fixed` top-right and floats over content — the old heading was short enough to sit beside it, a breadcrumb trail is not.

On the live instance at 390px: toolbar reached `y=80`, breadcrumb started at `y=59`. The tail of the path was hidden behind the controls. Caught by screenshot immediately after deploying #205.

Reserves the toolbar's height above the header, with extra clearance below 640px where the toolbar wraps. Verified clear at 1000px and 390px.

## The regression test took three attempts, and the first two passed while the defect was present

1. **Asserted against a form page.** Forms get clearance elsewhere, so removing the fix didn't fail it.
2. **Asserted against a document page** — but the fixture mounted no repos, so there was no document page.
3. **Mounted a document repo** — still passed, because the fixture built its app *without annotations or editing*. Fewer toolbar buttons meant a shorter toolbar that never reached the breadcrumb.

The fixture now mounts a document repo and enables annotations and editing, so its toolbar matches production. Removing the clearance now fails with the same geometry measured live: `NAV top 59.19 vs toolbar bottom 80.05`.

**A fixture that differs from production in the dimension under test will report success while the defect ships.** That is the third variant of this pattern today — byte-identical theme screenshots, a browser suite that skipped itself and exited 0, and now this.

Side benefit: the fixture can finally exercise document pages, which had blocked regression tests twice before (#189, #197).

185/185 unit, 5/5 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
