### PR TITLE
feat(forms): tag-based related-forms nav on form and receipt pages (#234 interim)

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -316,6 +316,19 @@ function datetimeCaptureScript(cspNonce) {
 </script>`;
 }
 
+function renderRelatedFormsNav(related) {
+  // #234 (interim slice): tag-based sibling navigation on form + receipt pages.
+  // Containers will replace the tag heuristic with containerId membership.
+  if (!related || !related.length) return '';
+  const pills = related.map((template) => (
+    `<a class="related-form-link" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}</a>`
+  )).join('');
+  return `<nav class="related-forms" aria-label="Related forms">
+        <h2>Related forms</h2>
+        <div class="related-forms-list">${pills}</div>
+      </nav>`;
+}
+
 function renderRecentEntries(template, records, timezone, csrfToken, now) {
   const entriesHref = `/forms/${encodeURIComponent(template.templateId)}/entries`;
   const content = records.length
@@ -402,6 +415,7 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
         <button class="button-link button-link-primary form-primary-action" type="submit">${escapeHtml(submitLabel)}</button>
       </form>
       ${renderRecentEntries(template, options.recentRecords || [], options.timezone, csrfToken, options.now)}
+      ${renderRelatedFormsNav(options.relatedForms)}
     </section>
   </main>
   ${datetimeCaptureScript(options.cspNonce)}
@@ -509,6 +523,7 @@ function renderReceiptPage(template, record, options = {}) {
         </div>
       </nav>
       <p class="receipt-meta">Logged ${escapeHtml(received)}<br><span>Receipt ID ${escapeHtml(record.submissionId)}</span></p>
+      ${renderRelatedFormsNav(options.relatedForms)}
     </section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;
@@ -1464,6 +1479,22 @@ function createFormsRouter(options) {
     return false;
   }
 
+  async function relatedFormsFor(req, template) {
+    // #234 interim: siblings share at least one tag; only forms the requester can open.
+    const tags = Array.isArray(template.tags) ? template.tags : [];
+    if (!tags.length) return [];
+    const related = [];
+    for (const candidate of await registry.listTemplates()) {
+      if (candidate.templateId === template.templateId || candidate.archived === true) continue;
+      const candidateTags = Array.isArray(candidate.tags) ? candidate.tags : [];
+      if (!candidateTags.some((tag) => tags.includes(tag))) continue;
+      if (await allowed(req, 'forms.submit', candidate) || await allowed(req, 'forms.view', candidate)) {
+        related.push(candidate);
+      }
+    }
+    return related.sort((left, right) => String(left.title).localeCompare(String(right.title)));
+  }
+
   function managementEnvelope(req, res, mutation, type) {
     const bearer = bearerPresented(req);
     if (bearer && cookieValue(req, CONTEXT_COOKIE)) {
@@ -2087,6 +2118,7 @@ function createFormsRouter(options) {
         recentRecords,
         timezone: serverTimezone,
         canManage,
+        relatedForms: await relatedFormsFor(req, template),
         now: currentDate(),
       }));
     } catch (error) {
@@ -2159,6 +2191,7 @@ function createFormsRouter(options) {
           recentRecords,
           timezone: serverTimezone,
           canManage,
+          relatedForms: await relatedFormsFor(req, template),
           now: currentDate(),
         }
       ));
@@ -2267,6 +2300,7 @@ function createFormsRouter(options) {
             recentRecords,
             timezone: serverTimezone,
             canManage,
+            relatedForms: await relatedFormsFor(req, template),
             now: currentDate(),
             autoStampDatetimeIds: untouchedDatetimeIds,
             now: currentDate(),
@@ -2479,6 +2513,7 @@ function createFormsRouter(options) {
         customThemeCss,
         cspNonce,
         canEdit,
+        relatedForms: await relatedFormsFor(req, template),
         timezone: serverTimezone,
       }));
     } catch (error) {

--- a/public/style.css
+++ b/public/style.css
@@ -2692,6 +2692,38 @@ tbody tr:last-child td {
   color: var(--link);
 }
 
+/* #234 (interim): tag-based related-forms navigation on form and receipt pages. */
+.form-layout .related-forms {
+  margin-top: 1.4rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+.form-layout .related-forms h2 {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-soft);
+  margin: 0 0 0.6rem;
+}
+.form-layout .related-forms-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+.form-layout .related-form-link {
+  display: inline-block;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.55rem;
+  text-decoration: none;
+  color: var(--text);
+  background: var(--bg-elev);
+  font-size: 0.85rem;
+}
+.form-layout .related-form-link:hover {
+  border-color: var(--accent);
+}
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -1926,3 +1926,53 @@ test('numeric-less forms keep the selection heading and body-sized text metrics 
     await cleanup(fixture, server);
   }
 });
+
+test('form and receipt pages render tag-based related-forms navigation (#234 interim)', async () => {
+  const fixture = await makeFixture();
+  const sibling = {
+    contractVersion: 1,
+    resourceKind: 'form-template',
+    templateId: 'mobility-log',
+    ownerId: 'operator',
+    revision: 1,
+    grammarVersion: 1,
+    title: 'Mobility Log',
+    tags: ['gym'],
+    fields: [{id: 'notes', type: 'long-text', label: 'Notes', required: true}],
+  };
+  const stranger = { ...sibling, templateId: 'pantry-log', title: 'Pantry Log', tags: ['kitchen'] };
+  await fs.writeFile(path.join(fixture.templatesPath, 'mobility-log.yaml'), yaml.dump(sibling), 'utf8');
+  await fs.writeFile(path.join(fixture.templatesPath, 'pantry-log.yaml'), yaml.dump(stranger), 'utf8');
+  // tag the gym fixture so it participates
+  const gymPath = path.join(fixture.templatesPath, 'gym-session-entry.yaml');
+  const gym = yaml.load(await fs.readFile(gymPath, 'utf8'), {schema: yaml.JSON_SCHEMA});
+  gym.tags = ['gym'];
+  await fs.writeFile(gymPath, yaml.dump(gym), 'utf8');
+  const server = await startServer(fixture, {formsTimezone: 'America/New_York'});
+  try {
+    const context = await getBrowserContext(server);
+    const page = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    const document = new JSDOM(page).window.document;
+    const links = [...document.querySelectorAll('.related-forms .related-form-link')];
+    assert.deepEqual(links.map((a) => a.textContent), ['Mobility Log'], 'same-tag sibling only');
+    assert.equal(links[0].getAttribute('href'), '/forms/mobility-log');
+    assert.ok(!page.includes('Pantry Log'), 'unrelated tags stay out');
+
+    // receipt carries the same nav
+    const accepted = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: nativeBody(context.token),
+    });
+    assert.equal(accepted.status, 303);
+    const receiptPath = accepted.headers.get('location');
+    const receipt = await (await server.request(receiptPath, {headers: {Cookie: context.cookie}})).text();
+    assert.ok(new JSDOM(receipt).window.document.querySelector('.related-forms .related-form-link'), 'receipt shows related forms');
+
+    // untagged sibling-less form renders no nav block
+    const strangerPage = await (await server.request('/forms/pantry-log', {headers: {Cookie: context.cookie}})).text();
+    assert.ok(!strangerPage.includes('related-forms-list') || !new JSDOM(strangerPage).window.document.querySelector('.related-form-link'), 'no siblings, no nav');
+  } finally {
+    await cleanup(fixture, server);
+  }
+});


### PR DESCRIPTION
Interim slice of #234 (does NOT close it).

Ships decisions (c) and (d) of the settled container design ahead of first-class containers, using the tags already live on every template: form pages and receipt pages end with a **Related forms** strip — published, non-archived templates sharing at least one tag, filtered to what the requester may open, title-sorted. This completes the operator's between-sets circuit flow (log → receipt → tap the next machine) today; containers will replace the tag heuristic with `containerId` membership and add the "← Container" affordance.

**Test gates:** new end-to-end test covers same-tag sibling rendering (and href), unrelated-tag exclusion, receipt-page nav, and the no-siblings/no-nav case. CSS placed above the linted document-components region (its scoping test caught the first placement). Suite 195 pass / 1 pre-existing fail (#240); both validators exit 0; browser canary passes with CHROME_BIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
