### PR TITLE
fix(viewer): measure toolbar clearance and make Properties a per-line menu

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1366,6 +1366,16 @@ function themeScript(cspNonce = null, defaults = {}) {
       applyColorScheme(savedScheme);
       applyTheme(savedTheme);
 
+      var toolbarEl = document.querySelector('.viewer-toolbar');
+      if (toolbarEl) {
+        var syncToolbarHeight = function () {
+          rootEl.style.setProperty('--toolbar-height', toolbarEl.offsetHeight + 'px');
+        };
+        syncToolbarHeight();
+        window.addEventListener('resize', syncToolbarHeight);
+        if (window.ResizeObserver) new ResizeObserver(syncToolbarHeight).observe(toolbarEl);
+      }
+
       var navPickerEl = document.querySelector('[data-nav-picker]');
       if (navPickerEl) {
         // Select the option whose href is the longest prefix of the current path,

--- a/public/style.css
+++ b/public/style.css
@@ -431,18 +431,13 @@ a:hover {
 
 .topbar {
   margin-bottom: 1rem;
-  /* The viewer toolbar is position:fixed at the top right and floats over content.
-     The header used to lead with a short filename heading that fit beside it; it now
-     leads with breadcrumbs, which are long enough to run underneath. Reserve the
-     toolbar's height so the first line of the header always clears it. */
-  padding-top: 2.9rem;
-}
-
-/* The toolbar wraps to a second row on narrow viewports, so it needs more clearance. */
-@media (max-width: 640px) {
-  .topbar {
-    padding-top: 5rem;
-  }
+  /* The toolbar is position:fixed and floats over content, and the header leads with
+     breadcrumbs long enough to run underneath it. Clearance is MEASURED rather than
+     guessed: --toolbar-height is set from the live element, because how many rows the
+     toolbar wraps to depends on viewport width, the button set, and even the length of
+     the selected theme's name. A fixed value is a guess that goes stale the next time
+     a control is added. The fallback covers the moment before script runs. */
+  padding-top: calc(var(--toolbar-height, 3.1rem) + 1.1rem);
 }
 
 .topbar h1 {
@@ -2482,10 +2477,11 @@ tbody tr:last-child td {
 .toolbar-properties .doc-properties-grid {
   position: absolute;
   left: 0;
-  right: 0;
+  right: auto;
   top: calc(100% + 0.5rem);
   z-index: 40;
-  width: auto;
+  width: max-content;
+  max-width: min(26rem, calc(100vw - 1.6rem));
   max-height: min(60vh, 28rem);
   overflow-y: auto;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
@@ -2520,8 +2516,9 @@ tbody tr:last-child td {
 
 .doc-properties-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 0.7rem 1.2rem;
+  grid-template-columns: max-content 1fr;
+  gap: 0.45rem 0.9rem;
+  align-items: baseline;
   margin: 0.7rem 0 0;
   padding: 0.85rem 0.95rem;
   background: var(--bg-elev);
@@ -2529,12 +2526,17 @@ tbody tr:last-child td {
   border-radius: 10px;
 }
 
+.doc-properties-grid > div {
+  display: contents;
+}
+
 .doc-properties-grid dt {
   color: var(--text-soft);
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin: 0 0 0.15rem;
+  margin: 0;
+  white-space: nowrap;
 }
 
 .doc-properties-grid dd {

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -388,6 +388,47 @@ browserTest('builder field rows start collapsed and expand without clipped contr
   await assertNoClippedControls(page, 'expanded builder');
 });
 
+browserTest('the header clears the toolbar while the window is resized, not just on load', async ({page, fixture}) => {
+  // Resizing is the case a fixed-width sweep misses: the toolbar rewraps as the
+  // window narrows, and clearance measured only at load time goes stale. Walk a
+  // live page down through the range rather than loading fresh at each width.
+  await page.setViewportSize({width: 1400, height: 800});
+  await page.goto(`${fixture.origin}/view/docs/guides/a-fairly-long-document-name.md`, {waitUntil: 'networkidle'});
+
+  const overlapping = [];
+  for (let width = 1400; width >= 330; width -= 40) {
+    await page.setViewportSize({width, height: 800});
+    await page.waitForTimeout(60);
+    const geometry = await page.evaluate(() => {
+      const toolbar = document.querySelector('.viewer-toolbar').getBoundingClientRect();
+      const crumbs = document.querySelector('.breadcrumbs').getBoundingClientRect();
+      return {toolbarBottom: Math.round(toolbar.bottom), crumbTop: Math.round(crumbs.top)};
+    });
+    if (geometry.crumbTop < geometry.toolbarBottom) {
+      overlapping.push(`${width}px (crumb ${geometry.crumbTop} < toolbar ${geometry.toolbarBottom})`);
+    }
+  }
+
+  assert.deepEqual(overlapping, [], 'header must clear the toolbar at every width while resizing');
+});
+
+browserTest('the Properties menu stays on screen at every width', async ({page, fixture}) => {
+  for (const width of [1400, 1000, 700, 430, 330]) {
+    await page.setViewportSize({width, height: 800});
+    await page.goto(`${fixture.origin}/view/docs/guides/a-fairly-long-document-name.md`, {waitUntil: 'networkidle'});
+    await page.click('.toolbar-properties > summary');
+    await page.waitForTimeout(80);
+    const box = await page.evaluate(() => {
+      const panel = document.querySelector('.doc-properties-grid').getBoundingClientRect();
+      return {left: Math.round(panel.left), right: Math.round(panel.right), viewport: window.innerWidth};
+    });
+    assert.ok(
+      box.left >= 0 && box.right <= box.viewport,
+      `Properties menu must stay on screen at ${width}px (left ${box.left}, right ${box.right})`
+    );
+  }
+});
+
 browserTest('the header clears the floating toolbar instead of running underneath it', async ({page, fixture}) => {
   // The toolbar is position:fixed at the top right and floats over content. The
   // header must start below it -- a long first line (breadcrumbs on document


### PR DESCRIPTION
Two follow-ups to the header work in #205–#207.

## Properties is a menu, not a slab

It dropped a full-toolbar-width panel across the page. It is now a compact list — one property per line, label beside value, sized to content (~281px) — the same shape as the other toolbar menus.

## Clearance is measured, not guessed

A small script sets `--toolbar-height` from the live element and keeps it current on resize and via `ResizeObserver`; the header reserves that plus a gutter.

How many rows the toolbar wraps to depends on viewport width, which buttons are present, **and the length of the selected theme's name**. Any fixed value is a guess that goes stale the next time a control is added. A CSS fallback covers the moment before script runs.

## Tests

Resizing is the case a fixed-width sweep misses, so one test walks a **live page** from 1400px down to 330px asserting the header clears the toolbar at every step. A second asserts the Properties menu stays on screen across five widths.

- The resize test **is mutation-verified** — removing the measured clearance fails it.
- The menu-position assertion is **not** mutation-verified: now that the menu is sized to content it fits either way. It stands as an invariant guard, not a proven regression test.

## On the reported overlap

I could not reproduce it — not on fresh loads across 16 widths, not on live resize across 54, with either the old or the new stylesheet. The most likely cause is a cached `style.css` from before #206 (1-hour cache), which shipped the original clearance. These changes make it robust regardless.

7/7 browser, 185/185 unit, validators green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)