### PR TITLE
style(forms): self-explanatory accent-themed related-forms strip

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -323,8 +323,8 @@ function renderRelatedFormsNav(related) {
   const pills = related.map((template) => (
     `<a class="related-form-link" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}</a>`
   )).join('');
+  // No heading — the strip explains itself (operator call, 2026-07-29).
   return `<nav class="related-forms" aria-label="Related forms">
-        <h2>Related forms</h2>
         <div class="related-forms-list">${pills}</div>
       </nav>`;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -2698,30 +2698,27 @@ tbody tr:last-child td {
   padding-top: 1rem;
   border-top: 1px solid var(--border);
 }
-.form-layout .related-forms h2 {
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-soft);
-  margin: 0 0 0.6rem;
-}
 .form-layout .related-forms-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.45rem;
+  gap: 0.5rem;
 }
 .form-layout .related-form-link {
   display: inline-block;
-  padding: 0.45rem 0.75rem;
-  border: 1px solid var(--border);
-  border-radius: 0.55rem;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+  border-left: 4px solid var(--accent);
+  border-radius: 0.6rem;
   text-decoration: none;
   color: var(--text);
-  background: var(--bg-elev);
-  font-size: 0.85rem;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-elev));
+  font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  font-weight: 500;
+  font-size: 0.88rem;
 }
 .form-layout .related-form-link:hover {
   border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elev));
 }
 
 /* ============================================================================


### PR DESCRIPTION
Operator polish on #241/#234: heading removed (strip explains itself); links restyled with theme elements — accent-tinted bg, accent left rule, Space Grotesk. Suite green minus the known #240 pre-existing failure; validators exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL