### PR TITLE
feat(forms): first-class container forms (#234)

### DIFF
--- a/lib/forms/canonical.js
+++ b/lib/forms/canonical.js
@@ -90,7 +90,8 @@ function schemaDigest(template) {
   }
   const schema = {
     grammarVersion: template.grammarVersion,
-    fields: template.fields,
+    // #234: containers carry no fields — digest an empty schema rather than undefined.
+    fields: Array.isArray(template.fields) ? template.fields : [],
   };
   return crypto.createHash('sha256').update(canonicalize(schema), 'utf8').digest('hex');
 }

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -16,11 +16,11 @@ const EMBED_SANDBOX = `${ARTIFACT_SANDBOX} allow-top-navigation-by-user-activati
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const TEMPLATE_CREATE_KEYS = new Set([
   'templateId', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
-  'lineage', 'presentation', 'fields',
+  'lineage', 'presentation', 'fields', 'kind', 'containerId', 'memberOrder',
 ]);
 const TEMPLATE_PATCH_KEYS = new Set([
   'revision', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
-  'lineage', 'presentation', 'fields',
+  'lineage', 'presentation', 'fields', 'containerId', 'memberOrder',
 ]);
 const TEMPLATE_PUBLISH_KEYS = new Set(['revision']);
 const TEMPLATE_CLONE_KEYS = new Set(['templateId', 'templateVersion', 'title']);
@@ -316,16 +316,45 @@ function datetimeCaptureScript(cspNonce) {
 </script>`;
 }
 
