### PR TITLE
feat(forms): the root is a container page — tap-in rows, entry-link titles

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -365,10 +365,13 @@ function renderContainerPage(template, members, options = {}) {
   const cards = members.length
     ? members.map((member) => (
       `<details class="container-member-row">
-        <summary class="container-member"><span class="container-member-title">${escapeHtml(member.title)}</span><span aria-hidden="true">›</span></summary>
+        <summary class="container-member"><a class="container-member-title" href="/forms/${encodeURIComponent(member.templateId)}">${escapeHtml(member.title)}</a><span aria-hidden="true">›</span></summary>
         <div class="container-member-preview">
           ${renderFormPreview(member)}
-          <a class="button-link button-link-primary container-member-open" href="/forms/${encodeURIComponent(member.templateId)}">Open ${escapeHtml(member.title)}</a>
+          <div class="container-member-actions">
+            <a class="button-link button-link-primary container-member-open" href="/forms/${encodeURIComponent(member.templateId)}">Open ${escapeHtml(member.title)}</a>
+            ${options.canManage ? `<a class="container-member-configure" href="/forms/${encodeURIComponent(member.templateId)}/configure">Configure</a>` : ''}
+          </div>
         </div>
       </details>`
     )).join('')
@@ -1124,37 +1127,37 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   const managed = templates.some((template) => template.management === true);
   const active = templates.filter((template) => template.state !== 'archived');
   const archived = templates.filter((template) => template.state === 'archived');
-  // #234: containers group the root — container cards first with their members
-  // nested beneath, then everything uncontained.
-  const renderOne = (template) => template.management
-    ? renderManagedTemplate(template, csrfToken, templates)
-    : `<a class="forms-index-simple" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}<span aria-hidden="true">›</span></a>`;
+  // #260: the root IS a container page one level up — clean tap-to-enter rows
+  // (containers first, then ungrouped forms straight to a new entry). The
+  // management detail (#257 quick-configure, meta, archived) lives in one
+  // collapsed Manage section at the bottom, out of the main view.
   const containers = active.filter((template) => template.kind === 'container');
   const containerIds = new Set(containers.map((template) => template.templateId));
-  const contained = active.filter((template) => template.kind !== 'container' && template.containerId && containerIds.has(template.containerId));
   const ungrouped = active.filter((template) => template.kind !== 'container' && !(template.containerId && containerIds.has(template.containerId)));
-  const groupedHtml = containers.map((container) => {
-    const members = contained.filter((template) => template.containerId === container.templateId);
-    return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
-      <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} form${members.length === 1 ? '' : 's'}</span>${container.management ? `<a class="forms-index-container-configure" href="/forms/${encodeURIComponent(container.templateId)}/configure">Configure</a>` : ''}</div>
-      ${container.management ? renderQuickConfigure(container, templates, csrfToken) : ''}
-      <div class="forms-index-list">${members.map(renderOne).join('')}</div>
-    </section>`;
-  }).join('');
-  const activeHtml = (containers.length || ungrouped.length)
-    ? `${groupedHtml}${ungrouped.length ? `<section class="forms-index-ungrouped" aria-label="Ungrouped forms">${containers.length ? '<h2 class="forms-index-ungrouped-head">Ungrouped</h2>' : ''}<div class="forms-index-list">${ungrouped.map(renderOne).join('')}</div></section>` : ''}`
-    : `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first template' : 'No forms available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active forms you can submit to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New template</a>' : ''}</div>`;
-  const archivedHtml = managed && archived.length
-    ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken)).join('')}</div></details>`
+  const memberCount = (container) => active.filter((template) => template.containerId === container.templateId).length;
+  const rows = [
+    ...containers.map((container) => {
+      const count = memberCount(container);
+      return `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(container.templateId)}"><span class="container-member-title">${escapeHtml(container.title)}</span><span class="forms-root-count">${count} form${count === 1 ? '' : 's'}</span><span aria-hidden="true">›</span></a>`;
+    }),
+    ...ungrouped.map((template) => (
+      `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(template.templateId)}"><span class="container-member-title">${escapeHtml(template.title)}</span><span aria-hidden="true">›</span></a>`
+    )),
+  ].join('');
+  const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first template' : 'No forms available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active forms you can submit to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New form</a>' : ''}</div>`;
+  const manageHtml = managed
+    ? `<details class="forms-index-manage"><summary>Manage templates <span>${active.filter((template) => template.management).length}</span></summary><div class="forms-index-list">${active.filter((template) => template.management).map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div>${archived.length ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>` : ''}</details>`
     : '';
   const body = `${toolbarHtml()}
-  <main class="layout form-layout forms-index-layout">
+  <main class="layout form-layout container-layout forms-index-layout">
     <header class="topbar forms-index-header">
-      <div><p class="eyebrow">Forms</p><h1>Templates</h1><p class="subtitle">${managed ? 'Create, configure, and review your forms.' : 'Choose a form to log an entry.'}</p></div>
-      <nav class="form-hub-nav" aria-label="Forms views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New template</a>' : ''}</nav>
+      <div><p class="eyebrow">Forms</p><h1>Forms</h1><p class="subtitle">${managed ? 'Tap a container to see and configure what lives inside it.' : 'Choose a form to log an entry.'}</p></div>
+      <nav class="form-hub-nav" aria-label="Forms views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New form</a><a class="configure-link" href="/forms/new?kind=container">New container</a>' : ''}</nav>
     </header>
