### PR TITLE
feat(viewer): make the path carry the title and move Properties to the toolbar

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1503,8 +1503,8 @@ function propertiesPanel({ repo, relativePath, size, mtime, kind, queryToken }) 
     ['Repo', `<a href="${escapeHtml(repoHref)}">${escapeHtml(repo)}</a>`],
     ['Folder', `<a href="${escapeHtml(dirHref)}">${escapeHtml(parent === '.' ? '/' : parent)}</a>`],
   ];
-  return `<details class="doc-properties">
-      <summary>Properties</summary>
+  return `<details class="doc-properties toolbar-properties">
+      <summary class="toolbar-btn">Properties</summary>
       <dl class="doc-properties-grid">${rows
         .map(([label, value]) => `<div><dt>${label}</dt><dd>${value}</dd></div>`)
         .join('')}</dl>
@@ -1514,8 +1514,6 @@ function propertiesPanel({ repo, relativePath, size, mtime, kind, queryToken }) 
 function documentHeader(options) {
   return `<header class="topbar">
       ${breadcrumbs(options.repo, options.relativePath, options.queryToken)}
-      ${options.showTitle ? `<h1>${escapeHtml(path.basename(options.relativePath))}</h1>` : ''}
-      ${propertiesPanel(options)}
       ${options.extra || ''}
     </header>`;
 }
@@ -1533,7 +1531,13 @@ function breadcrumbs(repo, relativePath, queryToken) {
       `/view/${encodeURIComponent(repo)}/${rel.split('/').map(encodeURIComponent).join('/')}`,
       queryToken
     );
-    items.push(`<a href="${href}">${escapeHtml(segment)}</a>`);
+    const isLast = idx === segments.length - 1;
+    // The last segment is the document's name. It carries the heading role here so
+    // the filename is not printed a second time on its own line -- it is already in
+    // the path. Styled large and bold, it reads as the title while staying in place.
+    items.push(isLast
+      ? `<h1 class="crumb-title"><a href="${href}" aria-current="page">${escapeHtml(segment)}</a></h1>`
+      : `<a href="${href}">${escapeHtml(segment)}</a>`);
   });
 
   return `<nav class="breadcrumbs">${items.join('<span class="sep">/</span>')}</nav>`;
