### PR TITLE
feat(forms): breadcrumb trail is the containment hierarchy

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -119,6 +119,11 @@ function formHeaders(res, cspNonce) {
 
 function formBreadcrumbs(template, options = {}) {
   const crumbs = [`<a href="/forms">Forms</a>`];
+  // #262: the trail IS the containment hierarchy — a form inside a container
+  // carries its container as a tappable ancestor on every page.
+  if (options.container) {
+    crumbs.push(`<a href="/forms/${encodeURIComponent(options.container.templateId)}">${escapeHtml(options.container.title)}</a>`);
+  }
   if (template) {
     const href = `/forms/${encodeURIComponent(template.templateId)}`;
     const label = options.leadLabel ? escapeHtml(options.leadLabel) : escapeHtml(template.title);
@@ -379,7 +384,7 @@ function renderContainerPage(template, members, options = {}) {
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout">
     <header class="topbar">
-      <div><p class="eyebrow">Forms</p><h1>${escapeHtml(template.title)}</h1>${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
+      <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
       ${containerHubNav(template.templateId, 'view', options.canManage)}
     </header>
     <section class="content form-card container-card">
@@ -486,7 +491,7 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">
-      ${formBreadcrumbs(template)}
+      ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
       ${formHubNav(template.templateId, 'log', options.canManage)}
     </header>
 
@@ -592,7 +597,7 @@ function renderReceiptPage(template, record, options = {}) {
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">
-      ${formBreadcrumbs(template, {leadLabel: template ? undefined : 'Form receipt'})}
+      ${formBreadcrumbs(template, {leadLabel: template ? undefined : 'Form receipt', container: options.relatedForms && options.relatedForms.container})}
     </header>
 
     <section class="content form-card receipt-card">
@@ -760,7 +765,7 @@ function renderEntriesPage(template, records, options = {}) {
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout entries-layout">
     <header class="topbar">
-      ${formBreadcrumbs(template)}
+      ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
       ${template.kind === 'container' ? containerHubNav(template.templateId, 'history', options.canManage) : formHubNav(template.templateId, 'history', options.canManage)}
     </header>
     <section class="content form-card entries-card">${content}</section>
@@ -907,7 +912,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   const body = `${toolbarHtml(formProperties(record))}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
-      ${formBreadcrumbs(template)}
+      ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
       ${formHubNav(template.templateId, 'configure', true)}
     </header>
     <section class="content form-card builder-card">
@@ -1076,7 +1081,7 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
   const body = `${toolbarHtml()}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
-      <div><p class="eyebrow">Container</p><h1>${escapeHtml(template.title)}</h1></div>
+      <div>${formBreadcrumbs(template)}</div>
       ${containerHubNav(template.templateId, 'configure', true)}
     </header>
     <section class="content form-card builder-card container-configure-card">
@@ -1151,7 +1156,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout forms-index-layout">
     <header class="topbar forms-index-header">
-      <div><p class="eyebrow">Forms</p><h1>Forms</h1><p class="subtitle">${managed ? 'Tap a container to see and configure what lives inside it.' : 'Choose a form to log an entry.'}</p></div>
+      <div><h1>Forms</h1><p class="subtitle">${managed ? 'Tap a container to see and configure what lives inside it.' : 'Choose a form to log an entry.'}</p></div>
       <nav class="form-hub-nav" aria-label="Forms views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New form</a><a class="configure-link" href="/forms/new?kind=container">New container</a>' : ''}</nav>
     </header>
     <section class="content form-card container-card">
@@ -2207,6 +2212,15 @@ function createFormsRouter(options) {
     }));
   }
 
+  // #262: breadcrumb ancestor — identity only, no submission access implied.
+  async function containerCrumbFor(template) {
+    if (!template || !template.containerId) return null;
+    const container = await registry.getTemplate(template.containerId);
+    return container && container.kind === 'container' && container.archived !== true
+      ? {templateId: container.templateId, title: container.title}
+      : null;
+  }
+
   async function sendConfigure(res, record, csrfToken, responseOptions = {}, status = 200) {
     const cspNonce = crypto.randomBytes(18).toString('base64url');
     formHeaders(res, cspNonce);
@@ -2248,6 +2262,7 @@ function createFormsRouter(options) {
       containers,
       parents,
       children,
+      relatedForms: {container: await containerCrumbFor(record.draft), related: []},
       ...responseOptions,
     }));
   }
@@ -2621,6 +2636,7 @@ function createFormsRouter(options) {
         timezone: serverTimezone,
         canManage,
         csrfToken,
+        relatedForms: {container: await containerCrumbFor(template), related: []},
       }));
     } catch (error) {
       next(error);

--- a/public/style.css
+++ b/public/style.css
@@ -2812,6 +2812,11 @@ tbody tr:last-child td {
 .form-layout .forms-index-manage > summary { cursor: pointer; color: var(--text-soft); font-size: 0.9rem; }
 .form-layout .forms-index-manage > .forms-index-list { margin-top: 0.8rem; }
 
+/* #262: the trail is the containment hierarchy — comfortable tap targets. */
+.form-layout .breadcrumbs { gap: 0.5rem; align-items: baseline; }
+.form-layout .breadcrumbs > a { color: var(--accent); text-decoration: none; padding: 0.15rem 0; }
+.form-layout .breadcrumbs > a:hover { text-decoration: underline; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2050,6 +2050,12 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     const containerPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
     assert.match(containerPage, /container-member-configure/);
+    // #262: trails encode containment — container page links home; member pages carry the container crumb
+    assert.match(containerPage, /<nav class="breadcrumbs"><a href="\/forms">Forms<\/a>/);
+    const memberPage = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    assert.match(memberPage, /<a href="\/forms\/gym">Gym<\/a>/);
+    const memberEntries = await (await server.request('/forms/gym-session-entry/entries', {headers: {Cookie: context.cookie}})).text();
+    assert.match(memberEntries, /<a href="\/forms\/gym">Gym<\/a>/);
 
     // container Configure: member checkboxes; unchecking releases membership
     const configure = await (await server.request('/forms/gym/configure', {headers: {Cookie: context.cookie}})).text();


### PR DESCRIPTION
Closes #262. Operator: "should be able to go back and forth easier" — run through the frontend-design skill.

Structure is information: the breadcrumb trail now IS the containment hierarchy, one component everywhere.

- Form pages (and their History / receipts / Configure): `Forms / Gym / Lat Pulldown` — both ancestors tappable. Previously the container level was skipped; the only way back to Gym was the strip at the very bottom.
- Container pages: `Forms / Gym` — previously the "Forms" eyebrow was dead text and there was NO tap from a container back to the root.
- Container Configure: same trail (replaces the inconsistent "Container" eyebrow).
- Root: plain h1, it is home. Sibling strip stays for lateral movement.

**Test gates:** container test asserts the home link on container pages and the container crumb on member form + history pages. Suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

Related: #263 (toolbar pickers stack open — same one-thing-open doctrine, separate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
