### PR TITLE
fix(forms): sane entry cards for numeric-less forms (#230)

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -559,20 +559,24 @@ function formatRecordTime(record, fallbackTimezone) {
 function listedValues(template, record) {
   const activeFields = (template.fields || []).filter((field) => field.isDestroyed !== true);
   const captured = new Map(record.values.map((entry) => [entry.fieldId, entry]));
+  const activeIds = new Set(activeFields.map((field) => field.id));
+  const visible = record.values.filter((entry) => activeIds.has(entry.fieldId));
+  // #230: the heading selection always renders (it is the card's label); metrics
+  // never duplicate it, and showInList narrows metrics rather than suppressing
+  // the heading.
+  const selection = visible.find((entry) => entry.fieldType === 'select' || entry.fieldType === 'multi-select') || null;
+  const notSelection = (entry) => !selection || entry.fieldId !== selection.fieldId;
   const marked = activeFields.filter((field) => field.showInList === true);
   if (marked.length > 0) {
     return {
-      selection: null,
-      entries: marked.map((field) => captured.get(field.id)).filter(Boolean),
+      selection,
+      entries: marked.map((field) => captured.get(field.id)).filter(Boolean).filter(notSelection),
     };
   }
-  const activeIds = new Set(activeFields.map((field) => field.id));
-  const visible = record.values.filter((entry) => activeIds.has(entry.fieldId));
-  const selection = visible.find((entry) => entry.fieldType === 'select' || entry.fieldType === 'multi-select');
   const numeric = visible.filter((entry) => entry.fieldType === 'number').slice(0, 3);
   const entries = numeric.length > 0
     ? numeric
-    : visible.filter((entry) => entry.fieldType !== 'long-text').slice(0, 2);
+    : visible.filter((entry) => entry.fieldType !== 'long-text').filter(notSelection).slice(0, 2);
   return {selection, entries};
 }
 
@@ -580,7 +584,9 @@ function entryMetrics(entries, timeZone) {
   return entries.map((entry) => {
     const unit = entry.fieldType === 'number' ? unitFromLabel(entry.fieldLabel) : null;
     const label = unit ? labelWithoutUnit(entry.fieldLabel) : entry.fieldLabel;
-    return `<span class="entry-metric"><span class="entry-metric-label">${escapeHtml(label)}</span><strong>${escapeHtml(displayValue(entry, timeZone))}</strong>${unit ? `<span class="entry-metric-unit">${escapeHtml(unit)}</span>` : ''}</span>`;
+    // #230: text values must not render at stat size — they wrap into card balloons.
+    const metricClass = entry.fieldType === 'number' ? 'entry-metric' : 'entry-metric entry-metric-text';
+    return `<span class="${metricClass}"><span class="entry-metric-label">${escapeHtml(label)}</span><strong>${escapeHtml(displayValue(entry, timeZone))}</strong>${unit ? `<span class="entry-metric-unit">${escapeHtml(unit)}</span>` : ''}</span>`;
   }).join('');
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -1135,6 +1135,17 @@ tbody tr:last-child td {
   letter-spacing: -0.03em;
 }
 
+/* #230: text values keep body scale and clamp to one line — stat sizing is for numbers. */
+.form-layout .entry-metric-text strong {
+  font-family: inherit;
+  font-size: 0.95rem;
+  letter-spacing: normal;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .form-layout .entry-metric-unit {
   color: var(--text-soft);
   font-size: 0.68rem;

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -1291,11 +1291,16 @@ test('showInList fields drive recent and history rows in template order', async 
     for (const route of ['/forms/gym-session-entry', '/forms/gym-session-entry/entries']) {
       const response = await server.request(route, {headers: {Cookie: context.cookie}});
       const document = new JSDOM(await response.text()).window.document;
+      // #230: the selection renders in the heading (not suppressed by showInList),
+      // and the metrics never duplicate it — so 'Lift' appears as the bold heading
+      // label while the marked metrics reduce to the remaining fields, in order.
+      const summary = document.querySelector('.entry-row-summary');
+      assert.ok(summary.querySelector('strong'), 'heading keeps the selection label');
       assert.deepEqual(
         [...document.querySelectorAll('.entry-row-summary .entry-metric-label')].slice(0, 2).map((label) => label.textContent),
-        ['Lift', 'Top reps'],
+        ['Top reps'],
       );
-      assert.equal(document.querySelector('.entry-row-summary').textContent.includes('Top weight'), false);
+      assert.equal(summary.textContent.includes('Top weight'), false);
     }
   } finally {
     await cleanup(fixture, server);
@@ -1865,6 +1870,58 @@ test('datetimes humanize on receipts/metrics and the recent panel day-prefixes n
       headers: { Cookie: context.cookie },
     })).text();
     assert.doesNotMatch(entriesPage, /Jul 28 · /);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('numeric-less forms keep the selection heading and body-sized text metrics (#230)', async () => {
+  const fixture = await makeFixture();
+  const doseTemplate = {
+    contractVersion: 1,
+    resourceKind: 'form-template',
+    templateId: 'dose-log',
+    ownerId: 'operator',
+    revision: 1,
+    grammarVersion: 1,
+    title: 'Dose Log',
+    fields: [
+      {id: 'taken-at', type: 'datetime', label: 'Taken at', required: true},
+      {id: 'med', type: 'select', label: 'Meds', required: true, options: [
+        {id: 'alpha', label: 'Alpha 100'}, {id: 'beta', label: 'Beta 200'},
+      ]},
+      {id: 'notes', type: 'long-text', label: 'Notes', required: false},
+    ],
+  };
+  await fs.writeFile(path.join(fixture.templatesPath, 'dose-log.yaml'), yaml.dump(doseTemplate), 'utf8');
+  const server = await startServer(fixture, {formsTimezone: 'America/New_York'});
+  try {
+    const context = await getBrowserContext(server);
+    const accepted = await server.request('/forms/dose-log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: new URLSearchParams({
+        _csrf: context.token,
+        'taken-at': '2026-07-29T11:05',
+        'taken-at__offset': '-240',
+        'taken-at__timezone': 'America/New_York',
+        med: 'alpha',
+      }),
+    });
+    assert.equal(accepted.status, 303);
+    const page = await (await server.request('/forms/dose-log', {headers: {Cookie: context.cookie}})).text();
+    const document = new JSDOM(page).window.document;
+    const summary = document.querySelector('.entry-row-summary');
+    // Heading carries the selection, gym-style.
+    assert.equal(summary.querySelector('strong').textContent, 'Alpha 100');
+    // The selection is not duplicated into the metrics.
+    const metricLabels = [...summary.querySelectorAll('.entry-metric-label')].map((n) => n.textContent);
+    assert.ok(!metricLabels.includes('Meds'), 'selection must not repeat as a metric');
+    // The datetime metric renders humanized and carries the text-metric class.
+    const textMetric = summary.querySelector('.entry-metric-text strong');
+    assert.ok(textMetric, 'non-number metrics carry the text class');
+    assert.match(textMetric.textContent, /Jul 29, 2026/);
+    assert.doesNotMatch(textMetric.textContent, /2026-07-29T/);
   } finally {
     await cleanup(fixture, server);
   }


### PR DESCRIPTION
Fixes #230.

Numeric-less forms (the meds dose log) got ballooned entry cards: text values rendered at stat size and wrapped across lines, and `listedValues` offered selection-in-heading XOR `showInList` metrics — compact cards cost the heading its label (operator: "history is not showing by date like the gym stuff").

**Changes:** non-number metrics carry a new `entry-metric-text` class (body scale, single line, ellipsis); the heading selection ALWAYS renders and is never duplicated into the metrics; `showInList` narrows metrics instead of suppressing the heading.

**Test gates:** updated the showInList ordering test to the new contract (heading keeps the selection; marked metrics dedupe it); new end-to-end fixture test with a meds-shaped numeric-less form asserts heading label, no metric duplication, the text-metric class, and the humanized datetime from #231. Suite 194 pass / 1 pre-existing fail; both validators exit 0; browser canary passes with CHROME_BIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
