### PR TITLE
feat(forms): expandable member previews on container pages

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -328,11 +328,31 @@ function datetimeCaptureScript(cspNonce) {
 </script>`;
 }
 
+function renderFormPreview(member) {
+  // Container member previews use the platform's own field renderers inside a
+  // disabled fieldset — see the form exactly as it renders, without submitting.
+  const fields = (member.fields || []).filter((field) => field.isDestroyed !== true);
+  const rows = fields.map((field) => {
+    const controlId = `preview-${member.templateId}-${field.id}`;
+    return `<div class="field field-${escapeHtml(field.type)}">
+      <label for="${escapeHtml(controlId)}">${escapeHtml(field.label)}${field.required ? ' <span aria-label="required">*</span>' : ''}</label>
+      ${renderControl(field, {}, [], false, {controlId})}
+    </div>`;
+  }).join('');
+  return `<fieldset disabled class="container-form-preview" aria-label="Preview of ${escapeHtml(member.title)}">${rows}</fieldset>`;
+}
+
 function renderContainerPage(template, members, options = {}) {
   // #234: a container's page IS its form view — member navigation instead of fields.
   const cards = members.length
     ? members.map((member) => (
-      `<a class="container-member" href="/forms/${encodeURIComponent(member.templateId)}"><span class="container-member-title">${escapeHtml(member.title)}</span><span aria-hidden="true">›</span></a>`
+      `<details class="container-member-row">
+        <summary class="container-member"><span class="container-member-title">${escapeHtml(member.title)}</span><span aria-hidden="true">›</span></summary>
+        <div class="container-member-preview">
+          ${renderFormPreview(member)}
+          <a class="button-link button-link-primary container-member-open" href="/forms/${encodeURIComponent(member.templateId)}">Open ${escapeHtml(member.title)}</a>
+        </div>
+      </details>`
     )).join('')
     : '<p class="container-empty">No forms in this container yet. Add some from its Configure page.</p>';
   const body = `${toolbarHtml()}

--- a/public/style.css
+++ b/public/style.css
@@ -2777,6 +2777,16 @@ tbody tr:last-child td {
   margin-top: 0.6rem;
 }
 
+/* #234 follow-up: expandable member previews on container pages. */
+.form-layout .container-member-row { border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 0.7rem; background: var(--bg-elev); }
+.form-layout .container-member-row > .container-member { border: 0; background: transparent; cursor: pointer; list-style: none; }
+.form-layout .container-member-row > .container-member::-webkit-details-marker { display: none; }
+.form-layout .container-member-row[open] > .container-member { border-bottom: 1px solid var(--border); border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+.form-layout .container-member-preview { padding: 0.9rem 1.1rem 1.1rem; }
+.form-layout .container-form-preview { border: 0; margin: 0 0 0.8rem; padding: 0; display: grid; gap: 0.7rem; opacity: 0.85; }
+.form-layout .container-form-preview .field label { display: block; margin-bottom: 0.25rem; color: var(--text-soft); font-size: 0.85rem; }
+.form-layout .container-member-open { display: inline-block; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2009,6 +2009,10 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     const page = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(page, /container-member-title/);
     assert.match(page, /gym-session-entry/);
+    // member rows expand to a disabled live preview of the form's fields
+    assert.match(page, /<fieldset disabled class="container-form-preview"/);
+    assert.match(page, /preview-gym-session-entry-lift/);
+    assert.match(page, /container-member-open/);
     const submit = await server.request('/forms/gym', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },


### PR DESCRIPTION
Follow-up to #234, operator ask: "see what the form looks like... however the forms themselves do it."

Container member rows become the platform's own `<details>` disclosure idiom: expanding a member renders a live preview of that form's fields (the real field renderers inside a disabled fieldset — defaults, options, and stepped selects included) plus an Open button. Browse the Gym container, peek at any machine form, open the one you want.

**Test gates:** container test extended — preview fieldset present, per-member control ids, Open link. Suite 197 pass / 1 pre-existing (#240); validators exit 0; canary passes with CHROME_BIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
