### PR TITLE
feat(viewer): make the contents control a dropdown instead of a view swap

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1736,11 +1736,7 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
   }
 
   const renderedClass = isMarkdown ? 'markdown' : rendered.kind;
-  const contentHtml = `${hasToc ? `<article class="content toc-view" id="toc-view" data-toc-view hidden aria-hidden="true">
-      <h2 class="toc-view-title">Contents</h2>
-      <nav class="toc-list" data-toc-list aria-label="Table of contents"></nav>
-    </article>` : ''}
-    <article class="content ${renderedClass}" data-rendered-view${isYaml ? ' hidden aria-hidden="true"' : ''}>
+  const contentHtml = `<article class="content ${renderedClass}" data-rendered-view${isYaml ? ' hidden aria-hidden="true"' : ''}>
       ${rendered.html}
     </article>
     ${supportsRawToggle ? `<article class="content raw" data-raw-view${isYaml ? '' : ' hidden aria-hidden="true"'}>
@@ -1748,7 +1744,7 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
     </article>` : ''}`;
 
   const extraButtons = [
-    hasToc ? '<button type="button" class="toolbar-btn" data-toc-toggle aria-label="Toggle table of contents" aria-expanded="false" aria-controls="toc-view">☰</button>' : '',
+    hasToc ? '<details class="doc-properties toolbar-toc" data-toc-menu><summary class="toolbar-btn" data-toc-toggle aria-label="Table of contents">☰</summary><nav class="toc-list" data-toc-list aria-label="Table of contents"></nav></details>' : '',
     supportsRawToggle ? `<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle raw and rendered views" data-pretty-label="${isYaml ? 'Pretty' : 'Rendered'}">${isYaml ? 'Pretty' : 'Raw'}</button>` : '',
     rawHtmlHref ? `<a class="toolbar-btn" href="${escapeHtml(rawHtmlHref)}" target="_blank" rel="noopener" aria-label="Open raw HTML in new tab">Open raw</a>` : '',
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',
@@ -1808,10 +1804,9 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
       var renderedView = document.querySelector('[data-rendered-view]');
       var rawView = document.querySelector('[data-raw-view]');
       var tocToggleBtn = document.querySelector('[data-toc-toggle]');
-      var tocView = document.querySelector('[data-toc-view]');
+      var tocView = document.querySelector('[data-toc-menu]');
       var tocList = document.querySelector('[data-toc-list]');
       var currentBaseView = rawView && !rawView.hidden ? 'raw' : 'rendered';
-      var tocReturnView = currentBaseView;
 
       if (rawView) {
         var rawSourceScript = document.getElementById('raw-document-source');
@@ -1851,14 +1846,6 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
         }
       }
 
-      function setTocButtonState(showingToc) {
-        if (!tocToggleBtn) {
-          return;
-        }
-        tocToggleBtn.textContent = showingToc ? 'Doc' : '☰';
-        tocToggleBtn.setAttribute('aria-expanded', showingToc ? 'true' : 'false');
-      }
-
       function scrollActiveItemIntoView() {
         if (!tocList) {
           return;
@@ -1869,20 +1856,10 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
         }
       }
 
-      function showTocView() {
-        if (!tocView) {
-          return;
+      function closeTocMenu() {
+        if (tocView) {
+          tocView.open = false;
         }
-        // Capture active heading BEFORE hiding the document (offsetTop becomes 0 when hidden)
-        deriveActiveFromScroll();
-        tocReturnView = currentBaseView;
-        setViewVisibility(renderedView, false);
-        if (rawView) {
-          setViewVisibility(rawView, false);
-        }
-        setViewVisibility(tocView, true);
-        setTocButtonState(true);
-        scrollActiveItemIntoView();
       }
 
       function showDocumentView(targetView) {
@@ -1892,10 +1869,7 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
           currentBaseView = 'rendered';
         }
         applyBaseView();
-        if (tocView) {
-          setViewVisibility(tocView, false);
-        }
-        setTocButtonState(false);
+        closeTocMenu();
         updateRawToggleLabel();
       }
 
@@ -1903,11 +1877,6 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
         rawToggleBtn.addEventListener('click', function () {
           currentBaseView = currentBaseView === 'raw' ? 'rendered' : 'raw';
           updateRawToggleLabel();
-
-          if (tocView && !tocView.hidden) {
-            tocReturnView = currentBaseView;
-            return;
-          }
 
           applyBaseView();
           window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -1928,7 +1897,6 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
         }
       }
 
-      setTocButtonState(false);
       updateRawToggleLabel();
 
       const root = renderedView || document.querySelector('.content');
@@ -2051,22 +2019,22 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
 
             setActiveHeading(id);
             showDocumentView('rendered');
+            closeTocMenu();
             setTimeout(function () {
               targetHeading.scrollIntoView({ behavior: 'smooth', block: 'start' });
             }, 0);
           });
 