-    <div class="forms-index-groups" aria-label="Active templates">${activeHtml}</div>
-    ${archivedHtml}
+    <section class="content form-card container-card">
+      <div class="container-members">${rows || emptyState}</div>
+    </section>
+    ${manageHtml}
   </main>
   ${themeScript(options.cspNonce)}`;
   return baseHtml({
@@ -2275,7 +2278,8 @@ function createFormsRouter(options) {
       if (!browserAuthenticated(req, res, type)) return;
       if (!await canCreateTemplate(req)) return formNotFound(req, res, type);
       emitAudit(req, type, 'accepted');
-      sendCreateTemplate(res, issueContext(req, res));
+      // #260: the root's New container action lands here preselected.
+      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : ''});
     } catch (error) {
       next(error);
     }

--- a/public/style.css
+++ b/public/style.css
@@ -2802,6 +2802,16 @@ tbody tr:last-child td {
 .forms-index-layout .quick-configure-actions { display: flex; align-items: center; gap: 0.9rem; }
 .forms-index-layout .forms-index-container > .quick-configure { margin: 0 0 0.6rem; border-top: 0; padding-top: 0; }
 
+/* #260: the root is a container page — tap-in rows + tucked Manage section. */
+.form-layout .forms-root-count { font-size: 0.78rem; color: var(--text-soft); margin-left: auto; padding-right: 0.6rem; }
+.form-layout a.container-member-title { color: inherit; text-decoration: none; }
+.form-layout a.container-member-title:hover { text-decoration: underline; }
+.form-layout .container-member-actions { display: flex; align-items: center; gap: 0.9rem; }
+.form-layout .container-member-configure { font-size: 0.85rem; }
+.form-layout .forms-index-manage { margin-top: 1.4rem; }
+.form-layout .forms-index-manage > summary { cursor: pointer; color: var(--text-soft); font-size: 0.9rem; }
+.form-layout .forms-index-manage > .forms-index-list { margin-top: 0.8rem; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -420,8 +420,13 @@ test('forms index separates archived templates and removes management detail for
     assert.equal(submitted.status, 303);
 
     const managerIndex = await browserPage(await server.request('/forms'));
-    assert.equal(managerIndex.document.querySelectorAll('.forms-index-groups[aria-label="Active templates"] .forms-index-item').length, 2);
+    // #260: the browse view is tap-in rows; managed cards sit in the Manage section
+    assert.equal(managerIndex.document.querySelectorAll('.container-members .forms-root-row').length, 2);
+    const manageCards = managerIndex.document.querySelectorAll('.forms-index-manage .forms-index-item');
+    const archivedCards = managerIndex.document.querySelectorAll('.forms-index-archived .forms-index-item');
+    assert.equal(manageCards.length - archivedCards.length, 2);
     assert.ok(managerIndex.document.querySelector('a[href="/forms/new"]'));
+    assert.ok(managerIndex.document.querySelector('a[href="/forms/new?kind=container"]'));
     const trainingCard = [...managerIndex.document.querySelectorAll('.forms-index-item')]
       .find((card) => /Training <log>/.test(card.querySelector('.forms-index-title h2').textContent));
     assert.ok(trainingCard);
@@ -444,7 +449,7 @@ test('forms index separates archived templates and removes management detail for
     assert.equal(submitOnly.document.querySelector('.forms-index-meta'), null);
     assert.equal(submitOnly.document.querySelector('.forms-index-archived'), null);
     assert.deepEqual(
-      [...submitOnly.document.querySelectorAll('.forms-index-simple')].map((link) => link.textContent.trim().replace(/›$/, '')),
+      [...submitOnly.document.querySelectorAll('.forms-root-row .container-member-title')].map((node) => node.textContent.trim()),
       ['Daily log', 'Training <log>'],
     );
     assert.doesNotMatch(submitOnly.document.body.textContent, /Old log|Entries|Destination|Configure|Archive/);

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2042,10 +2042,14 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     assert.match(member, /related-container-link/);
     assert.match(member, /← Gym/);
 
-    // root groups: container section with the member inside
+    // #260: the root is a container page — the container is a tap-in row with its count
     const root = await (await server.request('/forms', {headers: {Cookie: context.cookie}})).text();
-    assert.match(root, /forms-index-container-head/);
+    assert.match(root, /forms-root-row/);
     assert.match(root, /1 form</);
+    // member titles are direct entry links inside the container page
+    const containerPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
+    assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
+    assert.match(containerPage, /container-member-configure/);
 
     // container Configure: member checkboxes; unchecking releases membership
     const configure = await (await server.request('/forms/gym/configure', {headers: {Cookie: context.cookie}})).text();


### PR DESCRIPTION
Closes #260. Operator design pass resolving the root/configure circles: "this dashboard kinda page [/forms/gym] ... could almost replace the main form page."

- **Root browse = tap-in rows**: containers (with member counts) then ungrouped forms; titles link straight in — a form title opens a new entry.
- **New form + New container** actions on the root; `/forms/new?kind=container` preselects Kind.
- **No root History** (operator call).
- **Container member titles are entry links** (chevron still toggles the preview); managers get a per-member **Configure** link in the expanded row — the container is where its forms are configured.
- **Quick-configure (#257) kept but tucked** into one collapsed Manage section (with meta cards + archived) pending operator verdict.

**Test gates:** root-layout, submit-only, and container tests updated to the new structure; new assertions for entry-link titles + member Configure link + New container action. Suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
