### PR TITLE
feat(viewer): breadcrumb on forms, colour the current file, highlight open menus

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -115,6 +115,18 @@ function formHeaders(res, cspNonce) {
   ].join('; '));
 }
 
+function formBreadcrumbs(template, options = {}) {
+  const crumbs = [`<a href="/forms">Forms</a>`];
+  if (template) {
+    const href = `/forms/${encodeURIComponent(template.templateId)}`;
+    const label = options.leadLabel ? escapeHtml(options.leadLabel) : escapeHtml(template.title);
+    crumbs.push(`<h1 class="crumb-title"><a href="${href}" aria-current="page">${label}</a></h1>`);
+  } else if (options.leadLabel) {
+    crumbs.push(`<h1 class="crumb-title"><span aria-current="page">${escapeHtml(options.leadLabel)}</span></h1>`);
+  }
+  return `<nav class="breadcrumbs">${crumbs.join('<span class="sep">/</span>')}</nav>`;
+}
+
 function formHubNav(templateId, active, canManage) {
   const formHref = `/forms/${encodeURIComponent(templateId)}`;
   const links = [
@@ -374,8 +386,7 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">
-      <h1>${escapeHtml(template.title)}</h1>
-      <p><a class="back" href="/">Back</a></p>
+      ${formBreadcrumbs(template)}
       ${formHubNav(template.templateId, 'log', options.canManage)}
     </header>
 
@@ -469,9 +480,7 @@ function renderReceiptPage(template, record, options = {}) {
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">
-      <h1>Entry logged</h1>
-      <p class="subtitle">${template ? escapeHtml(template.title) : 'Form receipt'}</p>
-      <p><a class="back" href="/">Back</a></p>
+      ${formBreadcrumbs(template, {leadLabel: template ? undefined : 'Form receipt'})}
     </header>
 
     <section class="content form-card receipt-card">
@@ -620,8 +629,7 @@ function renderEntriesPage(template, records, options = {}) {
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout entries-layout">
     <header class="topbar">
-      <h1>All entries</h1>
-      <p class="subtitle">${escapeHtml(template.title)}</p>
+      ${formBreadcrumbs(template)}
       ${formHubNav(template.templateId, 'history', options.canManage)}
     </header>
     <section class="content form-card entries-card">${content}</section>
@@ -768,8 +776,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   const body = `${toolbarHtml(formProperties(record))}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
-      <p class="eyebrow">Form builder</p>
-      <h1>${escapeHtml(template.title)}</h1>
+      ${formBreadcrumbs(template)}
       ${formHubNav(template.templateId, 'configure', true)}
     </header>
     <section class="content form-card builder-card">
@@ -889,7 +896,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
   ).join('');
   const body = `${toolbarHtml()}
   <main class="layout form-layout builder-layout">
-    <header class="topbar"><p class="eyebrow"><a href="/forms">Forms</a></p><h1>New template</h1></header>
+    <header class="topbar">${formBreadcrumbs(null, {leadLabel: 'New template'})}</header>
     <section class="content form-card builder-card first-run-card">
       <p>Create a draft with one starter field. You can edit its fields immediately afterward.</p>
       ${builderErrors(options.errors)}
@@ -915,7 +922,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
 function renderArchivedFormPage(template, options = {}) {
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
-    <header class="topbar"><p class="eyebrow">Archived form</p><h1>${escapeHtml(template.title)}</h1>${formHubNav(template.templateId, 'log', options.canManage)}</header>
+    <header class="topbar">${formBreadcrumbs(template)}${formHubNav(template.templateId, 'log', options.canManage)}</header>
     <section class="content form-card archived-form-state"><h2>This form is archived</h2><p>It is not accepting new entries. Existing history and receipts are still available.</p><a class="button-link" href="/forms/${encodeURIComponent(template.templateId)}/entries">View history</a></section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;

--- a/public/style.css
+++ b/public/style.css
@@ -2283,6 +2283,11 @@ tbody tr:last-child td {
 .lookie-annotate-btn:hover, .lookie-annotate-btn:focus {
   opacity: 1; color: var(--accent); border-color: var(--accent);
 }
+.doc-properties[open] > summary.toolbar-btn {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .toolbar-btn-annotation-count[aria-pressed="true"],
 [data-annotation-mode-toggle][aria-pressed="true"] {
   border-color: var(--accent);
@@ -2441,12 +2446,19 @@ tbody tr:last-child td {
 .breadcrumbs .crumb-title {
   display: inline;
   margin: 0;
-  font-size: 1.35rem;
-  font-weight: 700;
-  line-height: 1.2;
+  /* Same size and weight as the rest of the trail; the current file is marked by
+     colour, not by growing. It is the last segment, so its position already says
+     it is where you are. */
+  font-size: inherit;
+  font-weight: 600;
+  line-height: inherit;
 }
 
 .breadcrumbs .crumb-title a {
+  /* The current file uses the main text colour, not the accent: body text is
+     distinct from the link colour in every theme by design (that is what makes a
+     link identifiable), so the filename always reads apart from the path -- even in
+     themes where accent and link are near-identical, as in The BIC. */
   color: var(--text);
   text-decoration: none;
 }

--- a/test/browser/forms.spec.mjs
+++ b/test/browser/forms.spec.mjs
@@ -351,7 +351,10 @@ browserTest('machine strength entry reaches its receipt and entries list', async
     page.locator('.form-primary-action').click(),
   ]);
 
-  assert.equal((await page.locator('h1').textContent()).trim(), 'Entry logged');
+  // The receipt header is now a breadcrumb ending in the form title, not a bare
+  // "Entry logged" heading; the receipt table below confirms the submission landed.
+  assert.equal((await page.locator('.crumb-title').textContent()).trim(), TEMPLATE_TITLE);
+  assert.equal((await page.locator('.breadcrumbs a[href="/forms"]').textContent()).trim(), 'Forms');
   const receipt = Object.fromEntries(await page.locator('.receipt-table tbody tr').evaluateAll((rows) =>
     rows.map((row) => {
       const label = row.querySelector('th').textContent.trim();

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -637,9 +637,10 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     const formHtml = await formResponse.text();
     const formDocument = assertSharedFormsShell(formResponse, formHtml, customThemeMarker);
     const context = browserContext(formResponse, formHtml);
-    assert.equal(formDocument.querySelector('.topbar h1').textContent, 'Gym Session Entry');
-    assert.equal(formDocument.querySelector('.topbar .subtitle'), null);
-    assert.equal(formDocument.querySelector('.topbar .back').getAttribute('href'), '/');
+    // Header is a breadcrumb ending in the form title (the coloured current crumb),
+    // matching the document header. Sub-view is shown by the hub-nav tabs.
+    assert.equal(formDocument.querySelector('.topbar .crumb-title').textContent, 'Gym Session Entry');
+    assert.equal(formDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]').textContent, 'Forms');
     assert.equal(formDocument.querySelector('.form-primary-action').textContent, 'Submit');
     assert.equal(formDocument.querySelector('label[for="field-notes"]').textContent, '<em>Notes</em> *');
     assert.match(formHtml, /&lt;em&gt;Notes&lt;\/em&gt;/);
@@ -665,8 +666,8 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     assert.equal(receiptResponse.status, 200);
     const receiptHtml = await receiptResponse.text();
     const receiptDocument = assertSharedFormsShell(receiptResponse, receiptHtml, customThemeMarker);
-    assert.equal(receiptDocument.querySelector('.topbar h1').textContent, 'Entry logged');
-    assert.equal(receiptDocument.querySelector('.topbar .back').getAttribute('href'), '/');
+    assert.equal(receiptDocument.querySelector('.topbar .crumb-title').textContent, 'Gym Session Entry');
+    assert.equal(receiptDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]').textContent, 'Forms');
     assert.equal(
       receiptDocument.querySelector('.form-primary-action').getAttribute('href'),
       '/forms/gym-session-entry'


### PR DESCRIPTION
Three related header changes.

## Forms get a breadcrumb, like documents

Form pages showed a bare `<h1>` and an ad-hoc "Back" link, and the several form views (form, receipt, entries, configure, archived) each built the header slightly differently. They now share one `formBreadcrumbs` helper rendering `Forms / <template title>`, matching the document header. The sub-view (Log / History / Configure) is already shown by the hub-nav tabs, so it does not need a third crumb.

## The current file is marked by colour, not size

The last breadcrumb segment was rendered `1.35rem` bold. It is now the same size and weight as the rest of the trail, distinguished by **colour** — its position as the last segment already says it is where you are.

The colour is `--text`, not `--accent`. Body text is distinct from the link colour in every theme by design — that is what makes a link identifiable — so the filename always reads apart from the path. `--accent` would have collided in themes where accent and link are near-identical, which is exactly the case in The BIC (both green). Verified distinct across The BIC, Planet Fitness, and Folly Beach.

## An open menu highlights its button

Clicking Files, Properties, Contents or Themes now marks the summary in the accent colour while its menu is open, the way Annotate marks its pressed state — so it is obvious which menu is open. One CSS rule on `[open] > summary`.

## Tests

Form-header assertions updated from the old `.topbar h1` / `.back` structure to the breadcrumb — they failed correctly, that is the structure changing.

188/188 unit, 11/11 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
