### PR TITLE
feat(forms): sticky wayfinding bar; containers are called groups

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -142,7 +142,7 @@ function containerHubNav(templateId, active, canManage) {
     ['history', `${href}/entries`, 'History'],
     ...(canManage ? [['configure', `${href}/configure`, 'Configure']] : []),
   ];
-  return `<nav class="form-hub-nav" aria-label="Container views">${links.map(([key, linkHref, label]) =>
+  return `<nav class="form-hub-nav" aria-label="Group views">${links.map(([key, linkHref, label]) =>
     `<a class="${key}-link" href="${linkHref}"${key === active ? ' aria-current="page"' : ''}>${label}</a>`
   ).join('')}</nav>`;
 }
@@ -380,13 +380,13 @@ function renderContainerPage(template, members, options = {}) {
         </div>
       </details>`
     )).join('')
-    : '<p class="container-empty">No trackers in this container yet. Add some from its Configure page.</p>';
+    : '<p class="container-empty">No trackers in this group yet. Add some from its Configure page.</p>';
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
-      ${containerHubNav(template.templateId, 'view', options.canManage)}
     </header>
+    ${containerHubNav(template.templateId, 'view', options.canManage)}
     <section class="content form-card container-card">
       <div class="container-members">${cards}</div>
       ${renderContainerRecent(template, options.recentTagged || [], options)}
@@ -492,8 +492,8 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   <main class="layout form-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
-      ${formHubNav(template.templateId, 'log', options.canManage)}
     </header>
+    ${formHubNav(template.templateId, 'log', options.canManage)}
 
     <section class="content form-card">
       ${template.description ? `<p class="form-description">${escapeHtml(template.description)}</p>` : ''}
