### PR TITLE
style(viewer): tint menu surfaces away from the page background

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2503,7 +2503,7 @@ tbody tr:last-child td {
   gap: 0.15rem;
   padding: 0.5rem;
   background: var(--bg-elev);
-  background-color: color-mix(in srgb, var(--bg-elev) 82%, transparent);
+  background-color: color-mix(in srgb, color-mix(in srgb, var(--bg-elev) 86%, var(--text-soft)) 84%, transparent);
   backdrop-filter: blur(10px);
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -2552,7 +2552,7 @@ tbody tr:last-child td {
   margin: 0.7rem 0 0;
   padding: 0.85rem 0.95rem;
   background: var(--bg-elev);
-  background-color: color-mix(in srgb, var(--bg-elev) 82%, transparent);
+  background-color: color-mix(in srgb, color-mix(in srgb, var(--bg-elev) 86%, var(--text-soft)) 84%, transparent);
   backdrop-filter: blur(10px);
   border: 1px solid var(--border);
   border-radius: 10px;


### PR DESCRIPTION
Menus used the page's own elevated background at 82% opacity, so a translucent menu read as a slightly see-through copy of the page rather than a surface above it.

They now mix a small amount of the theme's muted text colour into that background before applying transparency — lifting them toward neutral **without** a hardcoded grey that would only suit dark palettes. The tint derives from theme tokens, so it follows every theme including light ones.

188/188 unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)