### PR TITLE
fix(viewer): align the contents button and make menus translucent

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2461,7 +2461,8 @@ tbody tr:last-child td {
 /* In the toolbar the control sits beside Files, the theme picker and Annotate, so
    it must not take part in the toolbar's flex flow when open -- the panel is
    anchored beneath the toolbar instead of stretching it. */
-.toolbar-properties {
+.toolbar-properties,
+.toolbar-toc {
   /* No positioning context here on purpose: the panel anchors to .viewer-toolbar
      (position:fixed, so it is a containing block) and spans its width. Anchoring to
      the button instead pushed the panel off the left edge when right-aligned and off
@@ -2498,6 +2499,8 @@ tbody tr:last-child td {
   gap: 0.15rem;
   padding: 0.5rem;
   background: var(--bg-elev);
+  background-color: color-mix(in srgb, var(--bg-elev) 82%, transparent);
+  backdrop-filter: blur(10px);
   border: 1px solid var(--border);
   border-radius: 10px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
@@ -2545,6 +2548,8 @@ tbody tr:last-child td {
   margin: 0.7rem 0 0;
   padding: 0.85rem 0.95rem;
   background: var(--bg-elev);
+  background-color: color-mix(in srgb, var(--bg-elev) 82%, transparent);
+  backdrop-filter: blur(10px);
   border: 1px solid var(--border);
   border-radius: 10px;
 }


### PR DESCRIPTION
Two fixes to the toolbar, both measured rather than eyeballed.

## The contents button sat lower than everything else

Measured across all nine controls: the contents button was at `topGap 15, height 25`; every other control was at `topGap 7, height 33`.

Cause: it carries `doc-properties toolbar-toc`, but the margin reset only targeted `.toolbar-properties`. So it kept `margin: 0.5rem 0 0` from the standalone rule — which both pushed it down **and** stopped it stretching to the flex line height, which is why it was shorter as well as lower.

The reset now covers both. Verified: all nine controls report a single distinct `topGap` of 7.

## Menus were opaque while the bar was translucent

#211 made the toolbar *controls* translucent but not the panels they open, so a popup read as an opaque card floating over the page rather than an extension of the bar.

The Properties and contents menus now use the same treatment — a `color-mix` of their own theme token plus a backdrop blur. Verified resolving to `0.82` alpha with `blur(10px)`.

187/187 unit, 8/8 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