@@ -1698,7 +1702,7 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
     const body = `${toolbarHtml(extraButtons)}
   <main class="layout">
     ${documentHeader({
-      repo, relativePath, queryToken, size, mtime, kind: 'embedded html', showTitle: true,
+      repo, relativePath, queryToken, size, mtime, kind: 'embedded html',
     })}
 
     ${contentHtml}
@@ -1732,7 +1736,10 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
   ].filter(Boolean).join('\n    ');
 
-  const body = `${toolbarHtml(extraButtons, {
+  const propertiesControl = propertiesPanel({
+    repo, relativePath, queryToken, size, mtime, kind: rendered.kind,
+  });
+  const body = `${toolbarHtml([propertiesControl, extraButtons].filter(Boolean).join('\n    '), {
     annotationsEnabled,
     annotationModeAvailable: annotationsEnabled,
   })}
@@ -1740,7 +1747,6 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
     ${documentHeader({
       repo, relativePath, queryToken, size, mtime,
       kind: rendered.kind,
-      showTitle: true,
     })}
 
     ${contentHtml}
@@ -2140,10 +2146,11 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
 
 function renderImagePage({ repo, relativePath, parentHref, imageHref, mtime, size, customThemeCss, queryToken = null }) {
   const heading = `${repo}/${relativePath}`;
-  const body = `${toolbarHtml()}
+  const propertiesControl = propertiesPanel({ repo, relativePath, queryToken, size, mtime, kind: 'image' });
+  const body = `${toolbarHtml(propertiesControl)}
   <main class="layout">
     ${documentHeader({
-      repo, relativePath, queryToken, size, mtime, kind: 'image', showTitle: true,
+      repo, relativePath, queryToken, size, mtime, kind: 'image',
     })}
 
     <article class="content image-view">
@@ -2162,10 +2169,11 @@ function renderImagePage({ repo, relativePath, parentHref, imageHref, mtime, siz
 function renderAudioPage({ repo, relativePath, parentHref, audioHref, mimeType, mtime, size, customThemeCss, queryToken = null }) {
   const heading = `${repo}/${relativePath}`;
   const safeMime = mimeType || 'audio/mpeg';
-  const body = `${toolbarHtml()}
+  const propertiesControl = propertiesPanel({ repo, relativePath, queryToken, size, mtime, kind: 'audio' });
+  const body = `${toolbarHtml(propertiesControl)}
   <main class="layout">
     ${documentHeader({
-      repo, relativePath, queryToken, size, mtime, kind: 'audio', showTitle: true,
+      repo, relativePath, queryToken, size, mtime, kind: 'audio',
     })}
 
     <article class="content audio-view">
@@ -2188,10 +2196,11 @@ function renderAudioPage({ repo, relativePath, parentHref, audioHref, mimeType, 
 function renderVideoPage({ repo, relativePath, parentHref, videoHref, mimeType, mtime, size, customThemeCss, queryToken = null }) {
   const heading = `${repo}/${relativePath}`;
   const safeMime = mimeType || 'video/mp4';
-  const body = `${toolbarHtml()}
+  const propertiesControl = propertiesPanel({ repo, relativePath, queryToken, size, mtime, kind: 'video' });
+  const body = `${toolbarHtml(propertiesControl)}
   <main class="layout">
     ${documentHeader({
-      repo, relativePath, queryToken, size, mtime, kind: 'video', showTitle: true,
+      repo, relativePath, queryToken, size, mtime, kind: 'video',
     })}
 
     <article class="content video-view">
@@ -2213,10 +2222,11 @@ function renderVideoPage({ repo, relativePath, parentHref, videoHref, mimeType, 
 
 function renderPdfPage({ repo, relativePath, parentHref, pdfHref, mtime, size, customThemeCss, queryToken = null }) {
   const heading = `${repo}/${relativePath}`;
-  const body = `${toolbarHtml()}
+  const propertiesControl = propertiesPanel({ repo, relativePath, queryToken, size, mtime, kind: 'pdf' });
+  const body = `${toolbarHtml(propertiesControl)}
   <main class="layout">
     ${documentHeader({
-      repo, relativePath, queryToken, size, mtime, kind: 'pdf', showTitle: true,
+      repo, relativePath, queryToken, size, mtime, kind: 'pdf',
     })}
 
     <article class="content pdf-view">
@@ -2413,10 +2423,11 @@ function renderCsvPage({ repo, relativePath, source, parentHref, rawHref, mtime,
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
   ].filter(Boolean).join('\n    ');
 
-  const body = `${toolbarHtml(extraButtons)}
+  const propertiesControl = propertiesPanel({ repo, relativePath, queryToken, size, mtime, kind: summary, extra: `<p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>` });
+  const body = `${toolbarHtml([propertiesControl, extraButtons].filter(Boolean).join('\n    '))}
   <main class="layout">
     ${documentHeader({
-      repo, relativePath, queryToken, size, mtime, kind: summary, showTitle: true,
+      repo, relativePath, queryToken, size, mtime, kind: summary,
       extra: `<p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>`,
     })}
 
@@ -2508,10 +2519,11 @@ function renderJsonPage({ repo, relativePath, source, parentHref, rawHref, mtime
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
   ].filter(Boolean).join('\n    ');
 
-  const body = `${toolbarHtml(extraButtons)}
+  const propertiesControl = propertiesPanel({ repo, relativePath, queryToken, size, mtime, kind: summary, extra: `<p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>` });
+  const body = `${toolbarHtml([propertiesControl, extraButtons].filter(Boolean).join('\n    '))}
   <main class="layout">
     ${documentHeader({
-      repo, relativePath, queryToken, size, mtime, kind: summary, showTitle: true,
+      repo, relativePath, queryToken, size, mtime, kind: summary,
       extra: `<p class="csv-actions"><a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">View raw asset</a> <span class="sep">·</span> <a href="${escapeHtml(rawHref)}" download>Download</a></p>`,
     })}
 

