### PR TITLE
feat(forms): parent/sub-form inheritance — children inherit fields live

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -17,11 +17,11 @@ const EMBED_SANDBOX = `${ARTIFACT_SANDBOX} allow-top-navigation-by-user-activati
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const TEMPLATE_CREATE_KEYS = new Set([
   'templateId', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
-  'lineage', 'presentation', 'fields', 'kind', 'containerId', 'memberOrder',
+  'lineage', 'presentation', 'fields', 'kind', 'containerId', 'memberOrder', 'parentId',
 ]);
 const TEMPLATE_PATCH_KEYS = new Set([
   'revision', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
-  'lineage', 'presentation', 'fields', 'containerId', 'memberOrder',
+  'lineage', 'presentation', 'fields', 'containerId', 'memberOrder', 'parentId',
 ]);
 const TEMPLATE_PUBLISH_KEYS = new Set(['revision']);
 const TEMPLATE_CLONE_KEYS = new Set(['templateId', 'templateVersion', 'title']);
@@ -924,12 +924,14 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           <p class="builder-help">Destinations are deployment-approved aliases. Filesystem paths cannot be entered here.</p>
           <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
           <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
+          ${Array.isArray(options.parents) && options.parents.length ? `<label><span>Parent form</span><select name="parent"><option value=""${!template.parentId ? ' selected' : ''}>None</option>${options.parents.map((parent) => `<option value="${escapeHtml(parent.templateId)}"${template.parentId === parent.templateId ? ' selected' : ''}>${escapeHtml(parent.title)}</option>`).join('')}</select></label><p class="builder-help">A child form inherits every parent field live. Fields below override a parent field with the same id or extend the form; detaching copies the resolved fields back onto this form (#245).</p>` : ''}
+          ${Array.isArray(options.children) && options.children.length ? `<p class="builder-help builder-parent-note">Parent of ${options.children.length} form${options.children.length === 1 ? '' : 's'}: ${options.children.map((child) => escapeHtml(child.title)).join(', ')}. Edits here flow to them live.</p>` : ''}
           ${Array.isArray(options.containers) && options.containers.length ? `<label><span>Container</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${options.containers.map((container) => `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label><p class="builder-help">Containers group forms and give each member back-and-sibling navigation.</p>` : ''}
           <p class="builder-help">Themes are installed by the deployment and read from the server. Leave both alone and this form follows whatever theme the viewer has chosen.</p>
         </section>
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
-          ${template.fields.map((field, index) => builderField(field, index, template.fields.length)).join('')}
+          ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length)).join('')}
         </section>
         <button class="button-link button-link-primary form-primary-action" type="submit" name="_action" value="save">Save draft</button>
       </form>
@@ -1174,7 +1176,7 @@ function postedFields(current, body) {
   const indices = postedIndices(body, /^field\.(\d+)\./);
   return indices.map((fieldIndex) => {
     const prefix = `field.${fieldIndex}`;
-    const previous = current.fields[fieldIndex];
+    const previous = (current.fields || [])[fieldIndex];
     const id = previous ? previous.id : postedString(body, `${prefix}.id`);
     const type = postedString(body, `${prefix}.type`);
     const sameType = previous && previous.type === type;
@@ -1304,6 +1306,11 @@ function builderPatch(current, body) {
   if (Object.prototype.hasOwnProperty.call(body, 'container')) {
     // '' means uncontained; the registry fail-closes unknown container ids (#234).
     patch.containerId = postedString(body, 'container') || null;
+  }
+  if (Object.prototype.hasOwnProperty.call(body, 'parent')) {
+    // '' detaches; the registry fail-closes unknown/nested parents and
+    // materializes the resolved fields on detach (#245).
+    patch.parentId = postedString(body, 'parent') || null;
   }
   return patch;
 }
@@ -1848,6 +1855,7 @@ function createFormsRouter(options) {
           entryCount,
           kind: record.draft.kind === 'container' ? 'container' : 'form',
           containerId: record.draft.containerId || null,
+          parentId: record.draft.parentId || null,
         });
       } else if (record.state !== 'archived' && await allowed(req, 'forms.submit', record.draft)) {
         templates.push({
@@ -1855,6 +1863,7 @@ function createFormsRouter(options) {
           title: record.draft.title,
           kind: record.draft.kind === 'container' ? 'container' : 'form',
           containerId: record.draft.containerId || null,
+          parentId: record.draft.parentId || null,
         });
       }
     }
@@ -1932,7 +1941,17 @@ function createFormsRouter(options) {
       const record = await registry.getManagementTemplate(req.params.templateId);
       if (!record || !await allowed(req, 'forms.manage', record.draft)) return apiNotFound(req, res, type);
       emitAudit(req, type, 'accepted', record.draft);
-      res.status(200).json({ ok: true, ...templateProjection(record) });
+      // #245: the draft carries a child's OWN fields (what the builder edits);
+      // resolvedFields/resolvedSchemaDigest show what actually serves.
+      const projection = templateProjection(record);
+      if (record.draft.parentId) {
+        const resolved = await registry.getTemplate(record.draft.templateId);
+        if (resolved) {
+          projection.resolvedFields = resolved.fields;
+          projection.resolvedSchemaDigest = resolved.schemaDigest;
+        }
+      }
+      res.status(200).json({ ok: true, ...projection });
     } catch (error) {
       next(error);
     }
@@ -2156,10 +2175,22 @@ function createFormsRouter(options) {
       .filter((candidate) => candidate.draft.kind === 'container' && candidate.state !== 'archived')
       .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title}))
       .sort((left, right) => String(left.title).localeCompare(String(right.title)));
+    // #245: eligible parents are top-level active forms (single-level inheritance).
+    const parents = all
+      .filter((candidate) => candidate.draft.kind !== 'container' && candidate.state !== 'archived'
+        && !candidate.draft.parentId && candidate.draft.templateId !== record.draft.templateId)
+      .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title}))
+      .sort((left, right) => String(left.title).localeCompare(String(right.title)));
+    const children = all
+      .filter((candidate) => candidate.draft.parentId === record.draft.templateId && candidate.state !== 'archived')
+      .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title}))
+      .sort((left, right) => String(left.title).localeCompare(String(right.title)));
     res.status(status).type('html').send(renderConfigurePage(record, csrfToken, destinationIds, {
       customThemeCss,
       cspNonce,
       containers,
+      parents,
+      children,
       ...responseOptions,
     }));
   }

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -21,13 +21,13 @@ const CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/u;
 const TEMPLATE_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision',
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields', 'archived', 'kind', 'containerId', 'memberOrder',
+  'presentation', 'fields', 'archived', 'kind', 'containerId', 'memberOrder', 'parentId',
 ]);
 const TEMPLATE_VERSION_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'templateVersion',
   'sourceRevision', 'grammarVersion', 'publishedAt', 'publishedBy', 'title',
   'description', 'tags', 'lineage', 'presentation', 'fields', 'schemaDigest',
-  'kind', 'containerId', 'memberOrder',
+  'kind', 'containerId', 'memberOrder', 'parentId',
 ]);
 const FIELD_KEYS = new Set([
   'id', 'type', 'label', 'help', 'required', 'default', 'component',
@@ -413,7 +413,8 @@ function validateTemplate(doc) {
   rejectUnknownKeys(doc, TEMPLATE_KEYS, '', errors);
   const isContainer = doc.kind === 'container';
   const required = ['contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision', 'grammarVersion', 'title'];
-  if (!isContainer) required.push('fields');
+  // #245: a child form may inherit every field from its parent — own fields optional.
+  if (!isContainer && !own(doc, 'parentId')) required.push('fields');
   for (const key of required) if (!own(doc, key)) addError(errors, key, 'is required');
   // #234: containers are templates of kind 'container' — same lifecycle, no fields,
   // no destination, no nesting. Their page renders member navigation instead.
@@ -426,6 +427,7 @@ function validateTemplate(doc) {
     }
     if (own(doc, 'destinationId')) addError(errors, 'destinationId', 'must be absent for a container');
     if (own(doc, 'containerId')) addError(errors, 'containerId', 'containers cannot be nested');
+    if (own(doc, 'parentId')) addError(errors, 'parentId', 'is only valid on a form');
     if (own(doc, 'memberOrder')) {
       if (!Array.isArray(doc.memberOrder) || doc.memberOrder.length > 200) {
         addError(errors, 'memberOrder', 'must be an array of at most 200 definition IDs');
@@ -441,6 +443,10 @@ function validateTemplate(doc) {
   } else {
     if (own(doc, 'memberOrder')) addError(errors, 'memberOrder', 'is only valid on a container');
     if (own(doc, 'containerId')) validateId(doc.containerId, 'containerId', errors);
+    if (own(doc, 'parentId')) {
+      validateId(doc.parentId, 'parentId', errors);
+      if (doc.parentId === doc.templateId) addError(errors, 'parentId', 'must not reference the template itself');
+    }
   }
   if (own(doc, 'contractVersion') && doc.contractVersion !== 1) addError(errors, 'contractVersion', 'must equal 1');
   if (own(doc, 'resourceKind') && doc.resourceKind !== 'form-template') addError(errors, 'resourceKind', 'must equal form-template');
@@ -465,6 +471,8 @@ function validateTemplate(doc) {
   if (own(doc, 'presentation')) validatePresentation(doc.presentation, errors);
   if (isContainer) {
     // container field rules handled above
+  } else if (own(doc, 'parentId') && Array.isArray(doc.fields) && doc.fields.length === 0) {
+    // #245: a child may carry zero own fields — everything inherits from the parent.
   } else if (!Array.isArray(doc.fields) || doc.fields.length < 1 || doc.fields.length > 200) {
     if (own(doc, 'fields')) addError(errors, 'fields', 'must be an array containing 1 through 200 fields');
   } else {

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -10,9 +10,28 @@ const { canonicalize, schemaDigest } = require('./canonical');
 const { validateTemplate, validateTemplateVersion } = require('./schema');
 
 const DEFINITION_ID = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+// #245: child fields resolve against the parent at serve time — a child field
+// whose id matches a parent field overrides it in place; other child fields
+// append after. Live inheritance: edit the parent once, every child updates.
+function resolveInheritedFields(parentFields, childFields) {
+  const parent = Array.isArray(parentFields) ? parentFields : [];
+  const own = Array.isArray(childFields) ? childFields : [];
+  const overrides = new Map(own.map((field) => [field.id, field]));
+  const used = new Set();
+  const merged = parent.map((field) => {
+    if (overrides.has(field.id)) {
+      used.add(field.id);
+      return overrides.get(field.id);
+    }
+    return field;
+  });
+  for (const field of own) if (!used.has(field.id)) merged.push(field);
+  return merged;
+}
+
 const MUTABLE_TEMPLATE_KEYS = [
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields', 'containerId', 'memberOrder',
+  'presentation', 'fields', 'containerId', 'memberOrder', 'parentId',
 ];
 
 function isDefinitionId(value) {
@@ -263,10 +282,29 @@ class TemplateRegistry {
   }
 
   publicEntry(entry) {
+    const template = clone(entry.template);
+    let digest = entry.schemaDigest;
+    if (template.parentId) {
+      // #245: serve resolved fields; the digest is of the RESOLVED schema so it
+      // honestly changes when the parent changes. Parent existence is enforced
+      // at write time (assertParentReference); if it drifted, own fields serve.
+      const parent = this.entrySync(template.parentId);
+      if (parent) {
+        template.fields = clone(resolveInheritedFields(parent.template.fields, template.fields));
+        digest = schemaDigest(template);
+      }
+    }
     return {
-      ...clone(entry.template),
-      schemaDigest: entry.schemaDigest,
+      ...template,
+      schemaDigest: digest,
     };
+  }
+
+  entrySync(templateId) {
+    for (const entry of this.files.values()) {
+      if (entry.template.templateId === templateId) return entry;
+    }
+    return null;
   }
 
   managementEntry(entry) {
@@ -304,6 +342,26 @@ class TemplateRegistry {
     if (!ok) {
       throw validationError([{path: 'containerId', message: 'must identify an existing container'}]);
     }
+  }
+
+  async assertParentReference(template) {
+    // #245 fail-closed: parentId must identify an existing, unarchived form-kind
+    // template that itself has no parent (single-level inheritance).
+    if (!template.parentId) return;
+    const target = await this.entryFor(template.parentId);
+    const ok = target && target.template
+      && target.template.kind !== 'container'
+      && target.template.archived !== true
+      && !target.template.parentId;
+    if (!ok) {
+      throw validationError([{path: 'parentId', message: 'must identify an existing top-level form'}]);
+    }
+  }
+
+  childrenOf(templateId) {
+    return [...this.files.values()]
+      .filter((entry) => entry.template.parentId === templateId && entry.template.archived !== true)
+      .map((entry) => entry.template.templateId);
   }
 
   async listTemplates() {
@@ -392,6 +450,7 @@ class TemplateRegistry {
     this.validateDraft(template);
     return this.withMutationLock(template.templateId, async () => {
       await this.assertContainerReference(template);
+      await this.assertParentReference(template);
       if (await this.entryFor(template.templateId)) throw codedError('ECONFLICT', 'Template already exists.');
       await fs.mkdir(this.templatesPath, {recursive: true});
       const templateDirectory = path.join(this.templatesPath, template.templateId);
@@ -428,10 +487,19 @@ class TemplateRegistry {
         throw codedError('ESTALE', 'Template revision is stale.');
       }
       const revised = clone(entry.template);
+      // #245: detaching (parentId: null) materializes the resolved fields onto the
+      // child so nothing it served disappears — unless the patch supplies fields.
+      if (changes.parentId === null && entry.template.parentId
+          && !Object.prototype.hasOwnProperty.call(changes, 'fields')) {
+        const parent = await this.entryFor(entry.template.parentId);
+        if (parent) {
+          revised.fields = clone(resolveInheritedFields(parent.template.fields, entry.template.fields));
+        }
+      }
       const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
       for (const key of MUTABLE_TEMPLATE_KEYS) {
         if (!Object.prototype.hasOwnProperty.call(changes, key)) continue;
-        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation', 'containerId', 'memberOrder'].includes(key)) {
+        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation', 'containerId', 'memberOrder', 'parentId'].includes(key)) {
           delete revised[key];
         } else if (key === 'presentation' && isPlainObject(changes.presentation) && isPlainObject(revised.presentation)) {
           // #225: merge presentation patches instead of replacing wholesale — a patch
@@ -449,8 +517,15 @@ class TemplateRegistry {
         }
       }
       if (Object.prototype.hasOwnProperty.call(changes, 'fields')) {
-        const revisedIds = new Set(revised.fields.map((field) => field.id));
-        const removed = entry.template.fields.filter((field) => !revisedIds.has(field.id));
+        const revisedIds = new Set((revised.fields || []).map((field) => field.id));
+        // #245: with a parent, dropping an own field whose id the parent defines is
+        // deduplication, not deletion — the field survives in the resolved schema.
+        let inherited = new Set();
+        if (revised.parentId) {
+          const parent = await this.entryFor(revised.parentId);
+          if (parent) inherited = new Set(parent.template.fields.map((field) => field.id));
+        }
+        const removed = (entry.template.fields || []).filter((field) => !revisedIds.has(field.id) && !inherited.has(field.id));
         if (removed.length) {
           throw validationError(removed.map((field) => ({
             path: 'fields',
@@ -461,6 +536,7 @@ class TemplateRegistry {
       revised.revision += 1;
       this.validateDraft(revised);
       await this.assertContainerReference(revised);
+      await this.assertParentReference(revised);
       await this.durableReplace(entry.draftPath, canonicalize(revised));
       entry.template = revised;
       entry.schemaDigest = schemaDigest(revised);
@@ -483,12 +559,21 @@ class TemplateRegistry {
       if (currentlyArchived === archived) {
         throw codedError('ECONFLICT', archived ? 'Template is already archived.' : 'Template is already active.');
       }
+      if (archived) {
+        // #245 fail-closed: children resolve against this template — re-parent or
+        // archive them first.
+        const children = this.childrenOf(templateId);
+        if (children.length) {
+          throw validationError([{path: 'archived', message: `template has child forms (${children.join(', ')}) — detach or archive them first`}]);
+        }
+      }
       const revised = clone(entry.template);
       if (archived) revised.archived = true;
       else delete revised.archived;
       revised.revision += 1;
       this.validateDraft(revised);
       await this.assertContainerReference(revised);
+      await this.assertParentReference(revised);
       await this.durableReplace(entry.draftPath, canonicalize(revised));
       entry.template = revised;
       entry.schemaDigest = schemaDigest(revised);

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2064,3 +2064,81 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     await cleanup(fixture, server);
   }
 });
+
+test('parent/sub-form inheritance: resolution, overrides, live edits, detach, guards (#245)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {formsTimezone: 'America/New_York'});
+  try {
+    const context = await getBrowserContext(server);
+    const jsonHeaders = { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token };
+    const post = (route, body) => server.request(route, {method: 'POST', headers: jsonHeaders, body: JSON.stringify(body)});
+    const patch = (route, body) => server.request(route, {method: 'PATCH', headers: jsonHeaders, body: JSON.stringify(body)});
+
+    // child of the fixture form: one override (lift narrowed + default) + one extra
+    const created = await post('/api/forms/templates', {
+      templateId: 'bench-day', title: 'Bench day', grammarVersion: 1, destinationId: 'default',
+      parentId: 'gym-session-entry',
+      fields: [
+        {id: 'lift', type: 'select', label: 'Lift', required: true, default: 'bench', options: [{id: 'bench', label: 'Bench press'}]},
+        {id: 'spotter', type: 'short-text', label: 'Spotter', required: false},
+      ],
+    });
+    assert.equal(created.status, 201);
+    await post('/api/forms/templates/bench-day/publish', {revision: 1});
+
+    // resolved serving: parent fields present, override in the parent's position,
+    // extra appended; the draft keeps only the child's OWN fields.
+    const got = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
+    assert.equal(got.template.parentId, 'gym-session-entry');
+    assert.equal(got.template.fields.length, 2);
+    const ids = got.resolvedFields.map((field) => field.id);
+    assert.ok(ids.includes('session-date') && ids.includes('notes'), `inherited fields missing: ${ids}`);
+    assert.equal(ids.indexOf('lift'), JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.fields.map((f) => f.id).indexOf('lift'));
+    assert.equal(ids.at(-1), 'spotter');
+    assert.equal(got.resolvedFields.find((field) => field.id === 'lift').options.length, 1);
+    assert.match(String(got.resolvedSchemaDigest), /./);
+    const digestBefore = got.resolvedSchemaDigest;
+
+    // the child form page renders inherited fields and accepts a submission
+    const page = await (await server.request('/forms/bench-day', {headers: {Cookie: context.cookie}})).text();
+    assert.match(page, /Session date|session-date/);
+    assert.match(page, /Spotter/);
+    const submitted = await server.request('/forms/bench-day', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: nativeBody(context.token, {spotter: 'Sam'}),
+    });
+    assert.equal(submitted.status, 303);
+
+    // live inheritance: revise the parent, the child's resolved schema follows
+    const parentRev = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
+    const parentFields = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.fields;
+    const grown = await patch('/api/forms/templates/gym-session-entry', {
+      revision: parentRev,
+      fields: [...parentFields, {id: 'warmup-done', type: 'checkbox', label: 'Warmed up', required: false}],
+    });
+    assert.equal(grown.status, 200);
+    const after = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
+    assert.ok(after.resolvedFields.some((field) => field.id === 'warmup-done'), 'child did not inherit the new parent field');
+    assert.notEqual(after.resolvedSchemaDigest, digestBefore);
+
+    // guards: nesting refused; archiving a parent with children refused
+    const nested = await post('/api/forms/templates', {templateId: 'nested-kid', title: 'Nested', grammarVersion: 1, parentId: 'bench-day', fields: []});
+    assert.equal(nested.status, 422);
+    const benchRevForArchive = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
+    const archived = await post('/api/forms/templates/gym-session-entry/archive', {revision: benchRevForArchive});
+    assert.ok(archived.status === 422 || archived.status === 409, `parent archive not refused: ${archived.status}`);
+
+    // detach materializes the resolved fields onto the child
+    const childRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;
+    const detached = await patch('/api/forms/templates/bench-day', {revision: childRev, parentId: null});
+    assert.equal(detached.status, 200);
+    assert.equal(detached.headers.get('content-type').includes('json'), true);
+    const solo = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
+    assert.equal(solo.parentId, undefined);
+    assert.ok(solo.fields.some((field) => field.id === 'warmup-done'), 'detach did not materialize inherited fields');
+    assert.equal(solo.fields.at(-1).id, 'spotter');
+  } finally {
+    await cleanup(fixture, server);
+  }
+});

--- a/test/forms-template-api.test.js
+++ b/test/forms-template-api.test.js
@@ -263,6 +263,7 @@ test('template API lifecycle uses CAS and preserves immutable versions and old r
       entryCount: 1,
       kind: 'form',
       containerId: null,
+      parentId: null,
     }]);
     const fetchedResponse = await server.request('/api/forms/templates/training-log', {headers: AGENT_HEADERS});
     assert.equal(fetchedResponse.status, 200);
@@ -496,8 +497,8 @@ test('clone and archive APIs preserve source history, receipts, CAS, and authori
 
     const submitOnlyList = await server.request('/api/forms/templates', {headers: submitOnly});
     assert.deepEqual((await submitOnlyList.json()).templates.map((template) => Object.keys(template).sort()), [
-      ['containerId', 'kind', 'templateId', 'title'],
-      ['containerId', 'kind', 'templateId', 'title'],
+      ['containerId', 'kind', 'parentId', 'templateId', 'title'],
+      ['containerId', 'kind', 'parentId', 'templateId', 'title'],
     ]);
     assert.equal((await server.request('/api/forms/templates/training-log', {
       method: 'DELETE',


### PR DESCRIPTION
Closes #245. Operator go 2026-07-30: "I think that design is important."

Form-kind templates may declare `parentId` (fail-closed: existing, unarchived, top-level form — single-level v1). Children resolve at serve time: parent fields with same-id child overrides applied in place, extra child fields appended. Live inheritance — edit the parent once, every child updates instantly.

- Serving surfaces (form page, submit, previews, container pages) get resolved fields via `publicEntry`; the builder/management API keeps a child's OWN fields and exposes `resolvedFields` + `resolvedSchemaDigest` (digest of the RESOLVED schema — honestly tracks parent edits).
- Detach (`parentId: null`) materializes the resolved fields onto the child.
- Archiving a parent with active children is refused; nesting refused; self-reference refused.
- Retained-isDestroyed rule: dropping an own field whose id the parent defines is deduplication (it survives resolution), so children can slim to just their overrides.
- Configure: Parent select + inheritance note on children; children list on parents. Builder handles fields-less children.

**Test gates:** new end-to-end test (create child with override+extra → resolution order, override narrowing, live parent edit propagation, digest change, nesting/archive guards, detach materialization); template-API projections updated. Suite 199 pass / 1 pre-existing (#240); validate:editable 0; validate:raw-html red on main pre-existing (#249).

Migration follow-up (this session): repoint the 18 gym machine forms to `parentId: gym-strength-entry` + machine override only, retiring the user-space generator (the poor-man's container this replaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
