### PR TITLE
feat(forms): hub-nav tabs on container pages and the forms root

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -128,6 +128,18 @@ function formBreadcrumbs(template, options = {}) {
   return `<nav class="breadcrumbs">${crumbs.join('<span class="sep">/</span>')}</nav>`;
 }
 
+function containerHubNav(templateId, active, canManage) {
+  // #234 follow-up: a container is a form, so its pages carry the same hub tabs.
+  const href = `/forms/${encodeURIComponent(templateId)}`;
+  const links = [
+    ['view', href, 'Forms'],
+    ...(canManage ? [['configure', `${href}/configure`, 'Configure']] : []),
+  ];
+  return `<nav class="form-hub-nav" aria-label="Container views">${links.map(([key, linkHref, label]) =>
+    `<a class="${key}-link" href="${linkHref}"${key === active ? ' aria-current="page"' : ''}>${label}</a>`
+  ).join('')}</nav>`;
+}
+
 function formHubNav(templateId, active, canManage) {
   const formHref = `/forms/${encodeURIComponent(templateId)}`;
   const links = [
@@ -323,10 +335,13 @@ function renderContainerPage(template, members, options = {}) {
       `<a class="container-member" href="/forms/${encodeURIComponent(member.templateId)}"><span class="container-member-title">${escapeHtml(member.title)}</span><span aria-hidden="true">›</span></a>`
     )).join('')
     : '<p class="container-empty">No forms in this container yet. Add some from its Configure page.</p>';
-  const body = `${toolbarHtml(options.canManage ? `<a class="toolbar-btn" href="/forms/${encodeURIComponent(template.templateId)}/configure" aria-label="Configure container">Configure</a>` : '')}
+  const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout">
+    <header class="topbar">
+      <div><p class="eyebrow">Forms</p><h1>${escapeHtml(template.title)}</h1>${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
+      ${containerHubNav(template.templateId, 'view', options.canManage)}
+    </header>
     <section class="content form-card container-card">
-      <header class="topbar"><div><p class="eyebrow">Forms</p><h1>${escapeHtml(template.title)}</h1>${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div></header>
       <div class="container-members">${cards}</div>
     </section>
   </main>
@@ -965,8 +980,11 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
   const lifecycle = template.archived === true ? 'restore' : 'archive';
   const body = `${toolbarHtml()}
   <main class="layout form-layout builder-layout">
+    <header class="topbar">
+      <div><p class="eyebrow">Container</p><h1>${escapeHtml(template.title)}</h1></div>
+      ${containerHubNav(template.templateId, 'configure', true)}
+    </header>
     <section class="content form-card builder-card container-configure-card">
-      <header class="topbar"><div><p class="eyebrow">Container</p><h1>${escapeHtml(template.title)}</h1></div></header>
       <dl class="builder-revisions">
         <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
         <div><dt>Published</dt><dd>${escapeHtml(publishedText)}</dd></div>
@@ -1038,7 +1056,10 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     : '';
   const body = `${toolbarHtml()}
   <main class="layout form-layout forms-index-layout">
-    <header class="topbar forms-index-header"><div><p class="eyebrow">Forms</p><h1>Templates</h1><p class="subtitle">${managed ? 'Create, configure, and review your forms.' : 'Choose a form to log an entry.'}</p></div>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New template</a>' : ''}</header>
+    <header class="topbar forms-index-header">
+      <div><p class="eyebrow">Forms</p><h1>Templates</h1><p class="subtitle">${managed ? 'Create, configure, and review your forms.' : 'Choose a form to log an entry.'}</p></div>
+      <nav class="form-hub-nav" aria-label="Forms views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New template</a>' : ''}</nav>
+    </header>
     <div class="forms-index-groups" aria-label="Active templates">${activeHtml}</div>
     ${archivedHtml}
   </main>


### PR DESCRIPTION
Containers and the /forms root carry the same top tab strip as regular forms — the operator's form-of-forms parity: container pages get Forms | Configure tabs; the root gets Browse | New template. Suite green minus known #240; validators 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
