### PR TITLE
fix(viewer): align the new toolbar menus and show every theme

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2465,8 +2465,13 @@ tbody tr:last-child td {
 /* In the toolbar the control sits beside Files, the theme picker and Annotate, so
    it must not take part in the toolbar's flex flow when open -- the panel is
    anchored beneath the toolbar instead of stretching it. */
+/* Every toolbar disclosure. Each carries .doc-properties for the shared menu shell,
+   which brings a standalone top margin -- that margin pushes the control down AND
+   stops it stretching to the flex line height. Adding a new menu without listing it
+   here has now caused that misalignment twice. */
 .toolbar-properties,
-.toolbar-toc {
+.toolbar-toc,
+.toolbar-menu {
   /* No positioning context here on purpose: the panel anchors to .viewer-toolbar
      (position:fixed, so it is a containing block) and spans its width. Anchoring to
      the button instead pushed the panel off the left edge when right-aligned and off
@@ -2495,7 +2500,7 @@ tbody tr:last-child td {
   z-index: 40;
   min-width: 11rem;
   max-width: min(22rem, calc(100vw - 1.6rem));
-  max-height: min(60vh, 22rem);
+  max-height: min(72vh, 32rem);
   overflow-y: auto;
   display: flex;
   flex-direction: column;

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -524,3 +524,55 @@ browserTest('theme and section menus behave like menus, not native selects', asy
   });
   assert.ok(box.left >= 0 && box.right <= box.viewport, 'section menu stays on screen at 390px');
 });
+
+browserTest('every toolbar control sits on the same line', async ({page, fixture}) => {
+  // Each disclosure carries .doc-properties for the shared menu shell, which brings a
+  // standalone top margin. Forgetting to reset it for a NEW menu pushes that control
+  // down and stops it stretching to the line height. That has happened twice, so it
+  // is asserted for every control rather than for the ones that broke.
+  await page.setViewportSize({width: 1200, height: 800});
+  await page.goto(`${fixture.origin}/view/docs/guides/a-fairly-long-document-name.md`, {waitUntil: 'networkidle'});
+
+  const controls = await page.evaluate(() => {
+    const bar = document.querySelector('.viewer-toolbar').getBoundingClientRect();
+    return [...document.querySelectorAll('.viewer-toolbar > *')].map((el) => ({
+      label: (el.textContent || '').trim().slice(0, 16) || el.tagName,
+      top: Math.round(el.getBoundingClientRect().top - bar.top),
+      height: Math.round(el.getBoundingClientRect().height),
+    }));
+  });
+
+  assert.ok(controls.length > 3, 'expected a populated toolbar');
+  const offsets = [...new Set(controls.map((c) => c.top))];
+  assert.equal(offsets.length, 1, `controls must share one top offset, got ${JSON.stringify(controls)}`);
+  const heights = [...new Set(controls.map((c) => c.height))];
+  assert.equal(heights.length, 1, `controls must share one height, got ${JSON.stringify(controls)}`);
+});
+
+browserTest('the theme menu shows every installed theme without silent truncation', async ({page, fixture}) => {
+  // The fixture would otherwise carry only the built-in themes, which fit in any
+  // plausible height -- so it could not reproduce a deployment with custom themes
+  // installed, which is exactly where the list started hiding entries.
+  const {setThemeList, getThemeList} = require('../../lib/renderer.js');
+  const installed = getThemeList();
+  setThemeList([...installed, ...['alpha', 'beta', 'gamma', 'delta'].map((slug) => ({slug, label: `Theme ${slug}`}))]);
+
+  await page.setViewportSize({width: 1200, height: 800});
+  await page.goto(`${fixture.origin}/view/docs/guides/a-fairly-long-document-name.md`, {waitUntil: 'networkidle'});
+  await page.click('[data-theme-menu] > summary');
+  await page.waitForSelector('[data-theme-item]');
+
+  const menu = await page.evaluate(() => {
+    const list = document.querySelector('[data-theme-menu] .toolbar-menu-list');
+    return {items: list.children.length, scrollHeight: list.scrollHeight, clientHeight: list.clientHeight};
+  });
+
+  assert.ok(menu.items >= 10, 'expected the built-in themes at least');
+  // Scrolling is acceptable, but not while there is room to show them.
+  assert.ok(
+    menu.scrollHeight <= menu.clientHeight + 1,
+    `all ${menu.items} themes should fit (needs ${menu.scrollHeight}px, has ${menu.clientHeight}px)`
+  );
+
+  setThemeList(installed);
+});


### PR DESCRIPTION
Two defects from #216, both measured.

## Files and the theme control sat lower than everything else

`top: 15, height: 25` against `top: 7, height: 33` for every other control.

Cause: each toolbar disclosure carries `.doc-properties` for the shared menu shell, which brings a standalone top margin. That margin both pushes the control down and stops it stretching to the flex line height. The reset listed `.toolbar-properties` and `.toolbar-toc` — I added two new menus and did not add them to it.

**This is the second time this exact mistake shipped** (the contents button in #213), so the reset now covers every menu, and there is a test asserting *every* toolbar control shares one top offset and one height — rather than testing the ones that happened to break.

## Not all themes were visible

13 items needing 414px inside a 352px box. It scrolled, but silently — nothing indicated there was more.

Raised to `min(72vh, 32rem)` so an installed set fits without scrolling.

## Both mutation-verified

- Removing `.toolbar-menu` from the reset fails, printing every control's offset
- Shrinking the list back fails: `all 14 themes should fit (needs 487px, has 350px)`

The second needed the fixture fixed first: it carries only the 10 built-in themes, which fit in any plausible height, so it could not reproduce a deployment with custom themes installed. The test now registers extra themes to mirror one.

188/188 unit, 11/11 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