-          tocToggleBtn.addEventListener('click', function () {
-            if (!tocView.hidden) {
-              showDocumentView(tocReturnView);
-            } else {
-              showTocView();
+          tocView.addEventListener('toggle', function () {
+            if (tocView.open) {
+              deriveActiveFromScroll();
+              scrollActiveItemIntoView();
             }
           });
 
           document.addEventListener('keydown', function (event) {
-            if (event.key === 'Escape' && tocView && !tocView.hidden) {
-              showDocumentView(tocReturnView);
+            if (event.key === 'Escape' && tocView && tocView.open) {
+              closeTocMenu();
             }
           });
 

--- a/public/style.css
+++ b/public/style.css
@@ -2480,6 +2480,29 @@ tbody tr:last-child td {
   content: "";
 }
 
+/* The contents menu shares the Properties menu shell but holds a long list, so it
+   scrolls internally rather than growing past the viewport. */
+.toolbar-toc .toc-list {
+  position: absolute;
+  left: 0;
+  right: auto;
+  top: calc(100% + 0.5rem);
+  z-index: 40;
+  width: max-content;
+  min-width: 16rem;
+  max-width: min(30rem, calc(100vw - 1.6rem));
+  max-height: min(60vh, 26rem);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.5rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
 .toolbar-properties .doc-properties-grid {
   position: absolute;
   left: 0;

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -109,7 +109,8 @@ async function startFixture() {
   await fs.mkdir(path.join(docsPath, 'guides'), {recursive: true});
   await fs.writeFile(
     path.join(docsPath, 'guides', 'a-fairly-long-document-name.md'),
-    '---\nTitle: Sample\n---\n\n# Sample\n\nBody.\n',
+    '---\nTitle: Sample\n---\n\n# Sample\n\nBody.\n\n'
+    + Array.from({length: 12}, (_, i) => `## Section ${i + 1}\n\nText for section ${i + 1}.\n\n`).join(''),
     'utf8'
   );
 
@@ -457,4 +458,31 @@ browserTest('the header clears the floating toolbar instead of running underneat
     geometry.firstChildTop >= geometry.toolbarBottom,
     `header content must start below the toolbar (${geometry.firstChildTag} top ${geometry.firstChildTop} vs toolbar bottom ${geometry.toolbarBottom})`
   );
+});
+
+browserTest('the contents menu opens over the document instead of replacing it', async ({page, fixture}) => {
+  await page.setViewportSize({width: 1100, height: 700});
+  await page.goto(`${fixture.origin}/view/docs/guides/a-fairly-long-document-name.md`, {waitUntil: 'networkidle'});
+
+  const toggle = await page.$('[data-toc-toggle]');
+  if (!toggle) return; // document has too few headings for a contents menu
+
+  await toggle.click();
+  await page.waitForSelector('.toc-list .toc-item', {timeout: 5000});
+
+  const state = await page.evaluate(() => {
+    const list = document.querySelector('.toc-list');
+    const doc = document.querySelector('[data-rendered-view]');
+    const rect = list.getBoundingClientRect();
+    return {
+      documentStillVisible: doc ? !doc.hidden : null,
+      onScreen: rect.left >= 0 && rect.right <= window.innerWidth,
+      scrollsInternally: list.scrollHeight > 0 && getComputedStyle(list).overflowY === 'auto',
+    };
+  });
+
+  // The point of the change: it is a menu, not a view swap. The document must stay.
+  assert.equal(state.documentStillVisible, true, 'the document stays visible behind the menu');
+  assert.ok(state.onScreen, 'the contents menu stays on screen');
+  assert.ok(state.scrollsInternally, 'a long contents list scrolls inside the menu');
 });


### PR DESCRIPTION
The ☰ control was a **view swap wearing a button's clothes**: it hid the document entirely and replaced it with a full-width Contents page, so finding a section meant losing your place.

It is now a dropdown like Files and Properties — the contents open **over** the document, which stays put behind them. Choosing an entry closes the menu and scrolls to the heading.

## What that removed

The old behaviour needed machinery to remember which view to return to (`tocReturnView`), to relabel the button between ☰ and "Doc" (`setTocButtonState`), and to coordinate with the raw/rendered toggle so switching views while the contents were open did not strand you. A `<details>` element handles open and close natively, so all of that is gone rather than ported.

The active-heading highlighting and scroll-spy are unchanged, and the menu scrolls internally — this README has ~20 headings.

## Test

Asserts the document stays visible behind the menu, the menu stays on screen, and a long list scrolls inside it.

**Mutation-verified on the live path.** My first mutation attempt passed, because it targeted `showTocView()` — which had become dead code once `<details>` owned opening. That was the signal to delete the dead view-swap functions rather than leave them; mutating the actual toggle handler then failed the test correctly.

The fixture document grew from one heading to thirteen, since a single-heading document produces no contents menu to test.

187/187 unit, 8/8 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
