### PR TITLE
fix(forms): merge presentation patches in reviseDraft (#225)

### DIFF
--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -416,10 +416,22 @@ class TemplateRegistry {
         throw codedError('ESTALE', 'Template revision is stale.');
       }
       const revised = clone(entry.template);
+      const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
       for (const key of MUTABLE_TEMPLATE_KEYS) {
         if (!Object.prototype.hasOwnProperty.call(changes, key)) continue;
         if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation'].includes(key)) {
           delete revised[key];
+        } else if (key === 'presentation' && isPlainObject(changes.presentation) && isPlainObject(revised.presentation)) {
+          // #225: merge presentation patches instead of replacing wholesale — a patch
+          // stating only `theme` must not silently drop `submitLabel`. A null value
+          // inside the patch unsets that single key; top-level null still clears all.
+          const merged = { ...revised.presentation };
+          for (const [presentationKey, presentationValue] of Object.entries(changes.presentation)) {
+            if (presentationValue === null) delete merged[presentationKey];
+            else merged[presentationKey] = clone(presentationValue);
+          }
+          if (Object.keys(merged).length === 0) delete revised.presentation;
+          else revised.presentation = merged;
         } else {
           revised[key] = clone(changes[key]);
         }

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -599,3 +599,37 @@ test('Properties reports a theme only when that theme is actually installed', as
     await server.close();
   }
 });
+
+test('reviseDraft merges presentation patches instead of replacing wholesale (#225)', async () => {
+  const server = await makeServer();
+  try {
+    const before = await server.registry.getManagementTemplate('training-log');
+    await server.registry.reviseDraft('training-log', before.draft.revision, {
+      presentation: {theme: 'planet-fitness', themeMode: 'dark', submitLabel: 'Log it'},
+    });
+
+    // A patch stating only themeMode must not drop theme or submitLabel.
+    let current = await server.registry.getManagementTemplate('training-log');
+    await server.registry.reviseDraft('training-log', current.draft.revision, {
+      presentation: {themeMode: 'light'},
+    });
+    current = await server.registry.getManagementTemplate('training-log');
+    assert.deepEqual(current.draft.presentation, {
+      theme: 'planet-fitness', themeMode: 'light', submitLabel: 'Log it',
+    });
+
+    // null inside the patch unsets exactly that key.
+    await server.registry.reviseDraft('training-log', current.draft.revision, {
+      presentation: {submitLabel: null},
+    });
+    current = await server.registry.getManagementTemplate('training-log');
+    assert.deepEqual(current.draft.presentation, {theme: 'planet-fitness', themeMode: 'light'});
+
+    // Top-level null still clears the whole object (existing semantic).
+    await server.registry.reviseDraft('training-log', current.draft.revision, {presentation: null});
+    current = await server.registry.getManagementTemplate('training-log');
+    assert.equal(current.draft.presentation, undefined);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
Fixes #225.

`reviseDraft` replaced `presentation` wholesale: a patch stating only `presentation.theme` silently dropped `submitLabel` and any other unstated key — the trap documented in the ops knowledge base since 2026-07-21, forcing every caller (including the builder UI) to rebuild the whole object defensively.

**Change:** plain-object presentation patches now merge key-by-key. `null` inside the patch unsets exactly that key; top-level `presentation: null` still clears the object (existing semantic). Non-object values fall through to the old behavior.

**Test gates:** new registry-level test covers merge-preserves-unstated-keys, single-key unset via inner null, and whole-object clear via top-level null. The existing builder-save submitLabel-survival test still passes (its defensive rebuild remains valid). Suite 193 pass / 1 pre-existing fail; both validators exit 0; browser canary passes with CHROME_BIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
