### PR TITLE
feat(viewer): convert the Files and theme pickers to custom menus

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1300,7 +1300,9 @@ function getThemeList() {
 
 function toolbarHtml(extraButtons = '', options = {}) {
   const themes = getThemeList();
-  const themeOptions = themes.map(t => `<option value="${t.slug}">${t.label}</option>`).join('');
+  const themeItems = themes.map((theme) =>
+    `<button type="button" role="menuitem" data-theme-item value="${escapeHtml(theme.slug)}">${escapeHtml(theme.label)}</button>`
+  ).join('');
   const annotationChip = options.annotationsEnabled
     ? '<button type="button" class="toolbar-btn toolbar-btn-annotation-count" data-annotations-toggle aria-label="Show or hide resolved annotations" aria-pressed="false" hidden>💬 0</button>'
     : '';
@@ -1308,19 +1310,25 @@ function toolbarHtml(extraButtons = '', options = {}) {
     ? '<button type="button" class="toolbar-btn" data-annotation-mode-toggle aria-label="Show annotation targets" aria-pressed="false" title="Show annotation targets">💬 Annotate</button>'
     : '';
   const navLinks = getNavLinks();
-  // Same control as the theme picker: it shows where you ARE and switching moves
-  // you, so it needs no label of its own.
+  // Custom disclosures rather than <select>: a native select's popup is drawn by the
+  // operating system, so it cannot take the toolbar's translucency and blur. These
+  // match Properties and the contents menu instead.
   const navMenu = navLinks.length > 1
-    ? `<select class="toolbar-select" data-nav-picker aria-label="Go to section">${
-      navLinks.map((link) => `<option value="${escapeHtml(link.href)}">${escapeHtml(link.label)}</option>`).join('')
-    }</select>`
+    ? `<details class="doc-properties toolbar-menu" data-nav-menu>
+      <summary class="toolbar-btn" data-nav-label aria-label="Go to section">${escapeHtml(navLinks[0].label)}</summary>
+      <div class="toolbar-menu-list" role="menu">${navLinks.map((link) =>
+        `<a role="menuitem" data-nav-item href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a>`).join('')}</div>
+    </details>`
     : '';
   return `<div class="viewer-toolbar" role="toolbar" aria-label="Viewer controls">
     ${navMenu}
     ${extraButtons}
     ${annotationModeButton}
     ${annotationChip}
-    <select class="toolbar-select" data-theme-picker aria-label="Select color theme">${themeOptions}</select>
+    <details class="doc-properties toolbar-menu" data-theme-menu>
+      <summary class="toolbar-btn" data-theme-label aria-label="Select color theme">Theme</summary>
+      <div class="toolbar-menu-list" role="menu">${themeItems}</div>
+    </details>
     <button type="button" class="toolbar-btn" data-theme-toggle aria-label="Toggle light and dark mode">☀</button>
   </div>`;
 }
@@ -1341,11 +1349,10 @@ function themeScript(cspNonce = null, defaults = {}) {
     (function () {
       var rootEl = document.documentElement;
       var themeToggleBtn = document.querySelector('[data-theme-toggle]');
-      var themePickerEl = document.querySelector('[data-theme-picker]');
+      var themeMenuEl = document.querySelector('[data-theme-menu]');
 
       function applyColorScheme(slug) {
         rootEl.setAttribute('data-color-scheme', slug);
-        if (themePickerEl) themePickerEl.value = slug;
       }
 
       function applyTheme(mode) {
@@ -1376,28 +1383,46 @@ function themeScript(cspNonce = null, defaults = {}) {
         if (window.ResizeObserver) new ResizeObserver(syncToolbarHeight).observe(toolbarEl);
       }
 
-      var navPickerEl = document.querySelector('[data-nav-picker]');
-      if (navPickerEl) {
-        // Select the option whose href is the longest prefix of the current path,
-        // so /forms/gym-strength-entry/entries still reads as "Forms".
+      var navMenuEl = document.querySelector('[data-nav-menu]');
+      if (navMenuEl) {
+        // Label the control with the section whose href is the longest prefix of the
+        // current path, so /forms/gym-strength-entry/entries still reads as "Forms".
         var here = window.location.pathname;
-        var best = null;
-        for (var i = 0; i < navPickerEl.options.length; i += 1) {
-          var candidate = navPickerEl.options[i].value;
+        var navItems = navMenuEl.querySelectorAll('[data-nav-item]');
+        var bestItem = null;
+        for (var i = 0; i < navItems.length; i += 1) {
+          var candidate = navItems[i].getAttribute('href');
           var matches = candidate === '/' ? true : (here === candidate || here.indexOf(candidate + '/') === 0);
-          if (matches && (!best || candidate.length > best.length)) best = candidate;
+          if (matches && (!bestItem || candidate.length > bestItem.getAttribute('href').length)) bestItem = navItems[i];
         }
-        if (best) navPickerEl.value = best;
-        navPickerEl.addEventListener('change', function () {
-          if (navPickerEl.value) window.location.assign(navPickerEl.value);
-        });
+        if (bestItem) {
+          var navLabelEl = navMenuEl.querySelector('[data-nav-label]');
+          if (navLabelEl) navLabelEl.textContent = bestItem.textContent;
+          bestItem.setAttribute('aria-current', 'page');
+        }
       }
 
-      if (themePickerEl) {
-        themePickerEl.addEventListener('change', function () {
-          var scheme = themePickerEl.value;
-          applyColorScheme(scheme);
-          localStorage.setItem('lookie-link-color-scheme', scheme);
+      if (themeMenuEl) {
+        var themeLabelEl = themeMenuEl.querySelector('[data-theme-label]');
+        var themeItems = themeMenuEl.querySelectorAll('[data-theme-item]');
+
+        function labelTheme(slug) {
+          for (var i = 0; i < themeItems.length; i += 1) {
+            var active = themeItems[i].value === slug;
+            themeItems[i].setAttribute('aria-current', active ? 'true' : 'false');
+            if (active && themeLabelEl) themeLabelEl.textContent = themeItems[i].textContent;
+          }
+        }
+
+        labelTheme(rootEl.getAttribute('data-color-scheme') || 'slate');
+
+        themeMenuEl.addEventListener('click', function (event) {
+          var item = event.target.closest('[data-theme-item]');
+          if (!item) return;
+          applyColorScheme(item.value);
+          localStorage.setItem('lookie-link-color-scheme', item.value);
+          labelTheme(item.value);
+          themeMenuEl.open = false;
         });
       }
 

--- a/public/style.css
+++ b/public/style.css
@@ -2485,6 +2485,64 @@ tbody tr:last-child td {
   content: "";
 }
 
+/* Files and theme menus: same surface as the other toolbar menus. Native <select>
+   popups are drawn by the OS and cannot take this treatment, which is why these are
+   custom disclosures. */
+.toolbar-menu .toolbar-menu-list {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 0.5rem);
+  z-index: 40;
+  min-width: 11rem;
+  max-width: min(22rem, calc(100vw - 1.6rem));
+  max-height: min(60vh, 22rem);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.35rem;
+  background: var(--bg-elev);
+  background-color: color-mix(in srgb, color-mix(in srgb, var(--bg-elev) 86%, var(--text-soft)) 84%, transparent);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+/* Menus anchor to the toolbar rather than to their own button, which keeps them on
+   screen at any width. The theme control sits at the right end, so its menu aligns
+   to the right edge -- opening it at the far left, under an unrelated control, reads
+   as belonging to something else. */
+.toolbar-menu[data-theme-menu] .toolbar-menu-list {
+  left: auto;
+  right: 0;
+}
+
+.toolbar-menu .toolbar-menu-list > * {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.86rem;
+  text-align: left;
+  text-decoration: none;
+  padding: 0.4rem 0.6rem;
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.toolbar-menu .toolbar-menu-list > *:hover,
+.toolbar-menu .toolbar-menu-list > *:focus-visible {
+  background: var(--toolbar-btn-hover);
+}
+
+.toolbar-menu .toolbar-menu-list > [aria-current="true"],
+.toolbar-menu .toolbar-menu-list > [aria-current="page"] {
+  color: var(--accent);
+  font-weight: 700;
+}
+
 /* The contents menu shares the Properties menu shell but holds a long list, so it
    scrolls internally rather than growing past the viewport. */
 .toolbar-toc .toc-list {

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -486,3 +486,41 @@ browserTest('the contents menu opens over the document instead of replacing it',
   assert.ok(state.onScreen, 'the contents menu stays on screen');
   assert.ok(state.scrollsInternally, 'a long contents list scrolls inside the menu');
 });
+
+browserTest('theme and section menus behave like menus, not native selects', async ({page, fixture}) => {
+  await page.setViewportSize({width: 1200, height: 800});
+  await page.goto(`${fixture.origin}/view/docs/guides/a-fairly-long-document-name.md`, {waitUntil: 'networkidle'});
+
+  // The section menu labels itself with where you are.
+  const navLabel = await page.textContent('[data-nav-label]');
+  assert.equal(navLabel.trim(), 'Files', 'a document page reads as Files');
+
+  // Switching theme through the menu applies it, persists it, and relabels.
+  await page.click('[data-theme-menu] > summary');
+  await page.waitForSelector('[data-theme-item]');
+  const target = await page.$('[data-theme-item][value="nord"]');
+  if (target) {
+    await target.click();
+    await page.waitForTimeout(120);
+    const state = await page.evaluate(() => ({
+      scheme: document.documentElement.getAttribute('data-color-scheme'),
+      stored: localStorage.getItem('lookie-link-color-scheme'),
+      label: document.querySelector('[data-theme-label]').textContent.trim(),
+      open: document.querySelector('[data-theme-menu]').open,
+    }));
+    assert.equal(state.scheme, 'nord', 'theme applied');
+    assert.equal(state.stored, 'nord', 'theme persisted');
+    assert.equal(state.label, 'Nord', 'control relabels to the active theme');
+    assert.equal(state.open, false, 'menu closes after choosing');
+  }
+
+  // Menus stay on screen at phone width.
+  await page.setViewportSize({width: 390, height: 800});
+  await page.click('[data-nav-menu] > summary');
+  await page.waitForTimeout(120);
+  const box = await page.evaluate(() => {
+    const list = document.querySelector('[data-nav-menu] .toolbar-menu-list').getBoundingClientRect();
+    return {left: list.left, right: list.right, viewport: window.innerWidth};
+  });
+  assert.ok(box.left >= 0 && box.right <= box.viewport, 'section menu stays on screen at 390px');
+});

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -517,33 +517,31 @@ test('builder offers server-installed themes, saves the choice, and refuses one 
   }
 });
 
-test('toolbar section picker offers Files and Forms and disappears when there is nowhere to choose between', async () => {
+test('toolbar section menu offers Files and Forms and disappears when there is nowhere to choose between', async () => {
   const {setNavLinks, toolbarHtml} = require('../lib/renderer');
 
   const server = await makeServer();
   try {
     const page = await browserPage(await server.request('/forms/training-log'));
-    const picker = page.document.querySelector('[data-nav-picker]');
-    assert.ok(picker, 'section picker is present');
-    // Same control as the theme picker, so it looks and behaves identically.
-    assert.ok(picker.classList.contains('toolbar-select'));
-    assert.equal(picker.tagName, 'SELECT');
-    assert.deepEqual([...picker.options].map((option) => option.textContent), ['Files', 'Forms']);
-    assert.deepEqual([...picker.options].map((option) => option.value), ['/', '/forms']);
-    assert.doesNotMatch(page.html, /onchange=/i);
+    const menu = page.document.querySelector('[data-nav-menu]');
+    assert.ok(menu, 'section menu is present');
+    // A custom disclosure, not a native select: an OS-drawn popup cannot take the
+    // toolbar's translucency and blur.
+    assert.equal(menu.tagName, 'DETAILS');
+    const items = [...menu.querySelectorAll('[data-nav-item]')];
+    assert.deepEqual(items.map((item) => item.textContent), ['Files', 'Forms']);
+    assert.deepEqual(items.map((item) => item.getAttribute('href')), ['/', '/forms']);
+    assert.doesNotMatch(page.html, /onchange=|onclick=/i);
   } finally {
     await server.close();
   }
 
-  // One destination is not a choice, so the control is omitted rather than
-  // rendered with a single entry.
   setNavLinks([{href: '/', label: 'Files'}]);
-  assert.ok(!toolbarHtml().includes('data-nav-picker'), 'single destination renders no picker');
+  assert.ok(!toolbarHtml().includes('data-nav-menu'), 'single destination renders no menu');
 
   setNavLinks([{href: '/', label: 'Files'}, {href: '/forms', label: 'Forms'}]);
-  assert.ok(toolbarHtml().includes('data-nav-picker'), 'two destinations render the picker');
+  assert.ok(toolbarHtml().includes('data-nav-menu'), 'two destinations render the menu');
 
-  // Malformed entries are dropped rather than emitted as broken options.
   setNavLinks([{href: '/', label: 'Files'}, {label: 'No href'}, {href: '/forms', label: 'Forms'}]);
   assert.doesNotMatch(toolbarHtml(), /No href/);
   setNavLinks([]);

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -154,7 +154,7 @@ function browserContext(response, html) {
 function assertSharedFormsShell(response, html, customThemeMarker) {
   const document = new JSDOM(html).window.document;
   assert.ok(document.querySelector('link[rel="stylesheet"][href="/public/style.css"]'));
-  assert.ok(document.querySelector('[data-theme-picker]'));
+  assert.ok(document.querySelector('[data-theme-menu]'));
   assert.ok(document.querySelector('[data-theme-toggle]'));
   assert.match(html, /lookie-link-color-scheme/);
   assert.match(html, new RegExp(customThemeMarker));


### PR DESCRIPTION
Files and Themes were native `<select>` elements, whose popup lists are drawn by the operating system. CSS cannot give those translucency or a backdrop blur — so while every other toolbar menu picked up the treatment, those two stayed OS-styled.

Both are now custom disclosures matching Properties and the contents menu.

## Behaviour preserved

- **Section menu** still labels itself with where you are, by longest-prefix match, so `/forms/gym-strength-entry/entries` reads as **Forms**. Entries are plain links, so navigation needs no script.
- **Theme menu** applies the theme, persists it, relabels the control, marks the active entry, and closes. The active entry is highlighted in the accent colour.

## Anchoring

Menus anchor to the toolbar rather than to their own button, which is what keeps them on screen at any width. The theme control sits at the right end, so its menu aligns to the **right** edge — anchored left it opened at the far left of the bar, under an unrelated control, reading as if it belonged to something else.

Verified at 1200px and 390px: each menu sits over its own button and stays fully on screen.

## Trade-off, stated plainly

This gives up the native mobile picker wheel that a `<select>` provides for free. Menu entries are real links and buttons, so they stay keyboard-focusable, but a native select's full keyboard and mobile behaviour is not reproduced.

**Mutation-verified twice**: a theme choice that does not persist fails; a menu that does not close after choosing fails.

188/188 unit, 9/9 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