-function renderRelatedFormsNav(related) {
-  // #234 (interim slice): tag-based sibling navigation on form + receipt pages.
-  // Containers will replace the tag heuristic with containerId membership.
-  if (!related || !related.length) return '';
+function renderContainerPage(template, members, options = {}) {
+  // #234: a container's page IS its form view — member navigation instead of fields.
+  const cards = members.length
+    ? members.map((member) => (
+      `<a class="container-member" href="/forms/${encodeURIComponent(member.templateId)}"><span class="container-member-title">${escapeHtml(member.title)}</span><span aria-hidden="true">›</span></a>`
+    )).join('')
+    : '<p class="container-empty">No forms in this container yet. Add some from its Configure page.</p>';
+  const body = `${toolbarHtml(options.canManage ? `<a class="toolbar-btn" href="/forms/${encodeURIComponent(template.templateId)}/configure" aria-label="Configure container">Configure</a>` : '')}
+  <main class="layout form-layout container-layout">
+    <section class="content form-card container-card">
+      <header class="topbar"><div><p class="eyebrow">Forms</p><h1>${escapeHtml(template.title)}</h1>${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div></header>
+      <div class="container-members">${cards}</div>
+    </section>
+  </main>
+  ${themeScript(options.cspNonce, themeDefaults(template))}`;
+  return baseHtml({
+    title: template.title,
+    body,
+    customThemeCss: options.customThemeCss,
+    cspNonce: options.cspNonce,
+    defaultScheme: themeDefaults(template).scheme || null,
+    defaultMode: themeDefaults(template).mode || null,
+  });
+}
+
+function renderRelatedFormsNav(nav) {
+  // #234: container membership (with a back-to-container button) or tag fallback.
+  const related = nav && nav.related ? nav.related : [];
+  const container = nav && nav.container ? nav.container : null;
+  if (!related.length && !container) return '';
+  const back = container
+    ? `<a class="related-container-link" href="/forms/${encodeURIComponent(container.templateId)}">← ${escapeHtml(container.title)}</a>`
+    : '';
   const pills = related.map((template) => (
     `<a class="related-form-link" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}</a>`
   )).join('');
   // No heading — the strip explains itself (operator call, 2026-07-29).
   return `<nav class="related-forms" aria-label="Related forms">
-        <div class="related-forms-list">${pills}</div>
+        <div class="related-forms-list">${back}${pills}</div>
       </nav>`;
 }
 
@@ -841,6 +870,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           <p class="builder-help">Destinations are deployment-approved aliases. Filesystem paths cannot be entered here.</p>
           <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
           <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
+          ${Array.isArray(options.containers) && options.containers.length ? `<label><span>Container</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${options.containers.map((container) => `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label><p class="builder-help">Containers group forms and give each member back-and-sibling navigation.</p>` : ''}
           <p class="builder-help">Themes are installed by the deployment and read from the server. Leave both alone and this form follows whatever theme the viewer has chosen.</p>
         </section>
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
@@ -908,14 +938,100 @@ function renderManagedTemplate(template, csrfToken) {
   </article>`;
 }
 
+function renderContainerConfigurePage(record, csrfToken, options = {}) {
+  // #234: a container is itself a form — same Configure surface, members instead of fields.
+  const template = record.draft;
+  const configureHref = `/forms/${encodeURIComponent(template.templateId)}/configure`;
+  const published = record.publishedVersion;
+  const publishedText = published
+    ? `Version ${published.templateVersion}, from draft revision ${published.sourceRevision}`
+    : 'Not published yet';
+  const status = options.status ? `<p class="builder-status">${escapeHtml(options.status)}</p>` : '';
+  const conflict = options.conflict ? '<p class="builder-conflict">Someone else saved a newer draft. Review it and reapply your change.</p>' : '';
+  const currentTheme = (template.presentation && template.presentation.theme) || '';
+  const currentThemeMode = (template.presentation && template.presentation.themeMode) || '';
+  const themeOptions = [{slug: '', label: 'Use the viewer theme'}, ...getThemeList()].map((theme) =>
+    `<option value="${escapeHtml(theme.slug)}"${currentTheme === theme.slug ? ' selected' : ''}>${escapeHtml(theme.label)}</option>`
+  ).join('');
+  const themeModeOptions = [['', 'Follow the viewer'], ['dark', 'Always dark'], ['light', 'Always light']].map(
+    ([value, label]) => `<option value="${value}"${currentThemeMode === value ? ' selected' : ''}>${label}</option>`
+  ).join('');
+  const memberChoices = Array.isArray(options.memberChoices) ? options.memberChoices : [];
+  const membersHtml = memberChoices.length
+    ? memberChoices.map((choice) => (
+      `<label class="builder-check container-member-choice"><input type="checkbox" name="member" value="${escapeHtml(choice.templateId)}"${choice.checked ? ' checked' : ''}><span>${escapeHtml(choice.title)}</span></label>`
+    )).join('')
+    : '<p class="builder-help">No forms exist yet to add.</p>';
+  const lifecycle = template.archived === true ? 'restore' : 'archive';
+  const body = `${toolbarHtml()}
+  <main class="layout form-layout builder-layout">
+    <section class="content form-card builder-card container-configure-card">
+      <header class="topbar"><div><p class="eyebrow">Container</p><h1>${escapeHtml(template.title)}</h1></div></header>
+      <dl class="builder-revisions">
+        <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
+        <div><dt>Published</dt><dd>${escapeHtml(publishedText)}</dd></div>
+      </dl>
+      ${status}${conflict}${builderErrors(options.errors)}
+      <form method="post" action="${configureHref}" class="builder-form">
+        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+        <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+        <section class="builder-basics" aria-labelledby="container-basics-heading">
+          <h2 id="container-basics-heading">Container</h2>
+          <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
+          <label class="builder-wide"><span>Description</span><textarea name="description" rows="2" maxlength="2000">${escapeHtml(template.description || '')}</textarea></label>
+          <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
+          <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
+        </section>
+        <section class="builder-members" aria-labelledby="container-members-heading">
+          <h2 id="container-members-heading">Forms in this container</h2>
+          <p class="builder-help">Checked forms point their containerId here; unchecking releases them. Members gain back-and-sibling navigation automatically.</p>
+          <div class="container-member-choices">${membersHtml}</div>
+        </section>
+        <button class="button-link button-link-primary" type="submit">Save draft</button>
+      </form>
+      <form method="post" action="${configureHref}/publish" class="builder-publish-form">
+        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+        <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+        <button class="button-link" type="submit">Publish revision ${escapeHtml(template.revision)}</button>
+      </form>
+      <form method="post" action="/forms/${encodeURIComponent(template.templateId)}/${lifecycle}" class="builder-lifecycle-form">
+        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+        <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+        <button class="button-link" type="submit">${lifecycle === 'archive' ? 'Archive container' : 'Restore container'}</button>
+      </form>
+    </section>
+  </main>
+  ${themeScript(options.cspNonce, themeDefaults(template))}`;
+  return baseHtml({
+    title: `Configure — ${template.title}`,
+    body,
+    customThemeCss: options.customThemeCss,
+    cspNonce: options.cspNonce,
+  });
+}
+
 function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   const managed = templates.some((template) => template.management === true);
   const active = templates.filter((template) => template.state !== 'archived');
   const archived = templates.filter((template) => template.state === 'archived');
-  const activeHtml = active.length
-    ? active.map((template) => template.management
-      ? renderManagedTemplate(template, csrfToken)
-      : `<a class="forms-index-simple" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}<span aria-hidden="true">›</span></a>`).join('')
+  // #234: containers group the root — container cards first with their members
+  // nested beneath, then everything uncontained.
+  const renderOne = (template) => template.management
+    ? renderManagedTemplate(template, csrfToken)
+    : `<a class="forms-index-simple" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}<span aria-hidden="true">›</span></a>`;
+  const containers = active.filter((template) => template.kind === 'container');
+  const containerIds = new Set(containers.map((template) => template.templateId));
+  const contained = active.filter((template) => template.kind !== 'container' && template.containerId && containerIds.has(template.containerId));
+  const ungrouped = active.filter((template) => template.kind !== 'container' && !(template.containerId && containerIds.has(template.containerId)));
+  const groupedHtml = containers.map((container) => {
+    const members = contained.filter((template) => template.containerId === container.templateId);
+    return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
+      <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} form${members.length === 1 ? '' : 's'}</span>${container.management ? `<a class="forms-index-container-configure" href="/forms/${encodeURIComponent(container.templateId)}/configure">Configure</a>` : ''}</div>
+      <div class="forms-index-list">${members.map(renderOne).join('')}</div>
+    </section>`;
+  }).join('');
+  const activeHtml = (containers.length || ungrouped.length)
+    ? `${groupedHtml}${ungrouped.length ? `<section class="forms-index-ungrouped" aria-label="Ungrouped forms">${containers.length ? '<h2 class="forms-index-ungrouped-head">Ungrouped</h2>' : ''}<div class="forms-index-list">${ungrouped.map(renderOne).join('')}</div></section>` : ''}`
     : `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first template' : 'No forms available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active forms you can submit to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New template</a>' : ''}</div>`;
   const archivedHtml = managed && archived.length
     ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken)).join('')}</div></details>`
@@ -923,7 +1039,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   const body = `${toolbarHtml()}
   <main class="layout form-layout forms-index-layout">
     <header class="topbar forms-index-header"><div><p class="eyebrow">Forms</p><h1>Templates</h1><p class="subtitle">${managed ? 'Create, configure, and review your forms.' : 'Choose a form to log an entry.'}</p></div>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New template</a>' : ''}</header>
