### PR TITLE
feat(forms): give forms their own Properties menu

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -3,7 +3,7 @@
 const crypto = require('node:crypto');
 const express = require('express');
 
-const { baseHtml, themeScript, toolbarHtml, getThemeList } = require('../renderer');
+const { baseHtml, themeScript, toolbarHtml, getThemeList, propertiesMenu } = require('../renderer');
 const { storeForTemplate } = require('./destination-adapter');
 const { isDefinitionId } = require('./template-registry');
 
@@ -371,7 +371,7 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   const submitLabel = editing
     ? 'Save correction'
     : configuredSubmitLabel || 'Submit';
-  const body = `${toolbarHtml()}
+  const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">
       <h1>${escapeHtml(template.title)}</h1>
@@ -409,6 +409,33 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
 // It is a SELECTION from operator-installed themes, not a definition -- the same
 // indirection destinationId uses. An unknown slug degrades to the viewer default
 // rather than failing the form, because a theme is cosmetic, not a write path.
+// A form's facts, in the same shape documents use. Different values -- a form has
+// no size or mtime -- but the same question: what is actually true of this thing,
+// as opposed to what its title says.
+function formProperties(record) {
+  const template = (record && record.draft) || record;
+  if (!template) return '';
+  const published = record && record.publishedVersion;
+  const presentation = template.presentation || {};
+  const rows = [
+    ['Form', escapeHtml(template.templateId)],
+    ['Revision', escapeHtml(String(template.revision))],
+    ['Published', published
+      ? escapeHtml(`v${published.templateVersion} from revision ${published.sourceRevision}`)
+      : 'not published'],
+    ['Destination', escapeHtml(template.destinationId || 'default')],
+    ['Owner', escapeHtml(template.ownerId)],
+    ['Fields', escapeHtml(String((template.fields || []).filter((field) => !field.isDestroyed).length))],
+  ];
+  // Only report a theme that is actually installed. An unknown or malformed slug
+  // does not apply -- the form renders in the viewer's theme -- so printing it here
+  // would report something untrue, and Properties exists to report what IS true.
+  if (presentation.theme && getThemeList().some((entry) => entry.slug === presentation.theme)) {
+    rows.push(['Theme', escapeHtml(presentation.theme)]);
+  }
+  return propertiesMenu(rows);
+}
+
 function themeDefaults(template) {
   const presentation = template && template.presentation;
   if (!presentation) return {};
@@ -439,7 +466,7 @@ function renderReceiptPage(template, record, options = {}) {
   const editHref = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}/edit`;
   const canEdit = options.canEdit !== false;
   const received = formatRecordTime(record, options.timezone).dateTimeLabel;
-  const body = `${toolbarHtml()}
+  const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">
       <h1>Entry logged</h1>
@@ -590,7 +617,7 @@ function renderEntriesPage(template, records, options = {}) {
   const content = records.length > 0
     ? entries
     : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">Log an entry</a></div>`;
