### PR TITLE
fix(embed): click-gated top navigation so rewritten links work in /view (#232)

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -12,6 +12,7 @@ const MAX_CONTEXTS = 10000;
 const MAX_STEPPED_OPTIONS = 200;
 const RECENT_ENTRY_LIMIT = 3;
 const ARTIFACT_SANDBOX = 'sandbox allow-scripts allow-forms allow-popups';
+const EMBED_SANDBOX = `${ARTIFACT_SANDBOX} allow-top-navigation-by-user-activation`; // #232 — mirrors server.js
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const TEMPLATE_CREATE_KEYS = new Set([
   'templateId', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
@@ -1591,7 +1592,7 @@ function createFormsRouter(options) {
     next();
   });
   router.use('/embed', (_req, res, next) => {
-    res.set('Content-Security-Policy', ARTIFACT_SANDBOX);
+    res.set('Content-Security-Policy', EMBED_SANDBOX);
     next();
   });
   router.use('/forms', refuseQueryToken);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1739,7 +1739,7 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
         class="embedded-html-frame"
         title="${escapeHtml(relativePath)}"
         data-embedded-html
-        sandbox="allow-scripts allow-forms allow-popups"
+        sandbox="allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation"
         src="${escapeHtml(embedHtmlHref)}"
         loading="lazy"
       ></iframe>

--- a/scripts/validate-raw-html.js
+++ b/scripts/validate-raw-html.js
@@ -177,7 +177,8 @@ async function run() {
       );
       assert.equal(embedResp.status, 200, '/embed/<.html> should 200 when enabled');
       assert.equal(embedResp.headers['x-lookie-content-mode'], 'transformed-embed');
-      assert.equal(embedResp.headers['content-security-policy'], 'sandbox allow-scripts allow-forms allow-popups');
+      // #232: /embed grants click-gated top navigation so rewritten target="_top" links work in the /view frame.
+      assert.equal(embedResp.headers['content-security-policy'], 'sandbox allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation');
       assert.match(embedResp.text, /<base href="\/asset\/docs\/">/, '/embed injects an opaque asset base');
       assert.match(embedResp.text, /id="lookie-link-embed-theme"/, '/embed injects theme tokens');
       assert.match(embedResp.text, /data-lookie-link-theme="light"/, '/embed accepts the framed theme mode');
@@ -234,7 +235,7 @@ async function run() {
       assert.match(embedFrameTag[0], /src="\/embed\/docs\/flashcards\.html"/);
       assert.match(
         embedFrameTag[0],
-        /sandbox="allow-scripts allow-forms allow-popups"/,
+        /sandbox="allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation"/,
         '/view applies the opaque-origin sandbox to the embed frame'
       );
       assert.doesNotMatch(viewEnabled.text, /sandbox="[^"]*allow-same-origin/);

--- a/server.js
+++ b/server.js
@@ -316,6 +316,13 @@ function sendAccessError(res, accessContext, asJson = false) {
 // origin; allow-same-origin must never be added (ADR-92 B1 + operator decision).
 const ARTIFACT_SANDBOX = 'sandbox allow-scripts allow-forms allow-popups';
 
+// The /embed document additionally gets click-gated top navigation so the link
+// rewriter's target="_top" links actually work inside the /view frame (#232).
+// This does NOT weaken the opaque-origin boundary: no allow-same-origin, and
+// navigation requires a real user gesture. /raw and scriptable assets keep the
+// stricter ARTIFACT_SANDBOX.
+const EMBED_SANDBOX = `${ARTIFACT_SANDBOX} allow-top-navigation-by-user-activation`;
+
 // Asset MIME types a browser will execute as a document when navigated to
 // directly (SVG carries <script>; HTML/XHTML/XML can execute inline or via
 // XSLT). Served same-origin these are the same write primitive as /embed was,
@@ -2611,7 +2618,7 @@ function createApp(options = {}) {
         ),
       });
       res.set('X-Lookie-Content-Mode', 'transformed-embed');
-      res.set('Content-Security-Policy', ARTIFACT_SANDBOX);
+      res.set('Content-Security-Policy', EMBED_SANDBOX);
       res.status(200).type(RAW_HTML_MIME_TYPE).send(html);
     } catch (error) {
       console.error('Failed to transform embed HTML', { repo, relativePath, error });

--- a/test/artifact-sandbox.test.js
+++ b/test/artifact-sandbox.test.js
@@ -13,7 +13,10 @@ const { createApp } = require('../server.js');
 // those scripts can drive first-party mutations (/api/save, annotations, forms)
 // using the viewer's own credentials — proven exploitable before this guard.
 // The CSP sandbox forces an opaque origin. allow-same-origin must NEVER appear.
-const EXPECTED = 'sandbox allow-scripts allow-forms allow-popups';
+// /embed additionally grants click-gated top navigation (#232) so the link
+// rewriter's target="_top" links work inside the /view frame; /raw does not.
+const EXPECTED_RAW = 'sandbox allow-scripts allow-forms allow-popups';
+const EXPECTED_EMBED = `${EXPECTED_RAW} allow-top-navigation-by-user-activation`;
 
 async function withServer(run) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-sandbox-'));
@@ -39,13 +42,17 @@ async function withServer(run) {
 
 test('artifact HTML is served with an opaque-origin CSP sandbox on /raw and /embed', async () => {
   await withServer(async (origin) => {
-    for (const route of ['raw', 'embed']) {
+    const expectations = { raw: EXPECTED_RAW, embed: EXPECTED_EMBED };
+    for (const [route, expected] of Object.entries(expectations)) {
       const response = await fetch(`${origin}/${route}/docs/artifact.html`);
       assert.equal(response.status, 200, `${route} should serve the artifact`);
       const csp = response.headers.get('content-security-policy');
-      assert.equal(csp, EXPECTED, `${route} must carry the exact artifact sandbox`);
+      assert.equal(csp, expected, `${route} must carry the exact artifact sandbox`);
       assert.ok(!/allow-same-origin/.test(csp), `${route} must never grant allow-same-origin`);
     }
+    // negative canary: /raw must NOT gain top-navigation — it is the stricter surface
+    const rawCsp = (await fetch(`${origin}/raw/docs/artifact.html`)).headers.get('content-security-policy');
+    assert.ok(!/allow-top-navigation/.test(rawCsp), '/raw must not grant any top-navigation');
   });
 });
 
@@ -54,7 +61,7 @@ test('the /view wrapper frames the embedded artifact with a sandbox attribute', 
     const html = await (await fetch(`${origin}/view/docs/artifact.html`)).text();
     const iframe = html.match(/<iframe[^>]*data-embedded-html[^>]*>/);
     assert.ok(iframe, '/view should frame the artifact');
-    assert.match(iframe[0], /sandbox="allow-scripts allow-forms allow-popups"/);
+    assert.match(iframe[0], /sandbox="allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation"/);
     assert.ok(!/allow-same-origin/.test(iframe[0]), 'iframe must never grant allow-same-origin');
   });
 });
