### PR TITLE
fix(viewer): label the theme control before script runs, not after

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -350,6 +350,8 @@ function generateCustomThemeCss(themes) {
     if (Object.keys(theme.dark).length > 0) {
       const vars = Object.entries(theme.dark).map(([k, v]) => `  --${k}: ${v};`).join('\n');
       blocks.push(`:root[data-color-scheme="${theme.slug}"] {\n  color-scheme: dark;\n${vars}\n}`);
+      // Reveal this theme's name in the toolbar label without waiting for script.
+      blocks.push(`:root[data-color-scheme="${theme.slug}"] [data-theme-name="${theme.slug}"] { display: inline; }`);
     }
     if (Object.keys(theme.light).length > 0) {
       const vars = Object.entries(theme.light).map(([k, v]) => `  --${k}: ${v};`).join('\n');

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1300,6 +1300,13 @@ function getThemeList() {
 
 function toolbarHtml(extraButtons = '', options = {}) {
   const themes = getThemeList();
+  // Every theme name is rendered; CSS reveals the one matching the root's
+  // data-color-scheme, which the head script sets before the page paints. A
+  // script-assigned label flashed a placeholder first -- the page rendered before
+  // it knew which theme was active.
+  const themeNames = themes.map((theme) =>
+    `<span data-theme-name="${escapeHtml(theme.slug)}">${escapeHtml(theme.label)}</span>`
+  ).join('');
   const themeItems = themes.map((theme) =>
     `<button type="button" role="menuitem" data-theme-item value="${escapeHtml(theme.slug)}">${escapeHtml(theme.label)}</button>`
   ).join('');
@@ -1326,7 +1333,7 @@ function toolbarHtml(extraButtons = '', options = {}) {
     ${annotationModeButton}
     ${annotationChip}
     <details class="doc-properties toolbar-menu" data-theme-menu>
-      <summary class="toolbar-btn" data-theme-label aria-label="Select color theme">Theme</summary>
+      <summary class="toolbar-btn" data-theme-label aria-label="Select color theme">${themeNames}</summary>
       <div class="toolbar-menu-list" role="menu">${themeItems}</div>
     </details>
     <button type="button" class="toolbar-btn" data-theme-toggle aria-label="Toggle light and dark mode">☀</button>
@@ -1407,10 +1414,10 @@ function themeScript(cspNonce = null, defaults = {}) {
         var themeItems = themeMenuEl.querySelectorAll('[data-theme-item]');
 
         function labelTheme(slug) {
+          // Only the active marker needs setting; the visible label is CSS-driven
+          // off :root[data-color-scheme], so it updates the moment the theme does.
           for (var i = 0; i < themeItems.length; i += 1) {
-            var active = themeItems[i].value === slug;
-            themeItems[i].setAttribute('aria-current', active ? 'true' : 'false');
-            if (active && themeLabelEl) themeLabelEl.textContent = themeItems[i].textContent;
+            themeItems[i].setAttribute('aria-current', themeItems[i].value === slug ? 'true' : 'false');
           }
         }
 

--- a/public/style.css
+++ b/public/style.css
@@ -2490,6 +2490,31 @@ tbody tr:last-child td {
   content: "";
 }
 
+/* The toolbar renders every theme's name and CSS reveals the active one, keyed off
+   the data-color-scheme the head script sets before first paint. Assigning the label
+   from script instead meant the control rendered before it knew which theme was
+   active, showing a placeholder first. Custom themes emit their own rule from
+   lib/config.js alongside their variables. */
+.toolbar-menu [data-theme-name] {
+  display: none;
+}
+
+:root[data-color-scheme="slate"] [data-theme-name="slate"] { display: inline; }
+:root[data-color-scheme="teal"] [data-theme-name="teal"] { display: inline; }
+:root[data-color-scheme="nord"] [data-theme-name="nord"] { display: inline; }
+:root[data-color-scheme="rose-pine"] [data-theme-name="rose-pine"] { display: inline; }
+:root[data-color-scheme="monokai"] [data-theme-name="monokai"] { display: inline; }
+:root[data-color-scheme="solarized"] [data-theme-name="solarized"] { display: inline; }
+:root[data-color-scheme="github"] [data-theme-name="github"] { display: inline; }
+:root[data-color-scheme="ember"] [data-theme-name="ember"] { display: inline; }
+:root[data-color-scheme="noir"] [data-theme-name="noir"] { display: inline; }
+:root[data-color-scheme="indigo"] [data-theme-name="indigo"] { display: inline; }
+
+/* Nothing matched -- an unknown or not-yet-applied scheme still needs a label. */
+:root:not([data-color-scheme]) [data-theme-name="slate"] {
+  display: inline;
+}
+
 /* Files and theme menus: same surface as the other toolbar menus. Native <select>
    popups are drawn by the OS and cannot take this treatment, which is why these are
    custom disclosures. */

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -505,7 +505,9 @@ browserTest('theme and section menus behave like menus, not native selects', asy
     const state = await page.evaluate(() => ({
       scheme: document.documentElement.getAttribute('data-color-scheme'),
       stored: localStorage.getItem('lookie-link-color-scheme'),
-      label: document.querySelector('[data-theme-label]').textContent.trim(),
+      // innerText, not textContent: every theme name is in the DOM and CSS reveals
+      // one, so textContent would concatenate all of them.
+      label: document.querySelector('[data-theme-label]').innerText.trim(),
       open: document.querySelector('[data-theme-menu]').open,
     }));
     assert.equal(state.scheme, 'nord', 'theme applied');
@@ -575,4 +577,40 @@ browserTest('the theme menu shows every installed theme without silent truncatio
   );
 
   setThemeList(installed);
+});
+
+browserTest('the theme control is labelled before script runs, not after', async ({page, fixture}) => {
+  // Regression: the label used to be assigned by script, so the control rendered
+  // showing a placeholder and only became correct once JS ran -- visible as a flash,
+  // and permanently wrong if the script never got there. It is now server-rendered
+  // for every theme with CSS revealing the active one, keyed off the attribute the
+  // head script sets before first paint.
+  await page.goto(`${fixture.origin}/view/docs/guides/a-fairly-long-document-name.md`, {waitUntil: 'domcontentloaded'});
+  await page.evaluate(() => localStorage.setItem('lookie-link-color-scheme', 'nord'));
+  await page.reload({waitUntil: 'networkidle'});
+
+  const state = await page.evaluate(() => {
+    const summary = document.querySelector('[data-theme-label]');
+    const names = [...summary.querySelectorAll('[data-theme-name]')];
+    return {
+      total: names.length,
+      visible: names.filter((n) => getComputedStyle(n).display !== 'none').map((n) => n.textContent),
+      label: summary.innerText.trim(),
+    };
+  });
+
+  assert.ok(state.total >= 10, 'every theme name is rendered, not just the active one');
+  assert.deepEqual(state.visible, ['Nord'], 'exactly one name is revealed, by CSS');
+  assert.equal(state.label, 'Nord');
+
+  // Choosing a theme must relabel without a script assignment.
+  await page.click('[data-theme-menu] > summary');
+  await page.waitForSelector('[data-theme-item]');
+  await page.click('[data-theme-item][value="ember"]');
+  await page.waitForTimeout(100);
+  assert.equal(
+    await page.evaluate(() => document.querySelector('[data-theme-label]').innerText.trim()),
+    'Ember',
+    'the label follows the applied theme'
+  );
 });


### PR DESCRIPTION
The theme control rendered with the literal placeholder **"Theme"** and only became correct once script ran — a visible flash on every load, and permanently wrong if the script never got there. Converting the picker from a `<select>` to a custom menu in #216 introduced it: the select at least showed a plausible theme name.

## Fixed without adding script

The server now renders **every** theme's name, and CSS reveals the one matching `:root[data-color-scheme]` — the attribute the head script already sets *before first paint*. So the control is correctly labelled in the first frame.

Custom themes emit their reveal rule from `lib/config.js` alongside their variables, so a deployment's own themes work the same way. A fallback covers the case where no scheme is set at all.

Choosing a theme now relabels with **no script assignment**: the root attribute changes and CSS follows. The handler only marks `aria-current`.

Considered and rejected: an early inline script placed after the toolbar. `/view` has no CSP but forms pages run `script-src 'nonce-…'`, so it would have meant threading a nonce through every `toolbarHtml` call site to fix a flash — more machinery than the problem warranted.

## A gotcha worth recording

An existing test broke, correctly: it read the label with `textContent`, which **ignores CSS** and so returned every hidden theme name concatenated (`SlateTealNordRosePine…`). `innerText` respects `display: none`. Any assertion about what a user can *see* needs `innerText`.

Mutation-verified: removing the reveal rule for a theme fails the new test.

188/188 unit, 12/12 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