-    <section class="forms-index-list" aria-label="Active templates">${activeHtml}</section>
+    <div class="forms-index-groups" aria-label="Active templates">${activeHtml}</div>
     ${archivedHtml}
   </main>
   ${themeScript(options.cspNonce)}`;
@@ -949,7 +1065,9 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
         <label><span>Template ID</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*" required autofocus></label>
         <label><span>Title</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required></label>
-        <label><span>Destination</span><select name="destinationId" required>${destinationOptions}</select></label>
+        <label><span>Kind</span><select name="kind"><option value="">Form</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Container (groups other forms)</option></select></label>
+        <label><span>Destination</span><select name="destinationId">${destinationOptions}</select></label>
+        <p class="builder-help">Destination applies to forms only — containers hold forms, not entries.</p>
         <p class="builder-help">Only deployment-approved destination aliases are available; a filesystem path is never accepted.</p>
         <button class="button-link button-link-primary form-primary-action" type="submit">Create template</button>
       </form>
@@ -1115,7 +1233,7 @@ function builderPatch(current, body) {
   if (theme) presentation.theme = theme;
   if (themeMode === 'dark' || themeMode === 'light') presentation.themeMode = themeMode;
 
-  return {
+  const patch = {
     revision: Number(postedString(body, 'revision')),
     title: postedString(body, 'title'),
     destinationId: postedString(body, 'destinationId'),
@@ -1123,6 +1241,11 @@ function builderPatch(current, body) {
     presentation: Object.keys(presentation).length ? presentation : null,
     fields,
   };
+  if (Object.prototype.hasOwnProperty.call(body, 'container')) {
+    // '' means uncontained; the registry fail-closes unknown container ids (#234).
+    patch.containerId = postedString(body, 'container') || null;
+  }
+  return patch;
 }
 
 function timeZoneOffset(timestamp, timeZone) {
@@ -1479,20 +1602,59 @@ function createFormsRouter(options) {
     return false;
   }
 
+  function orderMembers(container, members) {
+    // Optional presentation-only ordering: memberOrder first (unknown ids ignored),
+    // everything unlisted appended title-sorted. Circuit order beats the alphabet.
+    const order = Array.isArray(container && container.memberOrder) ? container.memberOrder : [];
+    const byId = new Map(members.map((member) => [member.templateId, member]));
+    const ordered = [];
+    for (const memberId of order) {
+      if (byId.has(memberId)) {
+        ordered.push(byId.get(memberId));
+        byId.delete(memberId);
+      }
+    }
+    return ordered.concat([...byId.values()].sort((left, right) => String(left.title).localeCompare(String(right.title))));
+  }
+
+  async function containerMembersFor(req, container) {
+    const members = [];
+    for (const candidate of await registry.listTemplates()) {
+      if (candidate.archived === true || candidate.kind === 'container') continue;
+      if (candidate.containerId !== container.templateId) continue;
+      if (await allowed(req, 'forms.submit', candidate) || await allowed(req, 'forms.view', candidate)) {
+        members.push(candidate);
+      }
+    }
+    return orderMembers(container, members);
+  }
+
   async function relatedFormsFor(req, template) {
-    // #234 interim: siblings share at least one tag; only forms the requester can open.
+    // #234: container membership drives the strip; tags remain the fallback for
+    // uncontained forms.
+    if (template.containerId) {
+      const container = await registry.getTemplate(template.containerId);
+      if (container && container.kind === 'container' && container.archived !== true) {
+        const members = await containerMembersFor(req, container);
+        return {
+          container: {templateId: container.templateId, title: container.title},
+          related: members.filter((member) => member.templateId !== template.templateId),
+        };
+      }
+    }
     const tags = Array.isArray(template.tags) ? template.tags : [];
-    if (!tags.length) return [];
+    if (!tags.length) return {container: null, related: []};
     const related = [];
     for (const candidate of await registry.listTemplates()) {
       if (candidate.templateId === template.templateId || candidate.archived === true) continue;
+      if (candidate.kind === 'container') continue;
       const candidateTags = Array.isArray(candidate.tags) ? candidate.tags : [];
       if (!candidateTags.some((tag) => tags.includes(tag))) continue;
       if (await allowed(req, 'forms.submit', candidate) || await allowed(req, 'forms.view', candidate)) {
         related.push(candidate);
       }
     }
-    return related.sort((left, right) => String(left.title).localeCompare(String(right.title)));
+    return {container: null, related: related.sort((left, right) => String(left.title).localeCompare(String(right.title)))};
   }
 
   function managementEnvelope(req, res, mutation, type) {
@@ -1613,9 +1775,16 @@ function createFormsRouter(options) {
           destinationId: record.draft.destinationId || 'default',
           state: record.state,
           entryCount,
+          kind: record.draft.kind === 'container' ? 'container' : 'form',
+          containerId: record.draft.containerId || null,
         });
       } else if (record.state !== 'archived' && await allowed(req, 'forms.submit', record.draft)) {
-        templates.push({templateId: record.draft.templateId, title: record.draft.title});
+        templates.push({
+          templateId: record.draft.templateId,
+          title: record.draft.title,
+          kind: record.draft.kind === 'container' ? 'container' : 'form',
+          containerId: record.draft.containerId || null,
+        });
       }
     }
     return templates;
@@ -1838,10 +2007,26 @@ function createFormsRouter(options) {
     });
   }
 
+  function validContainerBuilderBody(body) {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) return false;
+    const fixed = new Set(['_csrf', 'revision', 'title', 'description', 'theme', 'themeMode', 'member']);
+    const theme = body.theme;
+    if (typeof theme === 'string' && theme !== '' && !getThemeList().some((entry) => entry.slug === theme)) return false;
+    const mode = body.themeMode;
+    if (typeof mode === 'string' && mode !== '' && mode !== 'dark' && mode !== 'light') return false;
+    return Object.entries(body).every(([key, value]) => {
+      if (!fixed.has(key)) return false;
+      if (key === 'member') {
+        return [].concat(value).every((memberId) => typeof memberId === 'string' && isDefinitionId(memberId));
+      }
+      return typeof value === 'string';
+    });
+  }
+
   function validBuilderBody(body, create = false) {
     const fixed = create
-      ? new Set(['_csrf', 'templateId', 'title', 'destinationId'])
-      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode']);
+      ? new Set(['_csrf', 'templateId', 'title', 'destinationId', 'kind'])
+      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container']);
     // An author SELECTS an installed theme; they can never introduce one. Anything
     // outside the server's list is refused rather than quietly ignored.
     if (!create && body && typeof body === 'object') {
@@ -1875,12 +2060,35 @@ function createFormsRouter(options) {
     }));
   }
 
-  function sendConfigure(res, record, csrfToken, responseOptions = {}, status = 200) {
+  async function sendConfigure(res, record, csrfToken, responseOptions = {}, status = 200) {
     const cspNonce = crypto.randomBytes(18).toString('base64url');
     formHeaders(res, cspNonce);
+    const all = await registry.listManagementTemplates();
+    if (record.draft.kind === 'container') {
+      const memberChoices = all
+        .filter((candidate) => candidate.draft.kind !== 'container' && candidate.state !== 'archived')
+        .map((candidate) => ({
+          templateId: candidate.draft.templateId,
+          title: candidate.draft.title,
+          checked: candidate.draft.containerId === record.draft.templateId,
+        }))
+        .sort((left, right) => String(left.title).localeCompare(String(right.title)));
+      res.status(status).type('html').send(renderContainerConfigurePage(record, csrfToken, {
+        customThemeCss,
+        cspNonce,
+        memberChoices,
+        ...responseOptions,
+      }));
+      return;
+    }
+    const containers = all
+      .filter((candidate) => candidate.draft.kind === 'container' && candidate.state !== 'archived')
+      .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title}))
+      .sort((left, right) => String(left.title).localeCompare(String(right.title)));
     res.status(status).type('html').send(renderConfigurePage(record, csrfToken, destinationIds, {
       customThemeCss,
       cspNonce,
+      containers,
       ...responseOptions,
     }));
   }
@@ -1933,13 +2141,18 @@ function createFormsRouter(options) {
         return;
       }
       const templateId = postedString(req.body, 'templateId');
-      const body = {
-        templateId,
-        grammarVersion: 1,
-        destinationId: postedString(req.body, 'destinationId'),
-        title: postedString(req.body, 'title'),
-        fields: [{id: 'entry', type: 'short-text', label: 'Entry', required: true}],
-      };
+      const kind = postedString(req.body, 'kind');
+      // #234: the GUI creates containers through the same flow — no starter field,
+      // no destination; the Configure page then manages members.
+      const body = kind === 'container'
+        ? {templateId, grammarVersion: 1, title: postedString(req.body, 'title'), kind: 'container'}
+        : {
+          templateId,
+          grammarVersion: 1,
+          destinationId: postedString(req.body, 'destinationId'),
+          title: postedString(req.body, 'title'),
+          fields: [{id: 'entry', type: 'short-text', label: 'Entry', required: true}],
+        };
       const record = await createTemplateThroughApi(req, body);
       emitAudit(req, type, 'accepted', record.draft);
       res.redirect(303, `/forms/${encodeURIComponent(templateId)}/configure`);
@@ -2017,7 +2230,7 @@ function createFormsRouter(options) {
       if (!record) return formNotFound(req, res, type);
       if (!await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
       emitAudit(req, type, 'accepted', record.draft);
-      sendConfigure(res, record, issueContext(req, res));
+      await sendConfigure(res, record, issueContext(req, res));
     } catch (error) {
       next(error);
     }
@@ -2031,6 +2244,45 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
       const record = await registry.getManagementTemplate(req.params.templateId);
       if (!record || !await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
+      if (record.draft.kind === 'container') {
+        // #234: container Configure — basics on the container itself, membership as
+        // containerId diffs applied to the chosen member forms (truth stays on members).
+        if (!validContainerBuilderBody(req.body)) {
+          emitAudit(req, type, 'rejected_validation', record.draft);
+          res.status(400).type('text/plain').send('Invalid form body.');
+          return;
+        }
+        const presentation = {};
+        const existing = record.draft.presentation || {};
+        if (typeof existing.submitLabel === 'string') presentation.submitLabel = existing.submitLabel;
+        const theme = postedString(req.body, 'theme');
+        const themeMode = postedString(req.body, 'themeMode');
+        if (theme) presentation.theme = theme;
+        if (themeMode === 'dark' || themeMode === 'light') presentation.themeMode = themeMode;
+        const description = postedString(req.body, 'description');
+        const revisedContainer = await reviseTemplateThroughApi(req.params.templateId, {
+          revision: Number(postedString(req.body, 'revision')),
+          title: postedString(req.body, 'title'),
+          description: description || null,
+          presentation: Object.keys(presentation).length ? presentation : null,
+        });
+        const desired = new Set([].concat(req.body.member || []).filter((memberId) => typeof memberId === 'string' && memberId));
+        const containerId = req.params.templateId;
+        for (const candidate of await registry.listManagementTemplates()) {
+          if (candidate.draft.kind === 'container' || candidate.state === 'archived') continue;
+          if (!await allowed(req, 'forms.manage', candidate.draft)) continue;
+          const isMember = candidate.draft.containerId === containerId;
+          const shouldBe = desired.has(candidate.draft.templateId);
+          if (isMember === shouldBe) continue;
+          await registry.reviseDraft(candidate.draft.templateId, candidate.draft.revision, {
+            containerId: shouldBe ? containerId : null,
+          });
+        }
+        const fresh = await registry.getManagementTemplate(containerId);
+        emitAudit(req, type, 'accepted', revisedContainer.draft);
+        await sendConfigure(res, fresh, issueContext(req, res), {status: 'Draft saved.'});
+        return;
+      }
       if (!validBuilderBody(req.body)) {
         emitAudit(req, type, 'rejected_validation', record.draft);
         res.status(400).type('text/plain').send('Invalid form body.');
@@ -2039,12 +2291,12 @@ function createFormsRouter(options) {
       const patch = builderPatch(record.draft, req.body);
       const revised = await reviseTemplateThroughApi(req.params.templateId, patch);
       emitAudit(req, type, 'accepted', revised.draft);
-      sendConfigure(res, revised, issueContext(req, res), {status: 'Draft saved.'});
+      await sendConfigure(res, revised, issueContext(req, res), {status: 'Draft saved.'});
     } catch (error) {
       if (error && error.code === 'ESTALE') {
         emitAudit(req, type, 'rejected_validation');
         const latest = await registry.getManagementTemplate(req.params.templateId);
-        sendConfigure(res, latest, issueContext(req, res), {conflict: true}, 409);
+        await sendConfigure(res, latest, issueContext(req, res), {conflict: true}, 409);
         return;
       }
       if (error && error.code === 'EVALIDATION') {
@@ -2054,7 +2306,7 @@ function createFormsRouter(options) {
           ...current,
           draft: {...current.draft, ...builderPatch(current.draft, req.body), revision: current.draft.revision},
         };
-        sendConfigure(res, candidate, issueContext(req, res), {errors: error.details}, 422);
+        await sendConfigure(res, candidate, issueContext(req, res), {errors: error.details}, 422);
         return;
       }
       if (!sendTemplateMutationError(req, res, error, type)) next(error);
@@ -2078,12 +2330,12 @@ function createFormsRouter(options) {
       const version = await publishTemplateThroughApi(req, req.params.templateId, {revision: Number(req.body.revision)});
       const published = await registry.getManagementTemplate(req.params.templateId);
       emitAudit(req, type, 'accepted', version);
-      sendConfigure(res, published, issueContext(req, res), {status: `Published version ${version.templateVersion}.`});
+      await sendConfigure(res, published, issueContext(req, res), {status: `Published version ${version.templateVersion}.`});
     } catch (error) {
       if (error && error.code === 'ESTALE') {
         emitAudit(req, type, 'rejected_validation');
         const latest = await registry.getManagementTemplate(req.params.templateId);
-        sendConfigure(res, latest, issueContext(req, res), {conflict: true}, 409);
+        await sendConfigure(res, latest, issueContext(req, res), {conflict: true}, 409);
         return;
       }
       if (!sendTemplateMutationError(req, res, error, type)) next(error);
@@ -2105,6 +2357,14 @@ function createFormsRouter(options) {
         formHeaders(res, cspNonce);
         emitAudit(req, 'form.render', 'accepted', template);
         res.status(200).type('html').send(renderArchivedFormPage(template, {customThemeCss, cspNonce, canManage}));
+        return;
+      }
+      if (template.kind === 'container') {
+        const members = await containerMembersFor(req, template);
+        const cspNonce = crypto.randomBytes(18).toString('base64url');
+        formHeaders(res, cspNonce);
+        emitAudit(req, 'form.render', 'accepted', template);
+        res.status(200).type('html').send(renderContainerPage(template, members, {customThemeCss, cspNonce, canManage}));
         return;
       }
       const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
@@ -2132,6 +2392,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.submissions.list');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template) return formNotFound(req, res, 'form.submissions.list');
+      if (template.kind === 'container') return formNotFound(req, res, 'form.submissions.list');
       const submissions = await listVisibleSubmissions(req, template, 100);
       if (!submissions) return formNotFound(req, res, 'form.submissions.list');
       const canManage = await allowed(req, 'forms.manage', template);
@@ -2157,6 +2418,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.render');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template) return formNotFound(req, res, 'form.render');
+      if (template.kind === 'container') return formNotFound(req, res, 'form.render');
       const destinationStore = storeForTemplate(store, template);
       const record = await destinationStore.getSubmission(req.params.submissionId).catch((error) => {
         if (error && error.code === 'EVALIDATION') return null;
@@ -2222,6 +2484,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.submit');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template || !await allowed(req, 'forms.submit', template)) return formNotFound(req, res, 'form.submit');
+      if (template.kind === 'container') return formNotFound(req, res, 'form.submit');
       const destinationStore = storeForTemplate(store, template);
       const actor = principalFor(req);
       if (!actor) return formNotFound(req, res, 'form.submit');
@@ -2343,6 +2606,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res);
       const template = await registry.getTemplate(req.params.templateId);
       if (!template || !await allowed(req, 'forms.submit', template)) return apiNotFound(req, res);
+      if (template.kind === 'container') return apiNotFound(req, res);
       const destinationStore = storeForTemplate(store, template);
       const actor = principalFor(req);
       if (!actor) return apiNotFound(req, res);
@@ -2424,6 +2688,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, 'form.submissions.list');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template) return apiNotFound(req, res, 'form.submissions.list');
+      if (template.kind === 'container') return apiNotFound(req, res, 'form.submissions.list');
       const visible = await allowed(req, 'forms.submit', template)
         || await allowed(req, 'forms.read_submissions', template);
       const actor = principalFor(req);
@@ -2457,6 +2722,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, 'form.submission.history');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template) return apiNotFound(req, res, 'form.submission.history');
+      if (template.kind === 'container') return apiNotFound(req, res, 'form.submission.history');
       const destinationStore = storeForTemplate(store, template);
       const history = await destinationStore.getSubmissionHistory(req.params.submissionId).catch((error) => {
         if (error && error.code === 'EVALIDATION') return null;
@@ -2491,6 +2757,7 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.receipt.read');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template) return formNotFound(req, res, 'form.receipt.read');
+      if (template.kind === 'container') return formNotFound(req, res, 'form.receipt.read');
       const destinationStore = storeForTemplate(store, template);
       const record = await destinationStore.getSubmission(req.params.submissionId).catch((error) => {
         if (error && error.code === 'EVALIDATION') return null;

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -21,12 +21,13 @@ const CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/u;
 const TEMPLATE_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision',
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields', 'archived',
+  'presentation', 'fields', 'archived', 'kind', 'containerId', 'memberOrder',
 ]);
 const TEMPLATE_VERSION_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'templateVersion',
   'sourceRevision', 'grammarVersion', 'publishedAt', 'publishedBy', 'title',
   'description', 'tags', 'lineage', 'presentation', 'fields', 'schemaDigest',
+  'kind', 'containerId', 'memberOrder',
 ]);
 const FIELD_KEYS = new Set([
   'id', 'type', 'label', 'help', 'required', 'default', 'component',
@@ -410,8 +411,37 @@ function validateTemplate(doc) {
   const errors = [];
   if (!isRecord(doc)) return {valid: false, errors: [{path: '', message: 'template must be an object'}]};
   rejectUnknownKeys(doc, TEMPLATE_KEYS, '', errors);
-  const required = ['contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision', 'grammarVersion', 'title', 'fields'];
+  const isContainer = doc.kind === 'container';
+  const required = ['contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision', 'grammarVersion', 'title'];
+  if (!isContainer) required.push('fields');
   for (const key of required) if (!own(doc, key)) addError(errors, key, 'is required');
+  // #234: containers are templates of kind 'container' — same lifecycle, no fields,
+  // no destination, no nesting. Their page renders member navigation instead.
+  if (own(doc, 'kind') && doc.kind !== 'form' && doc.kind !== 'container') {
+    addError(errors, 'kind', "must be 'form' or 'container'");
+  }
+  if (isContainer) {
+    if (own(doc, 'fields') && (!Array.isArray(doc.fields) || doc.fields.length > 0)) {
+      addError(errors, 'fields', 'must be absent or empty for a container');
+    }
+    if (own(doc, 'destinationId')) addError(errors, 'destinationId', 'must be absent for a container');
+    if (own(doc, 'containerId')) addError(errors, 'containerId', 'containers cannot be nested');
+    if (own(doc, 'memberOrder')) {
+      if (!Array.isArray(doc.memberOrder) || doc.memberOrder.length > 200) {
+        addError(errors, 'memberOrder', 'must be an array of at most 200 definition IDs');
+      } else {
+        const seen = new Set();
+        doc.memberOrder.forEach((memberId, index) => {
+          validateId(memberId, `memberOrder[${index}]`, errors);
+          if (seen.has(memberId)) addError(errors, `memberOrder[${index}]`, 'must not repeat a member');
+          seen.add(memberId);
+        });
+      }
+    }
+  } else {
+    if (own(doc, 'memberOrder')) addError(errors, 'memberOrder', 'is only valid on a container');
+    if (own(doc, 'containerId')) validateId(doc.containerId, 'containerId', errors);
+  }
   if (own(doc, 'contractVersion') && doc.contractVersion !== 1) addError(errors, 'contractVersion', 'must equal 1');
   if (own(doc, 'resourceKind') && doc.resourceKind !== 'form-template') addError(errors, 'resourceKind', 'must equal form-template');
   if (own(doc, 'templateId')) validateId(doc.templateId, 'templateId', errors);
@@ -433,7 +463,9 @@ function validateTemplate(doc) {
   }
   if (own(doc, 'lineage')) validateLineage(doc.lineage, errors);
   if (own(doc, 'presentation')) validatePresentation(doc.presentation, errors);
-  if (!Array.isArray(doc.fields) || doc.fields.length < 1 || doc.fields.length > 200) {
+  if (isContainer) {
+    // container field rules handled above
+  } else if (!Array.isArray(doc.fields) || doc.fields.length < 1 || doc.fields.length > 200) {
     if (own(doc, 'fields')) addError(errors, 'fields', 'must be an array containing 1 through 200 fields');
   } else {
     const ids = new Set();

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -12,7 +12,7 @@ const { validateTemplate, validateTemplateVersion } = require('./schema');
 const DEFINITION_ID = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const MUTABLE_TEMPLATE_KEYS = [
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields',
+  'presentation', 'fields', 'containerId', 'memberOrder',
 ];
 
 function isDefinitionId(value) {
@@ -295,6 +295,17 @@ class TemplateRegistry {
     return entry ? this.publicEntry(entry) : null;
   }
 
+  async assertContainerReference(template) {
+    // #234 fail-closed: a containerId must identify an existing, unarchived
+    // container-kind template — same alias-indirection posture as destinationId.
+    if (!template.containerId) return;
+    const target = await this.entryFor(template.containerId);
+    const ok = target && target.template && target.template.kind === 'container' && target.template.archived !== true;
+    if (!ok) {
+      throw validationError([{path: 'containerId', message: 'must identify an existing container'}]);
+    }
+  }
+
   async listTemplates() {
     await this.refresh();
     return [...this.files.values()]
@@ -380,6 +391,7 @@ class TemplateRegistry {
     }
     this.validateDraft(template);
     return this.withMutationLock(template.templateId, async () => {
+      await this.assertContainerReference(template);
       if (await this.entryFor(template.templateId)) throw codedError('ECONFLICT', 'Template already exists.');
       await fs.mkdir(this.templatesPath, {recursive: true});
       const templateDirectory = path.join(this.templatesPath, template.templateId);
@@ -419,7 +431,7 @@ class TemplateRegistry {
       const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
       for (const key of MUTABLE_TEMPLATE_KEYS) {
         if (!Object.prototype.hasOwnProperty.call(changes, key)) continue;
-        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation'].includes(key)) {
+        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation', 'containerId', 'memberOrder'].includes(key)) {
           delete revised[key];
         } else if (key === 'presentation' && isPlainObject(changes.presentation) && isPlainObject(revised.presentation)) {
           // #225: merge presentation patches instead of replacing wholesale — a patch
@@ -448,6 +460,7 @@ class TemplateRegistry {
       }
       revised.revision += 1;
       this.validateDraft(revised);
+      await this.assertContainerReference(revised);
       await this.durableReplace(entry.draftPath, canonicalize(revised));
       entry.template = revised;
       entry.schemaDigest = schemaDigest(revised);
@@ -475,6 +488,7 @@ class TemplateRegistry {
       else delete revised.archived;
       revised.revision += 1;
       this.validateDraft(revised);
+      await this.assertContainerReference(revised);
       await this.durableReplace(entry.draftPath, canonicalize(revised));
       entry.template = revised;
       entry.schemaDigest = schemaDigest(revised);

--- a/public/style.css
+++ b/public/style.css
@@ -2721,6 +2721,62 @@ tbody tr:last-child td {
   background: color-mix(in srgb, var(--accent) 16%, var(--bg-elev));
 }
 
+/* #234: container forms — container page, root grouping, configure members. */
+.form-layout .container-members {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+.form-layout .container-member {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.9rem 1.1rem;
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--accent);
+  border-radius: 0.7rem;
+  background: var(--bg-elev);
+  text-decoration: none;
+  color: var(--text);
+}
+.form-layout .container-member:hover { border-color: var(--accent); }
+.form-layout .container-member-title {
+  font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+.form-layout .container-empty { color: var(--text-soft); }
+.form-layout .related-container-link {
+  display: inline-block;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.6rem;
+  text-decoration: none;
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-elev));
+  font-family: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 0.88rem;
+}
+.form-layout .forms-index-container { margin-bottom: 1.4rem; }
+.form-layout .forms-index-container-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.7rem;
+  margin-bottom: 0.6rem;
+}
+.form-layout .forms-index-container-head a { text-decoration: none; color: var(--text); }
+.form-layout .forms-index-container-head h2 { margin: 0; }
+.form-layout .forms-index-container-count { color: var(--text-soft); font-size: 0.85rem; }
+.form-layout .forms-index-container-configure { margin-left: auto; font-size: 0.85rem; color: var(--text-soft); }
+.form-layout .forms-index-ungrouped-head { margin: 1.2rem 0 0.6rem; }
+.form-layout .container-member-choices {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+}
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -420,7 +420,7 @@ test('forms index separates archived templates and removes management detail for
     assert.equal(submitted.status, 303);
 
     const managerIndex = await browserPage(await server.request('/forms'));
-    assert.equal(managerIndex.document.querySelectorAll('.forms-index-list[aria-label="Active templates"] > .forms-index-item').length, 2);
+    assert.equal(managerIndex.document.querySelectorAll('.forms-index-groups[aria-label="Active templates"] .forms-index-item').length, 2);
     assert.ok(managerIndex.document.querySelector('a[href="/forms/new"]'));
     const trainingCard = [...managerIndex.document.querySelectorAll('.forms-index-item')]
       .find((card) => /Training <log>/.test(card.textContent));

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -1976,3 +1976,71 @@ test('form and receipt pages render tag-based related-forms navigation (#234 int
     await cleanup(fixture, server);
   }
 });
+
+test('container forms: lifecycle, page, membership nav, root grouping, guards (#234)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {formsTimezone: 'America/New_York'});
+  try {
+    const context = await getBrowserContext(server);
+    const post = (route, body) => server.request(route, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token },
+      body: JSON.stringify(body),
+    });
+    // create a container through the same template API
+    const created = await post('/api/forms/templates', {templateId: 'gym', title: 'Gym', kind: 'container', grammarVersion: 1});
+    assert.equal(created.status, 201);
+    // bad containerId fails closed
+    const bad = await server.request('/api/forms/templates/gym-session-entry', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token },
+      body: JSON.stringify({revision: 1, containerId: 'nope'}),
+    });
+    assert.equal(bad.status, 422);
+    // membership via PATCH
+    const joined = await server.request('/api/forms/templates/gym-session-entry', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token },
+      body: JSON.stringify({revision: 1, containerId: 'gym'}),
+    });
+    assert.equal(joined.status, 200);
+
+    // container page renders the member; submissions to it are refused
+    const page = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
+    assert.match(page, /container-member-title/);
+    assert.match(page, /gym-session-entry/);
+    const submit = await server.request('/forms/gym', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: nativeBody(context.token),
+    });
+    assert.equal(submit.status, 404);
+    assert.equal((await server.request('/forms/gym/entries', {headers: {Cookie: context.cookie}})).status, 404);
+
+    // member form carries the back-to-container button
+    const member = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    assert.match(member, /related-container-link/);
+    assert.match(member, /← Gym/);
+
+    // root groups: container section with the member inside
+    const root = await (await server.request('/forms', {headers: {Cookie: context.cookie}})).text();
+    assert.match(root, /forms-index-container-head/);
+    assert.match(root, /1 form</);
+
+    // container Configure: member checkboxes; unchecking releases membership
+    const configure = await (await server.request('/forms/gym/configure', {headers: {Cookie: context.cookie}})).text();
+    assert.match(configure, /container-member-choice/);
+    assert.match(configure, /checked/);
+    const gymRev = JSON.parse(await (await server.request('/api/forms/templates/gym')).text()).template.revision;
+    const saved = await server.request('/forms/gym/configure', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: new URLSearchParams({_csrf: context.token, revision: String(gymRev), title: 'Gym'}),
+    });
+    assert.equal(saved.status, 200);
+    const released = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text());
+    assert.equal(released.template.containerId, undefined);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});

--- a/test/forms-template-api.test.js
+++ b/test/forms-template-api.test.js
@@ -261,6 +261,8 @@ test('template API lifecycle uses CAS and preserves immutable versions and old r
       destinationId: 'gym-log',
       state: 'published',
       entryCount: 1,
+      kind: 'form',
+      containerId: null,
     }]);
     const fetchedResponse = await server.request('/api/forms/templates/training-log', {headers: AGENT_HEADERS});
     assert.equal(fetchedResponse.status, 200);
@@ -494,8 +496,8 @@ test('clone and archive APIs preserve source history, receipts, CAS, and authori
 
     const submitOnlyList = await server.request('/api/forms/templates', {headers: submitOnly});
     assert.deepEqual((await submitOnlyList.json()).templates.map((template) => Object.keys(template).sort()), [
-      ['templateId', 'title'],
-      ['templateId', 'title'],
+      ['containerId', 'kind', 'templateId', 'title'],
+      ['containerId', 'kind', 'templateId', 'title'],
     ]);
     assert.equal((await server.request('/api/forms/templates/training-log', {
       method: 'DELETE',


### PR DESCRIPTION
Fixes #234.

Implements the operator-designed container spec, every settled decision included:

- **Container is itself a form** — same registry, CAS lifecycle, publish, presentation, Configure page, and template APIs, of `kind: 'container'` (no fields, no destination, no nesting v1).
- **Membership** — `containerId` on member forms, fail-closed to an existing unarchived container (destinationId alias posture). `memberOrder` on containers: presentation-only circuit ordering, unknown ids ignored, unlisted members title-sorted.
- **Navigation (c/d)** — member forms AND receipts render "← Container" + the sibling strip from membership (tag heuristic remains as fallback for uncontained forms).
- **/forms root (e)** — container sections first with members nested, then Ungrouped.
- **GUI end-to-end** — New-template page gains a Kind select (containers created through the same flow); container Configure shows member checkboxes (check to point a form's containerId here, uncheck to release — the operator's "go into the container and choose the forms" flow); member Configure gains a Container select.
- Guards: submissions/entries/receipts 404 for containers; `schemaDigest` handles fields-less templates.

**Test gates:** new end-to-end container test (API create, fail-closed containerId 422, page render, submit refusal, ← button, root grouping, configure-release) plus updated projections/selectors. Suite 196 pass / 1 pre-existing (#240); both validators exit 0; browser canary passes with CHROME_BIN.

Migration (post-deploy, operator data): gym + health containers, members pointed, circuit order set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
