### PR TITLE
feat(forms): root quick-configure — the one-page forms manager

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -977,7 +977,57 @@ function renderTemplateActions(template, csrfToken) {
   </div>`;
 }
 
-function renderManagedTemplate(template, csrfToken) {
+function renderQuickConfigure(template, all, csrfToken) {
+  // #257: the /forms root is the one-page manager — the configure BASICS inline,
+  // behind the platform's disclosure idiom. Save & publish in one tap; the full
+  // draft/publish field editor stays at /forms/:id/configure.
+  if (template.state === 'archived') return '';
+  const configureHref = `/forms/${encodeURIComponent(template.templateId)}/configure`;
+  const themeOptions = [{slug: '', label: 'Use the viewer theme'}, ...getThemeList()].map((theme) =>
+    `<option value="${escapeHtml(theme.slug)}"${(template.theme || '') === theme.slug ? ' selected' : ''}>${escapeHtml(theme.label || theme.slug)}</option>`
+  ).join('');
+  const themeModeOptions = [['', 'Follow theme'], ['dark', 'Dark'], ['light', 'Light']].map(([value, label]) =>
+    `<option value="${value}"${(template.themeMode || '') === value ? ' selected' : ''}>${label}</option>`
+  ).join('');
+  let membership = '';
+  if (template.kind === 'container') {
+    const candidates = all.filter((other) => other.kind !== 'container' && other.state !== 'archived' && other.management === true);
+    membership = `<fieldset class="quick-configure-members"><legend>Forms in this container</legend>${candidates.map((other) =>
+      `<label class="container-member-choice"><input type="checkbox" name="member" value="${escapeHtml(other.templateId)}"${other.containerId === template.templateId ? ' checked' : ''}> ${escapeHtml(other.title)}</label>`
+    ).join('')}</fieldset>`;
+  }
+  const containers = all.filter((other) => other.kind === 'container' && other.state !== 'archived');
+  const containerSelect = template.kind !== 'container' && containers.length
+    ? `<label><span>Container</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${containers.map((container) =>
+      `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label>`
+    : '';
+  const parents = all.filter((other) => other.kind !== 'container' && other.state !== 'archived'
+    && !other.parentId && other.templateId !== template.templateId && other.management === true);
+  const parentSelect = template.kind !== 'container' && parents.length
+    ? `<label><span>Parent form</span><select name="parent"><option value=""${!template.parentId ? ' selected' : ''}>None</option>${parents.map((parent) =>
+      `<option value="${escapeHtml(parent.templateId)}"${template.parentId === parent.templateId ? ' selected' : ''}>${escapeHtml(parent.title)}</option>`).join('')}</select></label>`
+    : '';
+  return `<details class="quick-configure">
+    <summary>Quick configure</summary>
+    <form method="post" action="${configureHref}" class="quick-configure-form">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <input type="hidden" name="_action" value="basics">
+      <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+      <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
+      <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
+      <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
+      ${containerSelect}
+      ${parentSelect}
+      ${membership}
+      <div class="quick-configure-actions">
+        <button class="button-link button-link-primary" type="submit">Save &amp; publish</button>
+        <a href="${configureHref}">Full editor</a>
+      </div>
+    </form>
+  </details>`;
+}
+
+function renderManagedTemplate(template, csrfToken, all = []) {
   const published = template.publishedVersion === null ? 'Not published' : `Version ${template.publishedVersion}`;
   const stateLabel = template.state === 'archived'
     ? 'Archived'
@@ -991,6 +1041,7 @@ function renderManagedTemplate(template, csrfToken) {
       <div><dt>Entries</dt><dd>${escapeHtml(template.entryCount)}</dd></div>
     </dl>
     ${renderTemplateActions(template, csrfToken)}
+    ${renderQuickConfigure(template, all, csrfToken)}
   </article>`;
 }
 
@@ -1076,7 +1127,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   // #234: containers group the root — container cards first with their members
   // nested beneath, then everything uncontained.
   const renderOne = (template) => template.management
-    ? renderManagedTemplate(template, csrfToken)
+    ? renderManagedTemplate(template, csrfToken, templates)
     : `<a class="forms-index-simple" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}<span aria-hidden="true">›</span></a>`;
   const containers = active.filter((template) => template.kind === 'container');
   const containerIds = new Set(containers.map((template) => template.templateId));
@@ -1086,6 +1137,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     const members = contained.filter((template) => template.containerId === container.templateId);
     return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
       <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} form${members.length === 1 ? '' : 's'}</span>${container.management ? `<a class="forms-index-container-configure" href="/forms/${encodeURIComponent(container.templateId)}/configure">Configure</a>` : ''}</div>
+      ${container.management ? renderQuickConfigure(container, templates, csrfToken) : ''}
       <div class="forms-index-list">${members.map(renderOne).join('')}</div>
     </section>`;
   }).join('');
@@ -1856,6 +1908,8 @@ function createFormsRouter(options) {
           kind: record.draft.kind === 'container' ? 'container' : 'form',
           containerId: record.draft.containerId || null,
           parentId: record.draft.parentId || null,
+          theme: (record.draft.presentation && record.draft.presentation.theme) || '',
+          themeMode: (record.draft.presentation && record.draft.presentation.themeMode) || '',
         });
       } else if (record.state !== 'archived' && await allowed(req, 'forms.submit', record.draft)) {
         templates.push({
@@ -2099,7 +2153,7 @@ function createFormsRouter(options) {
 
   function validContainerBuilderBody(body) {
     if (!body || typeof body !== 'object' || Array.isArray(body)) return false;
-    const fixed = new Set(['_csrf', 'revision', 'title', 'description', 'theme', 'themeMode', 'member']);
+    const fixed = new Set(['_csrf', '_action', 'revision', 'title', 'description', 'theme', 'themeMode', 'member']);
     const theme = body.theme;
     if (typeof theme === 'string' && theme !== '' && !getThemeList().some((entry) => entry.slug === theme)) return false;
     const mode = body.themeMode;
@@ -2116,7 +2170,7 @@ function createFormsRouter(options) {
   function validBuilderBody(body, create = false) {
     const fixed = create
       ? new Set(['_csrf', 'templateId', 'title', 'destinationId', 'kind'])
-      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container']);
+      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container', 'parent']);
     // An author SELECTS an installed theme; they can never introduce one. Anything
     // outside the server's list is refused rather than quietly ignored.
     if (!create && body && typeof body === 'object') {
@@ -2382,12 +2436,49 @@ function createFormsRouter(options) {
         }
         const fresh = await registry.getManagementTemplate(containerId);
         emitAudit(req, type, 'accepted', revisedContainer.draft);
+        if (postedString(req.body, '_action') === 'basics') {
+          // #257: root quick-configure — one tap makes the change live.
+          await publishTemplateThroughApi(req, containerId, {revision: fresh.draft.revision});
+          res.redirect(303, '/forms');
+          return;
+        }
         await sendConfigure(res, fresh, issueContext(req, res), {status: 'Draft saved.'});
         return;
       }
       if (!validBuilderBody(req.body)) {
         emitAudit(req, type, 'rejected_validation', record.draft);
         res.status(400).type('text/plain').send('Invalid form body.');
+        return;
+      }
+      if (postedString(req.body, '_action') === 'basics') {
+        // #257: root quick-configure — basics only, fields untouched (a field-less
+        // save through builderPatch would wipe them), publish, back to the root.
+        const theme = postedString(req.body, 'theme');
+        const themeMode = (postedString(req.body, 'themeMode') === 'dark' || postedString(req.body, 'themeMode') === 'light')
+          ? postedString(req.body, 'themeMode') : '';
+        const basics = {
+          revision: Number(postedString(req.body, 'revision')),
+          title: postedString(req.body, 'title'),
+        };
+        if (record.draft.presentation && typeof record.draft.presentation === 'object') {
+          // merge path: null unsets a single key (#225)
+          basics.presentation = {theme: theme || null, themeMode: themeMode || null};
+        } else if (theme || themeMode) {
+          const fresh = {};
+          if (theme) fresh.theme = theme;
+          if (themeMode) fresh.themeMode = themeMode;
+          basics.presentation = fresh;
+        }
+        if (Object.prototype.hasOwnProperty.call(req.body, 'container')) {
+          basics.containerId = postedString(req.body, 'container') || null;
+        }
+        if (Object.prototype.hasOwnProperty.call(req.body, 'parent')) {
+          basics.parentId = postedString(req.body, 'parent') || null;
+        }
+        const revised = await reviseTemplateThroughApi(req.params.templateId, basics);
+        await publishTemplateThroughApi(req, req.params.templateId, {revision: revised.draft.revision});
+        emitAudit(req, type, 'accepted', revised.draft);
+        res.redirect(303, '/forms');
         return;
       }
       const patch = builderPatch(record.draft, req.body);

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -495,8 +495,10 @@ function validateTemplateVersion(doc) {
   const required = [
     'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'templateVersion',
     'sourceRevision', 'grammarVersion', 'publishedAt', 'publishedBy', 'title',
-    'fields', 'schemaDigest',
+    'schemaDigest',
   ];
+  // #257: containers version without fields (they have none to freeze).
+  if (doc.kind !== 'container') required.push('fields');
   for (const key of required) if (!own(doc, key)) addError(errors, key, 'is required');
 
   const draftProjection = {

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -606,7 +606,13 @@ class TemplateRegistry {
         ...(Object.prototype.hasOwnProperty.call(draft, 'tags') ? {tags: clone(draft.tags)} : {}),
         ...(Object.prototype.hasOwnProperty.call(draft, 'lineage') ? {lineage: clone(draft.lineage)} : {}),
         ...(Object.prototype.hasOwnProperty.call(draft, 'presentation') ? {presentation: clone(draft.presentation)} : {}),
-        fields: clone(draft.fields),
+        // #257: version docs carry the structural keys too — kind (containers were
+        // unpublishable without it), membership, and inheritance provenance.
+        ...(Object.prototype.hasOwnProperty.call(draft, 'kind') ? {kind: draft.kind} : {}),
+        ...(Object.prototype.hasOwnProperty.call(draft, 'containerId') ? {containerId: draft.containerId} : {}),
+        ...(Object.prototype.hasOwnProperty.call(draft, 'memberOrder') ? {memberOrder: clone(draft.memberOrder)} : {}),
+        ...(Object.prototype.hasOwnProperty.call(draft, 'parentId') ? {parentId: draft.parentId} : {}),
+        ...(draft.kind === 'container' ? {} : {fields: Array.isArray(draft.fields) ? clone(draft.fields) : []}),
         schemaDigest: `sha256:${schemaDigest(draft)}`,
       };
       const validation = validateTemplateVersion(version);

--- a/public/style.css
+++ b/public/style.css
@@ -2791,6 +2791,17 @@ tbody tr:last-child td {
 .form-layout .entry-form-chip { font-size: 0.72rem; padding: 0.1rem 0.5rem; border-radius: 999px; background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent); white-space: nowrap; }
 .form-layout .container-card .recent-entries { margin-top: 1.2rem; }
 
+/* #257: root quick-configure — inline basics editor on managed index cards. */
+.forms-index-layout .quick-configure { border-top: 1px solid var(--border); margin-top: 0.6rem; padding-top: 0.5rem; }
+.forms-index-layout .quick-configure > summary { cursor: pointer; font-size: 0.85rem; color: var(--accent); list-style: none; }
+.forms-index-layout .quick-configure > summary::-webkit-details-marker { display: none; }
+.forms-index-layout .quick-configure-form { display: grid; gap: 0.6rem; padding: 0.7rem 0 0.2rem; max-width: 28rem; }
+.forms-index-layout .quick-configure-form label { display: grid; gap: 0.2rem; font-size: 0.85rem; }
+.forms-index-layout .quick-configure-members { border: 1px solid var(--border); border-radius: 0.5rem; padding: 0.6rem 0.8rem; display: grid; gap: 0.3rem; }
+.forms-index-layout .quick-configure-members legend { font-size: 0.8rem; color: var(--text-soft); padding: 0 0.3rem; }
+.forms-index-layout .quick-configure-actions { display: flex; align-items: center; gap: 0.9rem; }
+.forms-index-layout .forms-index-container > .quick-configure { margin: 0 0 0.6rem; border-top: 0; padding-top: 0; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -423,7 +423,7 @@ test('forms index separates archived templates and removes management detail for
     assert.equal(managerIndex.document.querySelectorAll('.forms-index-groups[aria-label="Active templates"] .forms-index-item').length, 2);
     assert.ok(managerIndex.document.querySelector('a[href="/forms/new"]'));
     const trainingCard = [...managerIndex.document.querySelectorAll('.forms-index-item')]
-      .find((card) => /Training <log>/.test(card.textContent));
+      .find((card) => /Training <log>/.test(card.querySelector('.forms-index-title h2').textContent));
     assert.ok(trainingCard);
     assert.match(trainingCard.textContent, /Draft\s*r1/);
     assert.match(trainingCard.textContent, /Destination\s*gym-log/);
@@ -629,6 +629,72 @@ test('reviseDraft merges presentation patches instead of replacing wholesale (#2
     await server.registry.reviseDraft('training-log', current.draft.revision, {presentation: null});
     current = await server.registry.getManagementTemplate('training-log');
     assert.equal(current.draft.presentation, undefined);
+  } finally {
+    await server.close();
+  }
+});
+
+test('root quick-configure: inline basics + membership, publishes in one tap (#257)', async () => {
+  const server = await makeServer();
+  try {
+    // second top-level form so the parent select renders (regression surface for #251)
+    await server.registry.createDraft({
+      contractVersion: 1, resourceKind: 'form-template', templateId: 'cardio-log',
+      ownerId: 'operator', revision: 1, grammarVersion: 1, destinationId: 'default',
+      title: 'Cardio log',
+      fields: [{id: 'minutes', type: 'number', label: 'Minutes', required: true}],
+    });
+    await server.registry.createDraft({
+      contractVersion: 1, resourceKind: 'form-template', templateId: 'fitness',
+      ownerId: 'operator', revision: 1, grammarVersion: 1, title: 'Fitness', kind: 'container',
+    });
+
+    // the root carries quick-configure sections with the basics controls
+    const root = await browserPage(await server.request('/forms'));
+    const quick = root.document.querySelectorAll('.quick-configure');
+    assert.ok(quick.length >= 3, `expected quick-configure per managed card, got ${quick.length}`);
+    assert.ok(root.document.querySelector('.quick-configure-form input[name="title"]'));
+    assert.ok(root.document.querySelector('.quick-configure-form select[name="container"]'));
+    assert.ok(root.document.querySelector('.quick-configure-form select[name="parent"]'));
+    assert.ok(root.document.querySelector('.quick-configure-members input[name="member"]'));
+
+    // #251 regression: a FULL configure save with the parent select present must not 400
+    const configure = await browserPage(await server.request('/forms/training-log/configure'));
+    assert.ok(configure.document.querySelector('.builder-form select[name="parent"]'), 'parent select missing on configure');
+    const fullSave = await browserPost(server, '/forms/training-log/configure',
+      formValues(configure.document.querySelector('.builder-form'), 'save'), configure.cookie);
+    assert.equal(fullSave.status, 200);
+
+    // basics save on a form: title + container membership, published, back to the root
+    // (refetched — the full save above bumped the draft revision)
+    const rootFresh = await browserPage(await server.request('/forms'));
+    const trainingForm = [...rootFresh.document.querySelectorAll('.quick-configure-form')]
+      .find((form) => form.action.includes('/forms/training-log/'));
+    const values = formValues(trainingForm, 'basics');
+    values.set('title', 'Training log (renamed)');
+    values.set('container', 'fitness');
+    const saved = await browserPost(server, '/forms/training-log/configure', values, rootFresh.cookie);
+    assert.equal(saved.status, 303);
+    assert.equal(saved.headers.get('location'), '/forms');
+    const record = await server.registry.getManagementTemplate('training-log');
+    assert.equal(record.draft.title, 'Training log (renamed)');
+    assert.equal(record.draft.containerId, 'fitness');
+    assert.equal(record.state, 'published');
+    assert.deepEqual(record.draft.fields.map((field) => field.id), ['lift', 'notes'], 'basics save must not touch fields');
+
+    // container basics: member checkboxes drive membership diffs, then 303 to the root
+    const root2 = await browserPage(await server.request('/forms'));
+    const containerForm = [...root2.document.querySelectorAll('.quick-configure-form')]
+      .find((form) => form.action.includes('/forms/fitness/'));
+    const containerValues = formValues(containerForm, 'basics');
+    containerValues.delete('member');
+    containerValues.append('member', 'cardio-log');
+    const containerSaved = await browserPost(server, '/forms/fitness/configure', containerValues, root2.cookie);
+    assert.equal(containerSaved.status, 303);
+    const cardio = await server.registry.getManagementTemplate('cardio-log');
+    assert.equal(cardio.draft.containerId, 'fitness');
+    const training = await server.registry.getManagementTemplate('training-log');
+    assert.equal(training.draft.containerId, undefined, 'unchecked member must be released');
   } finally {
     await server.close();
   }

--- a/test/forms-template-api.test.js
+++ b/test/forms-template-api.test.js
@@ -264,6 +264,8 @@ test('template API lifecycle uses CAS and preserves immutable versions and old r
       kind: 'form',
       containerId: null,
       parentId: null,
+      theme: '',
+      themeMode: '',
     }]);
     const fetchedResponse = await server.request('/api/forms/templates/training-log', {headers: AGENT_HEADERS});
     assert.equal(fetchedResponse.status, 200);


### PR DESCRIPTION
Closes #257. Operator: "can we somehow combine /forms and /forms/gym/configure style stuff into one page???"

Every managed card on the /forms root gains a **Quick configure** disclosure (the platform idiom): title, theme, theme mode, Container + Parent selects on forms; **member checkboxes** on containers. **Save & publish** in one tap via new `_action=basics` on the configure POST — patches basics only (never fields; a field-less save through builderPatch would wipe them), publishes, 303 back to the root. The full draft/publish field editor stays linked.

Two latent bugs surfaced and fixed:
- **#251 regression:** `validBuilderBody` never learned the `parent` key the configure page posts — GUI configure saves 400ed whenever the Parent select rendered (invisible to the old single-form fixture; guaranteed in prod).
- **Containers couldn't publish** (nor fields-less children): `publishDraft` version docs never carried `kind`/`containerId`/`memberOrder`/`parentId` and `validateTemplateVersion` required `fields` unconditionally. Version docs now carry the structural keys.

**Test gates:** new end-to-end test (quick-configure present per card incl. container membership; full save with parent select ≠ 400; basics save publishes + preserves fields; container membership diffs via basics). Suite 200 pass / 1 pre-existing (#240); validate:editable 0; validate:raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
