### PR TITLE
fix(forms): humanize datetimes on receipts, metrics, and the recent panel (#231)

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -316,10 +316,10 @@ function datetimeCaptureScript(cspNonce) {
 </script>`;
 }
 
-function renderRecentEntries(template, records, timezone, csrfToken) {
+function renderRecentEntries(template, records, timezone, csrfToken, now) {
   const entriesHref = `/forms/${encodeURIComponent(template.templateId)}/entries`;
   const content = records.length
-    ? `<div class="entry-list">${records.map((record) => renderEntryRow(template, record, timezone, csrfToken)).join('')}</div>`
+    ? `<div class="entry-list">${records.map((record) => renderEntryRow(template, record, timezone, csrfToken, { now })).join('')}</div>`
     : '<p class="recent-entries-empty">Your first entry will appear here after you submit it.</p>';
   return `<aside class="recent-entries" aria-labelledby="recent-entries-heading">
         <div class="recent-entries-heading">
@@ -401,7 +401,7 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
         ${sections}
         <button class="button-link button-link-primary form-primary-action" type="submit">${escapeHtml(submitLabel)}</button>
       </form>
-      ${renderRecentEntries(template, options.recentRecords || [], options.timezone, csrfToken)}
+      ${renderRecentEntries(template, options.recentRecords || [], options.timezone, csrfToken, options.now)}
     </section>
   </main>
   ${datetimeCaptureScript(options.cspNonce)}
@@ -457,9 +457,20 @@ function themeDefaults(template) {
   return out;
 }
 
-function displayValue(entry) {
+function displayValue(entry, timeZone) {
   if (entry.selectedOptions) return entry.selectedOptions.map((option) => option.optionLabel).join(', ');
   if (entry.fieldType === 'checkbox') return entry.value ? 'Yes' : 'No';
+  if (entry.fieldType === 'datetime' && typeof entry.value === 'string') {
+    const date = new Date(entry.value);
+    if (Number.isFinite(date.getTime())) {
+      // #231: humanize captured datetimes everywhere values render; the raw ISO
+      // string stays in the record itself.
+      return new Intl.DateTimeFormat('en-US', {
+        ...(timeZone ? { timeZone } : {}),
+        month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit',
+      }).format(date);
+    }
+  }
   if (Array.isArray(entry.value)) return entry.value.join(', ');
   return String(entry.value);
 }
@@ -471,7 +482,7 @@ function renderReceiptPage(template, record, options = {}) {
     const capturedLabel = entry.fieldLabel || (field ? field.label : entry.fieldId);
     const unit = entry.fieldType === 'number' ? unitFromLabel(capturedLabel) : null;
     const label = unit ? labelWithoutUnit(capturedLabel) : capturedLabel;
-    return `<tr><th scope="row">${escapeHtml(label)}</th><td class="receipt-value${entry.fieldType === 'number' ? ' receipt-value-number' : ''}">${escapeHtml(displayValue(entry))}</td><td class="receipt-unit">${unit ? escapeHtml(unit) : ''}</td></tr>`;
+    return `<tr><th scope="row">${escapeHtml(label)}</th><td class="receipt-value${entry.fieldType === 'number' ? ' receipt-value-number' : ''}">${escapeHtml(displayValue(entry, record.timezone || options.timezone))}</td><td class="receipt-unit">${unit ? escapeHtml(unit) : ''}</td></tr>`;
   }).join('');
   const formHref = `/forms/${encodeURIComponent(record.templateId || template && template.templateId || '')}`;
   const entriesHref = `${formHref}/entries`;
@@ -538,6 +549,10 @@ function formatRecordTime(record, fallbackTimezone) {
       ...options,
       hour: 'numeric', minute: '2-digit',
     }).format(date),
+    shortDayLabel: new Intl.DateTimeFormat('en-US', {
+      ...options,
+      month: 'short', day: 'numeric',
+    }).format(date),
   };
 }
 
@@ -561,11 +576,11 @@ function listedValues(template, record) {
   return {selection, entries};
 }
 
-function entryMetrics(entries) {
+function entryMetrics(entries, timeZone) {
   return entries.map((entry) => {
     const unit = entry.fieldType === 'number' ? unitFromLabel(entry.fieldLabel) : null;
     const label = unit ? labelWithoutUnit(entry.fieldLabel) : entry.fieldLabel;
-    return `<span class="entry-metric"><span class="entry-metric-label">${escapeHtml(label)}</span><strong>${escapeHtml(displayValue(entry))}</strong>${unit ? `<span class="entry-metric-unit">${escapeHtml(unit)}</span>` : ''}</span>`;
+    return `<span class="entry-metric"><span class="entry-metric-label">${escapeHtml(label)}</span><strong>${escapeHtml(displayValue(entry, timeZone))}</strong>${unit ? `<span class="entry-metric-unit">${escapeHtml(unit)}</span>` : ''}</span>`;
   }).join('');
 }
 
@@ -589,15 +604,23 @@ function renderInlineEditFields(template, record) {
   }).join('');
 }
 
