### PR TITLE
fix(viewer): revalidate static assets, and make contents items translucent

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2215,7 +2215,11 @@ tbody tr:last-child td {
   width: 100%;
   border: 1px solid var(--border);
   border-radius: 8px;
+  /* Translucent so the menu's own backdrop blur reads through. An opaque item
+     background tiled over the whole panel and made a translucent container look
+     solid -- the container was translucent, its contents were not. */
   background: var(--bg-code);
+  background-color: color-mix(in srgb, var(--bg-code) 45%, transparent);
   color: var(--text);
   text-align: left;
   font-size: 0.92rem;

--- a/server.js
+++ b/server.js
@@ -844,7 +844,16 @@ function createApp(options = {}) {
   app.use(express.json({ limit: '2mb' }));
   app.use('/public', express.static(path.join(__dirname, 'public'), {
     etag: true,
-    maxAge: '1h',
+    // `no-cache` means "revalidate before using", not "do not store". Paired with
+    // the ETag above, an unchanged file costs a 304 and no body.
+    //
+    // This replaced `maxAge: '1h'`, under which the browser would not even ASK for
+    // up to an hour, so the ETag never got a chance to work. A deployed stylesheet
+    // fix stayed invisible until the cache expired, which repeatedly read as "the
+    // fix did not work" when the server was already serving the corrected file.
+    setHeaders(res) {
+      res.setHeader('Cache-Control', 'no-cache');
+    },
   }));
 
   app.get('/api/managed-repos', (req, res) => {

--- a/test/document-header.test.js
+++ b/test/document-header.test.js
@@ -69,3 +69,26 @@ test('Properties is collapsed by default so it costs no vertical space', () => {
   // <details> without an `open` attribute renders collapsed.
   assert.doesNotMatch(html, /<details class="doc-properties" open/);
 });
+
+test('static assets revalidate instead of being cached blind', async () => {
+  // A stylesheet fix must be visible on the next load, not up to an hour later.
+  // Regression guard: this was `maxAge: '1h'`, which stopped the browser asking at
+  // all, so deployed CSS changes appeared not to have worked when the server was
+  // already serving the corrected file.
+  const http = require('node:http');
+  const {createApp} = require('../server');
+
+  const app = createApp({mappings: {}, accessConfig: {humanDefault: 'full'}});
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const {port} = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/public/style.css`);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('cache-control'), /no-cache/);
+    assert.ok(response.headers.get('etag'), 'an ETag makes revalidation cheap');
+    assert.doesNotMatch(response.headers.get('cache-control'), /max-age=[1-9]/);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});


### PR DESCRIPTION
Two fixes, one of which is the reason several earlier fixes looked like they had not worked.

## Static assets were cached blind for an hour

`express.static` was configured with `maxAge: '1h'`, which emits `Cache-Control: public, max-age=3600`. Under that, a browser will not even **ask** for the file for an hour, so the `etag` sitting right beside it never got a chance to do anything.

The practical effect: a deployed stylesheet fix stayed invisible until the cache expired. Three separate times today a change was reported as not working while the server was already serving the corrected file — the theme-picker chevron, the header clearance, and the toolbar alignment.

Now `Cache-Control: no-cache`, which means *revalidate before using*, not *do not store*. With the ETag, an unchanged file costs a 304 and no body.

Mutation-verified: restoring `maxAge: '1h'` fails the new test.

## The contents menu only looked opaque

`.toc-item` carried `background: var(--bg-code)` — fully opaque — and the items tile the entire panel. So a translucent container was completely covered by opaque contents: the container was translucent, its contents were not.

Items now use a `color-mix` of the same token at 45%, so the panel's backdrop blur reads through. Verified on the live instance: list `0.82` alpha, items `0.45`.

188/188 unit, 8/8 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