--- a/public/style.css
+++ b/public/style.css
@@ -2431,10 +2431,64 @@ tbody tr:last-child td {
 
 
 
+/* The final breadcrumb segment is the document's name and the page's <h1>. It sits
+   inline in the trail rather than being repeated on a line below. */
+.breadcrumbs .crumb-title {
+  display: inline;
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.breadcrumbs .crumb-title a {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.breadcrumbs .crumb-title a:hover,
+.breadcrumbs .crumb-title a:focus-visible {
+  text-decoration: underline;
+}
+
 /* Properties: file facts, collapsed by default. Same disclosure interaction as the
    frontmatter panel, because they are the same kind of thing to a reader. */
 .doc-properties {
   margin: 0.5rem 0 0;
+}
+
+/* In the toolbar the control sits beside Files, the theme picker and Annotate, so
+   it must not take part in the toolbar's flex flow when open -- the panel is
+   anchored beneath the toolbar instead of stretching it. */
+.toolbar-properties {
+  /* No positioning context here on purpose: the panel anchors to .viewer-toolbar
+     (position:fixed, so it is a containing block) and spans its width. Anchoring to
+     the button instead pushed the panel off the left edge when right-aligned and off
+     the right edge when left-aligned -- the toolbar is on screen by definition. */
+  margin: 0;
+}
+
+.toolbar-properties > summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.toolbar-properties > summary::-webkit-details-marker,
+.toolbar-properties > summary::marker {
+  display: none;
+  content: "";
+}
+
+.toolbar-properties .doc-properties-grid {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  z-index: 40;
+  width: auto;
+  max-height: min(60vh, 28rem);
+  overflow-y: auto;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
 }
 
 .doc-properties > summary {

--- a/test/document-header.test.js
+++ b/test/document-header.test.js
@@ -28,14 +28,14 @@ test('the header no longer repeats the location three times', () => {
   assert.doesNotMatch(html, /Back to directory/);
 });
 
-test('file facts move out of the header into Properties', () => {
+test('file facts live in the toolbar Properties control, not the header', () => {
   const html = render();
 
   // The old meta line is gone...
   assert.doesNotMatch(html, /<p class="doc-meta">/);
   // ...and the same facts are available, collapsed, in Properties.
-  assert.match(html, /<details class="doc-properties">/);
-  assert.match(html, /<summary>Properties<\/summary>/);
+  assert.match(html, /<details class="doc-properties toolbar-properties">/);
+  assert.match(html, /<summary class="toolbar-btn">Properties<\/summary>/);
   assert.match(html, /<dt>Size<\/dt><dd>4\.1 KB<\/dd>/);
   assert.match(html, /<dt>Modified<\/dt><dd>2026-07-21<\/dd>/);
   assert.match(html, /<dt>File<\/dt><dd>guide\.md<\/dd>/);


### PR DESCRIPTION
The filename was printed twice — once as the last breadcrumb segment, once as a heading on the line below. It's already in the path, so the separate line was pure repetition.

**The final breadcrumb segment is now the page's `<h1>`**, set large and bold, reading as the title while staying in place:

```
home / operations / README.md
```

The heading element *moved* rather than disappeared, so the page keeps a proper document heading.

**Properties moves into the toolbar**, beside Files, Raw, Edit, Annotate and the theme picker — where the viewer's other global controls already live. Its panel drops beneath the toolbar when opened.

## Panel anchoring, after two failures

The panel anchors to the **toolbar**, not to its own button. Both button-anchored options broke at a real width:

- right-aligned → off the **left** edge at 1000px (the same defect as the first Go menu)
- left-aligned → off the **right** edge at 390px

The toolbar is on screen by definition, so anchoring there is correct at any width. Verified at 1400, 1000 and 390 by measuring the panel's rect against the viewport, not by eye.

## Scope

Media, PDF and CSV views get the same treatment — their breadcrumb already ends in the filename, so dropping the separate heading costs nothing. Directory index and edit view untouched.

185/185 unit, 5/5 browser, validators green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
