### PR TITLE
feat(language): the user-facing pillar is Trackers

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -118,7 +118,7 @@ function formHeaders(res, cspNonce) {
 }
 
 function formBreadcrumbs(template, options = {}) {
-  const crumbs = [`<a href="/forms">Forms</a>`];
+  const crumbs = [`<a href="/forms">Trackers</a>`];
   // #262: the trail IS the containment hierarchy — a form inside a container
   // carries its container as a tappable ancestor on every page.
   if (options.container) {
@@ -138,7 +138,7 @@ function containerHubNav(templateId, active, canManage) {
   // #234 follow-up: a container is a form, so its pages carry the same hub tabs.
   const href = `/forms/${encodeURIComponent(templateId)}`;
   const links = [
-    ['view', href, 'Forms'],
+    ['view', href, 'Trackers'],
     ['history', `${href}/entries`, 'History'],
     ...(canManage ? [['configure', `${href}/configure`, 'Configure']] : []),
   ];
@@ -380,7 +380,7 @@ function renderContainerPage(template, members, options = {}) {
         </div>
       </details>`
     )).join('')
-    : '<p class="container-empty">No forms in this container yet. Add some from its Configure page.</p>';
+    : '<p class="container-empty">No trackers in this container yet. Add some from its Configure page.</p>';
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout">
     <header class="topbar">
@@ -415,7 +415,7 @@ function renderRelatedFormsNav(nav) {
     `<a class="related-form-link" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}</a>`
   )).join('');
   // No heading — the strip explains itself (operator call, 2026-07-29).
-  return `<nav class="related-forms" aria-label="Related forms">
+  return `<nav class="related-forms" aria-label="Related trackers">
         <div class="related-forms-list">${back}${pills}</div>
       </nav>`;
 }
@@ -761,7 +761,7 @@ function renderEntriesPage(template, records, options = {}) {
       </section>`).join('');
   const content = records.length > 0
     ? entries
-    : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">${template.kind === 'container' ? 'Open the forms' : 'Log an entry'}</a></div>`;
+    : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">${template.kind === 'container' ? 'Open the trackers' : 'Log an entry'}</a></div>`;
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout entries-layout">
     <header class="topbar">
@@ -1143,21 +1143,21 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   const rows = [
     ...containers.map((container) => {
       const count = memberCount(container);
-      return `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(container.templateId)}"><span class="container-member-title">${escapeHtml(container.title)}</span><span class="forms-root-count">${count} form${count === 1 ? '' : 's'}</span><span aria-hidden="true">›</span></a>`;
+      return `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(container.templateId)}"><span class="container-member-title">${escapeHtml(container.title)}</span><span class="forms-root-count">${count} tracker${count === 1 ? '' : 's'}</span><span aria-hidden="true">›</span></a>`;
     }),
     ...ungrouped.map((template) => (
       `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(template.templateId)}"><span class="container-member-title">${escapeHtml(template.title)}</span><span aria-hidden="true">›</span></a>`
     )),
   ].join('');
-  const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first template' : 'No forms available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active forms you can submit to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New form</a>' : ''}</div>`;
+  const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first template' : 'No forms available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active trackers you can log to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New form</a>' : ''}</div>`;
   const manageHtml = managed
     ? `<details class="forms-index-manage"><summary>Manage templates <span>${active.filter((template) => template.management).length}</span></summary><div class="forms-index-list">${active.filter((template) => template.management).map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div>${archived.length ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>` : ''}</details>`
     : '';
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout forms-index-layout">
     <header class="topbar forms-index-header">
-      <div><h1>Forms</h1><p class="subtitle">${managed ? 'Tap a container to see and configure what lives inside it.' : 'Choose a form to log an entry.'}</p></div>
-      <nav class="form-hub-nav" aria-label="Forms views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New form</a><a class="configure-link" href="/forms/new?kind=container">New container</a>' : ''}</nav>
+      <div><h1>Trackers</h1><p class="subtitle">${managed ? 'Tap a container to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
+      <nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New tracker</a><a class="configure-link" href="/forms/new?kind=container">New container</a>' : ''}</nav>
     </header>
     <section class="content form-card container-card">
       <div class="container-members">${rows || emptyState}</div>
@@ -1166,7 +1166,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   </main>
   ${themeScript(options.cspNonce)}`;
   return baseHtml({
-    title: 'Forms',
+    title: 'Trackers',
     body,
     customThemeCss: options.customThemeCss,
     cspNonce: options.cspNonce,

--- a/server.js
+++ b/server.js
@@ -642,7 +642,7 @@ function createApp(options = {}) {
   // Forms only appears when the deployment actually serves them.
   setNavLinks([
     { href: '/', label: 'Files' },
-    ...(formsConfig && formsConfig.enabled === true ? [{ href: '/forms', label: 'Forms' }] : []),
+    ...(formsConfig && formsConfig.enabled === true ? [{ href: '/forms', label: 'Trackers' }] : []),
   ]);
   const accessConfig = parseAccessConfig(rawAccessConfig);
   const apiKeyStore = options.apiKeyStore === undefined

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -522,7 +522,7 @@ test('builder offers server-installed themes, saves the choice, and refuses one 
   }
 });
 
-test('toolbar section menu offers Files and Forms and disappears when there is nowhere to choose between', async () => {
+test('toolbar section menu offers Files and Trackers and disappears when there is nowhere to choose between', async () => {
   const {setNavLinks, toolbarHtml} = require('../lib/renderer');
 
   const server = await makeServer();
@@ -534,7 +534,7 @@ test('toolbar section menu offers Files and Forms and disappears when there is n
     // toolbar's translucency and blur.
     assert.equal(menu.tagName, 'DETAILS');
     const items = [...menu.querySelectorAll('[data-nav-item]')];
-    assert.deepEqual(items.map((item) => item.textContent), ['Files', 'Forms']);
+    assert.deepEqual(items.map((item) => item.textContent), ['Files', 'Trackers']);
     assert.deepEqual(items.map((item) => item.getAttribute('href')), ['/', '/forms']);
     assert.doesNotMatch(page.html, /onchange=|onclick=/i);
   } finally {

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -640,7 +640,7 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     // Header is a breadcrumb ending in the form title (the coloured current crumb),
     // matching the document header. Sub-view is shown by the hub-nav tabs.
     assert.equal(formDocument.querySelector('.topbar .crumb-title').textContent, 'Gym Session Entry');
-    assert.equal(formDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]').textContent, 'Forms');
+    assert.equal(formDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]').textContent, 'Trackers');
     assert.equal(formDocument.querySelector('.form-primary-action').textContent, 'Submit');
     assert.equal(formDocument.querySelector('label[for="field-notes"]').textContent, '<em>Notes</em> *');
     assert.match(formHtml, /&lt;em&gt;Notes&lt;\/em&gt;/);
@@ -667,7 +667,7 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     const receiptHtml = await receiptResponse.text();
     const receiptDocument = assertSharedFormsShell(receiptResponse, receiptHtml, customThemeMarker);
     assert.equal(receiptDocument.querySelector('.topbar .crumb-title').textContent, 'Gym Session Entry');
-    assert.equal(receiptDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]').textContent, 'Forms');
+    assert.equal(receiptDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]').textContent, 'Trackers');
     assert.equal(
       receiptDocument.querySelector('.form-primary-action').getAttribute('href'),
       '/forms/gym-session-entry'
@@ -2045,13 +2045,13 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     // #260: the root is a container page — the container is a tap-in row with its count
     const root = await (await server.request('/forms', {headers: {Cookie: context.cookie}})).text();
     assert.match(root, /forms-root-row/);
-    assert.match(root, /1 form</);
+    assert.match(root, /1 tracker</);
     // member titles are direct entry links inside the container page
     const containerPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
     assert.match(containerPage, /container-member-configure/);
     // #262: trails encode containment — container page links home; member pages carry the container crumb
-    assert.match(containerPage, /<nav class="breadcrumbs"><a href="\/forms">Forms<\/a>/);
+    assert.match(containerPage, /<nav class="breadcrumbs"><a href="\/forms">Trackers<\/a>/);
     const memberPage = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
     assert.match(memberPage, /<a href="\/forms\/gym">Gym<\/a>/);
     const memberEntries = await (await server.request('/forms/gym-session-entry/entries', {headers: {Cookie: context.cookie}})).text();


### PR DESCRIPTION
Closes #265. Operator: "Yep, trackers it is."

End-user surfaces now say **Trackers**: toolbar nav menu (Files / Trackers), root page title + h1, breadcrumb first crumb, container hub tab, root row counts ("22 trackers"), civilian empty states ("There are no active trackers you can log to", "Open the trackers", "No trackers in this container yet"), related-nav aria label, "New tracker" action.

Builder plane unchanged: /forms/new, Configure, templates, Manage section, the API, and every URL (`/forms/...` is plumbing, not language). "Logs" was rejected specifically because next to "Files" it reads as log files.

**Test gates:** nav-menu, breadcrumb, and root-count assertions updated. Suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