@@ -766,8 +766,8 @@ function renderEntriesPage(template, records, options = {}) {
   <main class="layout form-layout entries-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
-      ${template.kind === 'container' ? containerHubNav(template.templateId, 'history', options.canManage) : formHubNav(template.templateId, 'history', options.canManage)}
     </header>
+    ${template.kind === 'container' ? containerHubNav(template.templateId, 'history', options.canManage) : formHubNav(template.templateId, 'history', options.canManage)}
     <section class="content form-card entries-card">${content}</section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;
@@ -913,8 +913,8 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   <main class="layout form-layout builder-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
-      ${formHubNav(template.templateId, 'configure', true)}
     </header>
+    ${formHubNav(template.templateId, 'configure', true)}
     <section class="content form-card builder-card">
       <dl class="builder-revisions">
         <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
@@ -934,7 +934,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
           ${Array.isArray(options.parents) && options.parents.length ? `<label><span>Parent form</span><select name="parent"><option value=""${!template.parentId ? ' selected' : ''}>None</option>${options.parents.map((parent) => `<option value="${escapeHtml(parent.templateId)}"${template.parentId === parent.templateId ? ' selected' : ''}>${escapeHtml(parent.title)}</option>`).join('')}</select></label><p class="builder-help">A child form inherits every parent field live. Fields below override a parent field with the same id or extend the form; detaching copies the resolved fields back onto this form (#245).</p>` : ''}
           ${Array.isArray(options.children) && options.children.length ? `<p class="builder-help builder-parent-note">Parent of ${options.children.length} form${options.children.length === 1 ? '' : 's'}: ${options.children.map((child) => escapeHtml(child.title)).join(', ')}. Edits here flow to them live.</p>` : ''}
-          ${Array.isArray(options.containers) && options.containers.length ? `<label><span>Container</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${options.containers.map((container) => `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label><p class="builder-help">Containers group forms and give each member back-and-sibling navigation.</p>` : ''}
+          ${Array.isArray(options.containers) && options.containers.length ? `<label><span>Group</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${options.containers.map((container) => `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label><p class="builder-help">Groups hold related trackers and give each member back-and-sibling navigation.</p>` : ''}
           <p class="builder-help">Themes are installed by the deployment and read from the server. Leave both alone and this form follows whatever theme the viewer has chosen.</p>
         </section>
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
@@ -1000,13 +1000,13 @@ function renderQuickConfigure(template, all, csrfToken) {
   let membership = '';
   if (template.kind === 'container') {
     const candidates = all.filter((other) => other.kind !== 'container' && other.state !== 'archived' && other.management === true);
-    membership = `<fieldset class="quick-configure-members"><legend>Forms in this container</legend>${candidates.map((other) =>
+    membership = `<fieldset class="quick-configure-members"><legend>Trackers in this group</legend>${candidates.map((other) =>
       `<label class="container-member-choice"><input type="checkbox" name="member" value="${escapeHtml(other.templateId)}"${other.containerId === template.templateId ? ' checked' : ''}> ${escapeHtml(other.title)}</label>`
     ).join('')}</fieldset>`;
   }
   const containers = all.filter((other) => other.kind === 'container' && other.state !== 'archived');
   const containerSelect = template.kind !== 'container' && containers.length
-    ? `<label><span>Container</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${containers.map((container) =>
+    ? `<label><span>Group</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${containers.map((container) =>
       `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label>`
     : '';
   const parents = all.filter((other) => other.kind !== 'container' && other.state !== 'archived'
@@ -1082,8 +1082,8 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
   <main class="layout form-layout builder-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}</div>
-      ${containerHubNav(template.templateId, 'configure', true)}
     </header>
+    ${containerHubNav(template.templateId, 'configure', true)}
     <section class="content form-card builder-card container-configure-card">
       <dl class="builder-revisions">
         <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
@@ -1102,7 +1102,7 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
         </section>
         <section class="builder-members" aria-labelledby="container-members-heading">
           <h2 id="container-members-heading">Forms in this container</h2>
-          <p class="builder-help">Checked forms point their containerId here; unchecking releases them. Members gain back-and-sibling navigation automatically.</p>
+          <p class="builder-help">Checked trackers join this group; unchecking releases them. Members gain back-and-sibling navigation automatically.</p>
           <div class="container-member-choices">${membersHtml}</div>
         </section>
         <button class="button-link button-link-primary" type="submit">Save draft</button>
@@ -1149,16 +1149,16 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
       `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(template.templateId)}"><span class="container-member-title">${escapeHtml(template.title)}</span><span aria-hidden="true">›</span></a>`
     )),
   ].join('');
-  const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first template' : 'No forms available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active trackers you can log to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New form</a>' : ''}</div>`;
+  const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first tracker' : 'No trackers available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active trackers you can log to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New tracker</a>' : ''}</div>`;
   const manageHtml = managed
     ? `<details class="forms-index-manage"><summary>Manage templates <span>${active.filter((template) => template.management).length}</span></summary><div class="forms-index-list">${active.filter((template) => template.management).map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div>${archived.length ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>` : ''}</details>`
     : '';
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout forms-index-layout">
     <header class="topbar forms-index-header">
-      <div><h1>Trackers</h1><p class="subtitle">${managed ? 'Tap a container to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
-      <nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New tracker</a><a class="configure-link" href="/forms/new?kind=container">New container</a>' : ''}</nav>
+      <div><h1>Trackers</h1><p class="subtitle">${managed ? 'Tap a group to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
+    <nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New tracker</a><a class="configure-link" href="/forms/new?kind=container">New group</a>' : ''}</nav>
     <section class="content form-card container-card">
       <div class="container-members">${rows || emptyState}</div>
     </section>
@@ -1187,9 +1187,9 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
         <label><span>Template ID</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*" required autofocus></label>
         <label><span>Title</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required></label>
-        <label><span>Kind</span><select name="kind"><option value="">Form</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Container (groups other forms)</option></select></label>
+        <label><span>Kind</span><select name="kind"><option value="">Form</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>
         <label><span>Destination</span><select name="destinationId">${destinationOptions}</select></label>
-        <p class="builder-help">Destination applies to forms only — containers hold forms, not entries.</p>
+        <p class="builder-help">Destination applies to trackers only — groups hold trackers, not entries.</p>
         <p class="builder-help">Only deployment-approved destination aliases are available; a filesystem path is never accepted.</p>
         <button class="button-link button-link-primary form-primary-action" type="submit">Create template</button>
       </form>
@@ -1207,7 +1207,8 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
 function renderArchivedFormPage(template, options = {}) {
   const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
-    <header class="topbar">${formBreadcrumbs(template)}${formHubNav(template.templateId, 'log', options.canManage)}</header>
+    <header class="topbar">${formBreadcrumbs(template)}</header>
+    ${formHubNav(template.templateId, 'log', options.canManage)}
     <section class="content form-card archived-form-state"><h2>This form is archived</h2><p>It is not accepting new entries. Existing history and receipts are still available.</p><a class="button-link" href="/forms/${encodeURIComponent(template.templateId)}/entries">View history</a></section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;

--- a/public/style.css
+++ b/public/style.css
@@ -2817,6 +2817,10 @@ tbody tr:last-child td {
 .form-layout .breadcrumbs > a { color: var(--accent); text-decoration: none; padding: 0.15rem 0; }
 .form-layout .breadcrumbs > a:hover { text-decoration: underline; }
 
+/* #267: the wayfinding bar sticks below the measured toolbar — one pinned
+   element, translucent like the toolbar so content reads as sliding under it. */
+.form-layout > .form-hub-nav { position: sticky; top: calc(var(--toolbar-height, 3.1rem) + 0.5rem); z-index: 15; backdrop-filter: blur(6px); background: color-mix(in srgb, var(--bg-elev) 82%, transparent); margin: 0 0 1rem; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -363,7 +363,7 @@ test('forms index offers its single API-backed creation path only to managers an
     assert.equal(deniedIndex.document.querySelector('a[href="/forms/new"]'), null);
     assert.equal((await server.request('/forms/new', {headers: {'X-No-Manage': 'yes'}})).status, 404);
     const emptyIndex = await browserPage(await server.request('/forms'));
-    assert.match(emptyIndex.document.body.textContent, /Create your first template/);
+    assert.match(emptyIndex.document.body.textContent, /Create your first tracker/);
     assert.ok(emptyIndex.document.querySelector('a[href="/forms/new"]'));
     let firstRun = await browserPage(await server.request('/forms/new'));
     const cookie = firstRun.cookie;


### PR DESCRIPTION
Closes #267. Operator: the top row "should be staying at the top *somehow* to make navigation easier"; "Container should be group."

- **Sticky wayfinding bar**: the hub-nav moves out of `<header class="topbar">` (sticky is constrained to the parent box — inside the header it would scroll away with it) to a layout-level child, pinned at `top: calc(var(--toolbar-height) + 0.5rem)` with the toolbar's translucency/blur, z-index under the toolbar. One pinned element; everything else unchanged.
- **Group language** (user-facing only; `kind: 'container'` unchanged in API/schema): New group, "Group (holds related trackers)", "Tap a group…", "No trackers in this group yet", Group selects, membership legend/help, aria "Group views".
- Finishes the #265 sweep the root empty state missed ("Create your first tracker" / "No trackers available" / "New tracker").

**Test gates:** suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

Note: operator floated a further idea mid-build — the VERY TOP toolbar changing contextually (the Files idiom) instead of/alongside a second bar. Tracked for a design decision; this PR ships the sticky-bar answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