@@ -77,7 +84,7 @@ test('scriptable asset MIME types are sandboxed on /asset; ordinary files are no
   const origin = `http://127.0.0.1:${server.address().port}`;
   try {
     const svg = await fetch(`${origin}/asset/docs/diagram.svg`);
-    assert.equal(svg.headers.get('content-security-policy'), EXPECTED, 'SVG must be sandboxed');
+    assert.equal(svg.headers.get('content-security-policy'), EXPECTED_RAW, 'SVG must be sandboxed');
     assert.ok(!/allow-same-origin/.test(svg.headers.get('content-security-policy')));
     assert.equal(svg.headers.get('x-content-type-options'), 'nosniff');
 

--- a/test/embed-html.test.js
+++ b/test/embed-html.test.js
@@ -223,7 +223,7 @@ test('document viewer frames HTML through embed while retaining a distinct raw-s
   const embedFrame = html.match(/<iframe[^>]*data-embedded-html[^>]*>/);
   assert.ok(embedFrame, 'the viewer should frame the embed route');
   assert.match(embedFrame[0], /src="\/embed\/alpha\/docs\/page\.html"/);
-  assert.match(embedFrame[0], /sandbox="allow-scripts allow-forms allow-popups"/);
+  assert.match(embedFrame[0], /sandbox="allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation"/);
   assert.doesNotMatch(html, /sandbox="[^"]*allow-same-origin/);
   assert.match(html, /href="\/embed\/alpha\/docs\/page\.html"[^>]*>Open embedded<\/a>/);
   assert.match(html, /href="\/raw\/alpha\/docs\/page\.html"[^>]*>Open raw<\/a>/);

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -918,12 +918,17 @@ test('enabled forms isolate raw HTML with the opaque-origin sandbox profile', as
     const policy = response.headers.get('content-security-policy');
     assert.equal(policy, 'sandbox allow-scripts allow-forms allow-popups');
     assert.doesNotMatch(policy, /allow-same-origin/);
+    // /embed additionally grants click-gated top navigation (#232) — /raw stays stricter.
     const embed = await server.request('/embed/artifacts/page.html');
     assert.equal(embed.status, 200);
-    assert.equal(embed.headers.get('content-security-policy'), policy);
+    assert.equal(
+      embed.headers.get('content-security-policy'),
+      `${policy} allow-top-navigation-by-user-activation`
+    );
+    assert.doesNotMatch(embed.headers.get('content-security-policy'), /allow-same-origin/);
     const view = await server.request('/view/artifacts/page.html');
     const document = new JSDOM(await view.text()).window.document;
-    assert.equal(document.querySelector('iframe[data-embedded-html]').getAttribute('sandbox'), 'allow-scripts allow-forms allow-popups');
+    assert.equal(document.querySelector('iframe[data-embedded-html]').getAttribute('sandbox'), 'allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation');
 
     const asset = await server.request('/asset/artifacts/page.html');
     assert.equal(asset.status, 200);


### PR DESCRIPTION
Fixes #232.

The embed link-rewriter emits `target="_top"` on rewritten relative links, but the embed sandbox granted no top-navigation — every internal link in embedded HTML silently no-opped inside the /view frame (verified 2026-07-28 with a live click test).

**Change:** `allow-top-navigation-by-user-activation` on the /embed response CSP (server.js + forms router mirror) and the /view iframe sandbox attribute. Click-gated only. **/raw and scriptable assets keep the stricter ARTIFACT_SANDBOX** — now asserted separately with a negative canary.

**Test gates:**
- `artifact-sandbox.test.js`: per-route expectations split (EXPECTED_RAW / EXPECTED_EMBED) + negative canary that /raw never gains top-navigation
- `forms-runner.test.js` sandbox-profile test updated; **the real-browser token-harvesting canary re-run and PASSING** with the new sandbox (CHROME_BIN → playwright headless shell on the dev box)
- `validate:raw-html` exit 0, `validate:editable` exit 0
- Suite: 191 pass / 1 fail — the failure is pre-existing on main (access-control "html renders as sanitized documents", fails on pristine 5de7469 too; will file separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