-  const body = `${toolbarHtml()}
+  const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout entries-layout">
     <header class="topbar">
       <h1>All entries</h1>
@@ -738,7 +765,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   const publishedText = published
     ? `Version ${published.templateVersion}, from draft revision ${published.sourceRevision}`
     : 'Not published yet';
-  const body = `${toolbarHtml()}
+  const body = `${toolbarHtml(formProperties(record))}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
       <p class="eyebrow">Form builder</p>
@@ -886,7 +913,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
 }
 
 function renderArchivedFormPage(template, options = {}) {
-  const body = `${toolbarHtml()}
+  const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar"><p class="eyebrow">Archived form</p><h1>${escapeHtml(template.title)}</h1>${formHubNav(template.templateId, 'log', options.canManage)}</header>
     <section class="content form-card archived-form-state"><h2>This form is archived</h2><p>It is not accepting new entries. Existing history and receipts are still available.</p><a class="button-link" href="/forms/${encodeURIComponent(template.templateId)}/entries">View history</a></section>

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1498,6 +1498,19 @@ function jsonForInlineScript(value) {
 // File FACTS, as distinct from the frontmatter panel's CLAIMS. The two may disagree
 // -- a document declaring "Last Updated: 2026-07-21" beside a file modified today is
 // telling you something -- so this deliberately does not deduplicate against it.
+// Shared shell for the toolbar Properties menu. Callers supply their own rows,
+// because what counts as a "fact" differs by surface: a document has size and
+// mtime, a form has a revision and a destination.
+function propertiesMenu(rows) {
+  if (!rows.length) return '';
+  return `<details class="doc-properties toolbar-properties">
+      <summary class="toolbar-btn">Properties</summary>
+      <dl class="doc-properties-grid">${rows
+        .map(([label, value]) => `<div><dt>${label}</dt><dd>${value}</dd></div>`)
+        .join('')}</dl>
+    </details>`;
+}
+
 function propertiesPanel({ repo, relativePath, size, mtime, kind, queryToken }) {
   const parent = path.posix.dirname(relativePath);
   const encodeRel = (rel) => rel.split('/').map(encodeURIComponent).join('/');
@@ -1513,12 +1526,7 @@ function propertiesPanel({ repo, relativePath, size, mtime, kind, queryToken }) 
     ['Repo', `<a href="${escapeHtml(repoHref)}">${escapeHtml(repo)}</a>`],
     ['Folder', `<a href="${escapeHtml(dirHref)}">${escapeHtml(parent === '.' ? '/' : parent)}</a>`],
   ];
-  return `<details class="doc-properties toolbar-properties">
-      <summary class="toolbar-btn">Properties</summary>
-      <dl class="doc-properties-grid">${rows
-        .map(([label, value]) => `<div><dt>${label}</dt><dd>${value}</dd></div>`)
-        .join('')}</dl>
-    </details>`;
+  return propertiesMenu(rows);
 }
 
 function documentHeader(options) {
@@ -2647,4 +2655,5 @@ module.exports = {
   getThemeList,
   themeScript,
   toolbarHtml,
+  propertiesMenu,
 };

--- a/public/style.css
+++ b/public/style.css
@@ -2487,19 +2487,14 @@ tbody tr:last-child td {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
 }
 
+/* Appearance comes from .toolbar-btn, which the summary already carries, so
+   Properties matches Files, Raw, Edit and the theme picker exactly. Only the
+   disclosure marker and cursor need overriding -- restyling it here made it read
+   as greyed out and unlike every other control in the bar. */
 .doc-properties > summary {
   list-style: none;
   cursor: pointer;
   display: inline-block;
-  border: 1px solid var(--border);
-  background-color: var(--toolbar-btn-bg);
-  color: var(--text-soft);
-  border-radius: 999px;
-  padding: 0.16rem 0.7rem;
-  font-size: 0.76rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
 
 .doc-properties > summary::-webkit-details-marker,
@@ -2511,7 +2506,6 @@ tbody tr:last-child td {
 .doc-properties > summary:hover,
 .doc-properties > summary:focus-visible {
   background-color: var(--toolbar-btn-hover);
-  color: var(--text);
 }
 
 .doc-properties-grid {

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -548,3 +548,56 @@ test('toolbar section picker offers Files and Forms and disappears when there is
   assert.doesNotMatch(toolbarHtml(), /No href/);
   setNavLinks([]);
 });
+
+test('a form carries its own Properties, reporting facts rather than claims', async () => {
+  const {setThemeList} = require('../lib/renderer');
+  setThemeList([{slug: 'slate', label: 'Slate'}, {slug: 'planet-fitness', label: 'Planet Fitness'}]);
+
+  const server = await makeServer();
+  try {
+    const page = await browserPage(await server.request('/forms/training-log'));
+    const doc = page.document;
+    const panel = doc.querySelector('.toolbar-properties');
+    assert.ok(panel, 'a form page exposes Properties in the toolbar');
+
+    const rows = new Map([...panel.querySelectorAll('div')].map((row) => [
+      row.querySelector('dt').textContent,
+      row.querySelector('dd').textContent,
+    ]));
+    assert.equal(rows.get('Form'), 'training-log');
+    assert.equal(rows.get('Revision'), '1');
+    assert.equal(rows.get('Published'), 'not published', 'reports reality, not intent');
+    assert.equal(rows.get('Destination'), 'gym-log');
+    assert.equal(rows.get('Fields'), '2');
+    assert.equal(rows.has('Theme'), false, 'no theme set, so no theme row');
+  } finally {
+    setThemeList(null);
+    await server.close();
+  }
+});
+
+test('Properties reports a theme only when that theme is actually installed', async () => {
+  const {setThemeList} = require('../lib/renderer');
+  const server = await makeServer();
+  try {
+    const before = await server.registry.getManagementTemplate('training-log');
+    await server.registry.reviseDraft('training-log', before.draft.revision, {
+      presentation: {theme: 'planet-fitness'},
+    });
+
+    setThemeList([{slug: 'slate', label: 'Slate'}, {slug: 'planet-fitness', label: 'Planet Fitness'}]);
+    let page = await browserPage(await server.request('/forms/training-log'));
+    let text = page.document.querySelector('.toolbar-properties').textContent;
+    assert.match(text, /planet-fitness/, 'installed theme is reported');
+
+    // The same template on a deployment without that theme: the form does NOT render
+    // in it, so Properties must not claim it does.
+    setThemeList([{slug: 'slate', label: 'Slate'}]);
+    page = await browserPage(await server.request('/forms/training-log'));
+    text = page.document.querySelector('.toolbar-properties').textContent;
+    assert.doesNotMatch(text, /planet-fitness/, 'uninstalled theme is not reported as applied');
+  } finally {
+    setThemeList(null);
+    await server.close();
+  }
+});


### PR DESCRIPTION
Documents gained Properties in #205–#208; forms had the toolbar clearance but not the control. A form has facts worth the same treatment — just different ones. No size or mtime, but a revision, a published version, a destination and an owner.

Extracts `propertiesMenu` from the document implementation so both surfaces share one menu shell and its styling, each supplying its own rows.

Forms report: **form id, draft revision, published version** (or `not published`), **destination, owner, live field count**, and the theme.

## The theme row only appears when that theme is installed

An unknown or malformed slug doesn't apply — the form renders in the viewer's theme — so naming it here would report something untrue. **Properties exists to report what IS true.**

That also keeps a hostile slug out of the page entirely rather than relying on escaping alone. The existing theme-smuggling test caught this when my first version printed it escaped: safe, but still a lie about what was applied.

## Scope

Form, receipt, entries, configure and archived pages. The forms index and new-template page have no single template and are unchanged.

**Mutation-verified twice**: reporting a theme regardless of installation fails; removing Properties from form pages fails.

187/187 unit, 7/7 browser, validators green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
