### PR TITLE
feat(forms): container dashboard — aggregate member entries

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -11,6 +11,7 @@ const CONTEXT_COOKIE = 'lookie_forms_context';
 const MAX_CONTEXTS = 10000;
 const MAX_STEPPED_OPTIONS = 200;
 const RECENT_ENTRY_LIMIT = 3;
+const CONTAINER_RECENT_LIMIT = 6;
 const ARTIFACT_SANDBOX = 'sandbox allow-scripts allow-forms allow-popups';
 const EMBED_SANDBOX = `${ARTIFACT_SANDBOX} allow-top-navigation-by-user-activation`; // #232 — mirrors server.js
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -133,6 +134,7 @@ function containerHubNav(templateId, active, canManage) {
   const href = `/forms/${encodeURIComponent(templateId)}`;
   const links = [
     ['view', href, 'Forms'],
+    ['history', `${href}/entries`, 'History'],
     ...(canManage ? [['configure', `${href}/configure`, 'Configure']] : []),
   ];
   return `<nav class="form-hub-nav" aria-label="Container views">${links.map(([key, linkHref, label]) =>
@@ -342,6 +344,22 @@ function renderFormPreview(member) {
   return `<fieldset disabled class="container-form-preview" aria-label="Preview of ${escapeHtml(member.title)}">${rows}</fieldset>`;
 }
 
+function renderContainerRecent(template, tagged, options = {}) {
+  // #248: a container's dashboard is the aggregate of its members' entries —
+  // the same recent-entries idiom normal forms use, rows chipped by member form.
+  const entriesHref = `/forms/${encodeURIComponent(template.templateId)}/entries`;
+  const content = tagged.length
+    ? `<div class="entry-list">${tagged.map(({ member, record }) =>
+      renderEntryRow(member, record, options.timezone, options.csrfToken, { now: options.now, memberTitle: member.title })).join('')}</div>`
+    : '<p class="recent-entries-empty">Entries from the forms above will appear here.</p>';
+  return `<aside class="recent-entries" aria-labelledby="recent-entries-heading">
+        <div class="recent-entries-heading">
+          <h2 id="recent-entries-heading">Recent entries</h2>
+          <a href="${entriesHref}">View all</a>
+        </div>
+        ${content}</aside>`;
+}
+
 function renderContainerPage(template, members, options = {}) {
   // #234: a container's page IS its form view — member navigation instead of fields.
   const cards = members.length
@@ -363,6 +381,7 @@ function renderContainerPage(template, members, options = {}) {
     </header>
     <section class="content form-card container-card">
       <div class="container-members">${cards}</div>
+      ${renderContainerRecent(template, options.recentTagged || [], options)}
     </section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;
@@ -704,7 +723,7 @@ function renderEntryRow(template, record, timezone, csrfToken, rowOptions = {}) 
   }
   return `<details class="entry-row">
     <summary class="entry-row-summary">
-      <span class="entry-row-heading"><time datetime="${escapeHtml(stamp.timestamp)}">${escapeHtml(headTime)}</time>${listed.selection ? `<strong>${escapeHtml(displayValue(listed.selection, recordTimeZone))}</strong>` : ''}<span class="entry-edit-marker">Edit</span></span>
+      <span class="entry-row-heading"><time datetime="${escapeHtml(stamp.timestamp)}">${escapeHtml(headTime)}</time>${rowOptions.memberTitle ? `<span class="entry-form-chip">${escapeHtml(rowOptions.memberTitle)}</span>` : ''}${listed.selection ? `<strong>${escapeHtml(displayValue(listed.selection, recordTimeZone))}</strong>` : ''}<span class="entry-edit-marker">Edit</span></span>
       <span class="entry-metrics">${entryMetrics(listed.entries, recordTimeZone)}</span>
     </summary>
     <div class="entry-row-editor">
@@ -730,16 +749,16 @@ function renderEntriesPage(template, records, options = {}) {
   const entries = [...groups.values()].map(({ stamp, records: dayRecords }) => `
       <section class="entries-day" aria-labelledby="entries-${escapeHtml(stamp.dateKey)}">
         <h2 id="entries-${escapeHtml(stamp.dateKey)}"><time datetime="${escapeHtml(stamp.dateKey)}">${escapeHtml(stamp.dayLabel)}</time></h2>
-        <div class="entry-list">${dayRecords.map(({ record }) => renderEntryRow(template, record, options.timezone, options.csrfToken)).join('')}</div>
+        <div class="entry-list">${dayRecords.map(({ record }) => renderEntryRow(record.__member || template, record, options.timezone, options.csrfToken, record.__member ? { memberTitle: record.__member.title } : {})).join('')}</div>
       </section>`).join('');
   const content = records.length > 0
     ? entries
-    : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">Log an entry</a></div>`;
+    : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">${template.kind === 'container' ? 'Open the forms' : 'Log an entry'}</a></div>`;
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout entries-layout">
     <header class="topbar">
       ${formBreadcrumbs(template)}
-      ${formHubNav(template.templateId, 'history', options.canManage)}
+      ${template.kind === 'container' ? containerHubNav(template.templateId, 'history', options.canManage) : formHubNav(template.templateId, 'history', options.canManage)}
     </header>
     <section class="content form-card entries-card">${content}</section>
   </main>
@@ -1549,6 +1568,17 @@ function createFormsRouter(options) {
 
   async function allowed(req, capability, resource) {
     return Boolean(await authorize({ req, capability, resource }));
+  }
+
+  // #248: a container's entries are the merged, newest-first entries of its members.
+  async function containerTaggedEntries(req, members, limit) {
+    const batches = await Promise.all(members.map(async (member) => {
+      const records = await listVisibleSubmissions(req, member, limit) || [];
+      return records.map((record) => ({ member, record }));
+    }));
+    return batches.flat()
+      .sort((a, b) => Date.parse(b.record.eventAt || b.record.submittedAt || 0) - Date.parse(a.record.eventAt || a.record.submittedAt || 0))
+      .slice(0, limit);
   }
 
   async function listVisibleSubmissions(req, template, limit) {
@@ -2402,10 +2432,15 @@ function createFormsRouter(options) {
       }
       if (template.kind === 'container') {
         const members = await containerMembersFor(req, template);
+        const recentTagged = await containerTaggedEntries(req, members, CONTAINER_RECENT_LIMIT);
+        const csrfToken = issueContext(req, res);
         const cspNonce = crypto.randomBytes(18).toString('base64url');
         formHeaders(res, cspNonce);
         emitAudit(req, 'form.render', 'accepted', template);
-        res.status(200).type('html').send(renderContainerPage(template, members, {customThemeCss, cspNonce, canManage}));
+        res.status(200).type('html').send(renderContainerPage(template, members, {
+          customThemeCss, cspNonce, canManage, recentTagged, csrfToken,
+          timezone: serverTimezone, now: currentDate(),
+        }));
         return;
       }
       const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
@@ -2433,7 +2468,20 @@ function createFormsRouter(options) {
       if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, 'form.submissions.list');
       const template = await registry.getTemplate(req.params.templateId);
       if (!template) return formNotFound(req, res, 'form.submissions.list');
-      if (template.kind === 'container') return formNotFound(req, res, 'form.submissions.list');
+      if (template.kind === 'container') {
+        const members = await containerMembersFor(req, template);
+        const tagged = await containerTaggedEntries(req, members, 100);
+        const submissions = tagged.map(({ member, record }) => ({ ...record, __member: member }));
+        const canManage = await allowed(req, 'forms.manage', template);
+        const csrfToken = issueContext(req, res);
+        const cspNonce = crypto.randomBytes(18).toString('base64url');
+        formHeaders(res, cspNonce);
+        emitAudit(req, 'form.submissions.list', 'accepted', template);
+        res.status(200).type('html').send(renderEntriesPage(template, submissions, {
+          customThemeCss, cspNonce, timezone: serverTimezone, canManage, csrfToken,
+        }));
+        return;
+      }
       const submissions = await listVisibleSubmissions(req, template, 100);
       if (!submissions) return formNotFound(req, res, 'form.submissions.list');
       const canManage = await allowed(req, 'forms.manage', template);

--- a/public/style.css
+++ b/public/style.css
@@ -2787,6 +2787,10 @@ tbody tr:last-child td {
 .form-layout .container-form-preview .field label { display: block; margin-bottom: 0.25rem; color: var(--text-soft); font-size: 0.85rem; }
 .form-layout .container-member-open { display: inline-block; }
 
+/* #248: container dashboard — member-form chip on aggregated entry rows. */
+.form-layout .entry-form-chip { font-size: 0.72rem; padding: 0.1rem 0.5rem; border-radius: 999px; background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent); white-space: nowrap; }
+.form-layout .container-card .recent-entries { margin-top: 1.2rem; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2019,7 +2019,23 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
       body: nativeBody(context.token),
     });
     assert.equal(submit.status, 404);
-    assert.equal((await server.request('/forms/gym/entries', {headers: {Cookie: context.cookie}})).status, 404);
+
+    // #248: the container dashboard — a member entry surfaces on the container
+    // page's recent list (chipped by form) and on the aggregated history page.
+    const logged = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: nativeBody(context.token),
+    });
+    assert.ok(logged.status === 200 || logged.status === 303, `submit status ${logged.status}`);
+    const dashboard = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
+    assert.match(dashboard, /recent-entries/);
+    assert.match(dashboard, /entry-form-chip">Gym Session Entry</);
+    const history = await server.request('/forms/gym/entries', {headers: {Cookie: context.cookie}});
+    assert.equal(history.status, 200);
+    const historyPage = await history.text();
+    assert.match(historyPage, /entries-day/);
+    assert.match(historyPage, /entry-form-chip/);
 
     // member form carries the back-to-container button
     const member = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();


### PR DESCRIPTION
Closes #248. Operator ask: containers "behaving like real forms and having the dashboard for that form... integrated into the view kind of like we do with normal forms."

- Container page gains the platform's Recent entries aside: members' entries merged newest-first (limit 6), rows rendered by the real `renderEntryRow` — inline corrections post to the member form, receipt links work — with a member-title chip for provenance.
- `/forms/<container>/entries` (previously guarded 404) is now the aggregated day-grouped history via `renderEntriesPage`; container hub nav gains the History tab.
- Visibility fail-closed per member via `listVisibleSubmissions`.

**Test gates:** container test extended (member submit → chip on container page, 200 + day groups on history). Suite 198 pass / 1 pre-existing (#240); validators exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL

**Gate note:** `validate:raw-html` is red on clean origin/main (pre-existing, from e33cebc — flagged separately); `validate:editable` and the full suite are green here.