-function renderEntryRow(template, record, timezone, csrfToken) {
+function renderEntryRow(template, record, timezone, csrfToken, rowOptions = {}) {
   const formHref = `/forms/${encodeURIComponent(template.templateId)}`;
   const stamp = formatRecordTime(record, timezone);
   const href = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}`;
   const listed = listedValues(template, record);
+  const recordTimeZone = record.timezone || timezone;
+  // #231: in flat lists (the recent panel) a bare time is ambiguous across days —
+  // prefix the short day whenever the record is not from "today" in its timezone.
+  let headTime = stamp.timeLabel;
+  if (rowOptions.now instanceof Date && Number.isFinite(rowOptions.now.getTime())) {
+    const todayKey = formatRecordTime({ eventAt: rowOptions.now.toISOString(), timezone: recordTimeZone }, timezone).dateKey;
+    if (stamp.dateKey !== todayKey) headTime = `${stamp.shortDayLabel} · ${stamp.timeLabel}`;
+  }
   return `<details class="entry-row">
     <summary class="entry-row-summary">
-      <span class="entry-row-heading"><time datetime="${escapeHtml(stamp.timestamp)}">${escapeHtml(stamp.timeLabel)}</time>${listed.selection ? `<strong>${escapeHtml(displayValue(listed.selection))}</strong>` : ''}<span class="entry-edit-marker">Edit</span></span>
-      <span class="entry-metrics">${entryMetrics(listed.entries)}</span>
+      <span class="entry-row-heading"><time datetime="${escapeHtml(stamp.timestamp)}">${escapeHtml(headTime)}</time>${listed.selection ? `<strong>${escapeHtml(displayValue(listed.selection, recordTimeZone))}</strong>` : ''}<span class="entry-edit-marker">Edit</span></span>
+      <span class="entry-metrics">${entryMetrics(listed.entries, recordTimeZone)}</span>
     </summary>
     <div class="entry-row-editor">
       <form method="post" action="${formHref}" class="inline-edit-form">
@@ -2130,6 +2153,7 @@ function createFormsRouter(options) {
           recentRecords,
           timezone: serverTimezone,
           canManage,
+          now: currentDate(),
         }
       ));
     } catch (error) {
@@ -2237,6 +2261,7 @@ function createFormsRouter(options) {
             recentRecords,
             timezone: serverTimezone,
             canManage,
+            now: currentDate(),
             autoStampDatetimeIds: untouchedDatetimeIds,
             now: currentDate(),
           }

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -1817,3 +1817,55 @@ test('a template cannot smuggle a script through the theme slug', () => {
   const html = renderReceiptPage(hostile, record, {});
   assert.ok(!html.includes('alert(1)'), 'hostile slug is not emitted into the page');
 });
+
+test('datetimes humanize on receipts/metrics and the recent panel day-prefixes non-today rows (#231)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {
+    formsTimezone: 'America/New_York',
+    formsClock: () => new Date('2026-07-29T18:00:00Z'), // 2:00 PM EDT — "today"
+  });
+  try {
+    const context = await getBrowserContext(server);
+    for (const stamp of ['2026-07-29T09:30', '2026-07-28T11:05']) {
+      const resp = await server.request('/forms/gym-session-entry', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+        body: nativeBody(context.token, {
+          'session-date': stamp,
+          'session-date__offset': '-240',
+          'session-date__timezone': 'America/New_York',
+        }),
+      });
+      assert.equal(resp.status, 303);
+    }
+    const records = await Promise.all((await submissionFiles(fixture.submissionsPath)).map(async (fileName) => (
+      JSON.parse(await fs.readFile(path.join(fixture.submissionsPath, fileName), 'utf8'))
+    )));
+    const yesterday = records.find((record) => record.eventAt.startsWith('2026-07-28'));
+
+    // Receipt: captured datetime renders humanized, never as a raw ISO text node.
+    const receipt = await server.request(`/forms/gym-session-entry/receipts/${yesterday.submissionId}`, {
+      headers: { Cookie: context.cookie },
+    });
+    assert.equal(receipt.status, 200);
+    const receiptHtml = await receipt.text();
+    assert.match(receiptHtml, /Jul 28, 2026, 11:05 AM/);
+    assert.doesNotMatch(receiptHtml, />2026-07-28T11:05/);
+
+    // Form-page recent panel: yesterday's row day-prefixed, today's row stays a bare time.
+    const formPage = await (await server.request('/forms/gym-session-entry', {
+      headers: { Cookie: context.cookie },
+    })).text();
+    assert.match(formPage, /Jul 28 · 11:05 AM/);
+    assert.doesNotMatch(formPage, /Jul 29 · 9:30 AM/);
+    assert.match(formPage, />9:30 AM</);
+
+    // Entries page groups by day already — rows there must NOT gain the prefix.
+    const entriesPage = await (await server.request('/forms/gym-session-entry/entries', {
+      headers: { Cookie: context.cookie },
+    })).text();
+    assert.doesNotMatch(entriesPage, /Jul 28 · /);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});


### PR DESCRIPTION
Fixes #231.

Raw ISO datetimes reached the operator in three places: the receipt page (every submit), entry-card metric slots, and the recent panel's undated bare times across multi-day lists.

**Changes:** `displayValue()` formats datetime values per record timezone; receipt rows + `entryMetrics` thread the timezone; `formatRecordTime()` gains `shortDayLabel` and the recent panel day-prefixes rows not from "today" (via the injectable forms clock — all three form-page render sites now pass `now`). The grouped entries page deliberately keeps bare times under its date headers.

**Test gates:** new clock-pinned test covers receipt humanization (+ negative: no raw-ISO text node), recent-panel prefix on yesterday / bare time today, and the no-prefix rule on the grouped page. Suite 192 pass / 1 pre-existing fail (same as main); `validate:raw-html` and `validate:editable` exit 0; browser canary passes with CHROME_BIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
