### PR TITLE
feat(forms): contextual tracker jump menu; exclusive toolbar disclosures

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -381,7 +381,7 @@ function renderContainerPage(template, members, options = {}) {
       </details>`
     )).join('')
     : '<p class="container-empty">No trackers in this group yet. Add some from its Configure page.</p>';
-  const body = `${toolbarHtml()}
+  const body = `${toolbarHtml(options.jumpMenu || '')}
   <main class="layout form-layout container-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
@@ -488,7 +488,7 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   const submitLabel = editing
     ? 'Save correction'
     : configuredSubmitLabel || 'Submit';
-  const body = `${toolbarHtml(formProperties(template))}
+  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template)}`)}
   <main class="layout form-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
@@ -529,6 +529,29 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
 // A form's facts, in the same shape documents use. Different values -- a form has
 // no size or mtime -- but the same question: what is actually true of this thing,
 // as opposed to what its title says.
+function trackerJumpMenu(templates, current) {
+  // #269: the toolbar's contextual navigation for the trackers world — the same
+  // idiom as the Files ToC menu: core switches stay, this appears in context.
+  // Lists every group with its trackers, then ungrouped, for one-tap jumps.
+  const list = Array.isArray(templates) ? templates.filter((t) => t.state !== 'archived') : [];
+  if (!list.length) return '';
+  const groups = list.filter((t) => t.kind === 'container');
+  const groupIds = new Set(groups.map((t) => t.templateId));
+  const ungrouped = list.filter((t) => t.kind !== 'container' && !(t.containerId && groupIds.has(t.containerId)));
+  const item = (t, cls = '') => `<a role="menuitem" class="tracker-jump-item${cls}"${current && current.templateId === t.templateId ? ' aria-current="page"' : ''} href="/forms/${encodeURIComponent(t.templateId)}">${escapeHtml(t.title)}</a>`;
+  const sections = [
+    ...groups.map((group) => `${item(group, ' tracker-jump-group')}${list.filter((t) => t.containerId === group.templateId).map((t) => item(t, ' tracker-jump-member')).join('')}`),
+    ungrouped.length ? `${groups.length ? '<span class="tracker-jump-head">Ungrouped</span>' : ''}${ungrouped.map((t) => item(t)).join('')}` : '',
+  ].join('');
+  const label = current
+    ? (current.kind === 'container' ? current.title : ((current.containerId && (groups.find((g) => g.templateId === current.containerId) || {}).title) || current.title))
+    : 'Trackers';
+  return `<details class="doc-properties toolbar-menu" name="lookie-toolbar" data-tracker-menu>
+      <summary class="toolbar-btn" aria-label="Jump to a tracker or group">${escapeHtml(label)}</summary>
+      <div class="toolbar-menu-list tracker-jump-list" role="menu">${sections}</div>
+    </details>`;
+}
+
 function formProperties(record) {
   const template = (record && record.draft) || record;
   if (!template) return '';
@@ -594,7 +617,7 @@ function renderReceiptPage(template, record, options = {}) {
   const editHref = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}/edit`;
   const canEdit = options.canEdit !== false;
   const received = formatRecordTime(record, options.timezone).dateTimeLabel;
-  const body = `${toolbarHtml(formProperties(template))}
+  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template)}`)}
   <main class="layout form-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {leadLabel: template ? undefined : 'Form receipt', container: options.relatedForms && options.relatedForms.container})}
@@ -762,7 +785,7 @@ function renderEntriesPage(template, records, options = {}) {
   const content = records.length > 0
     ? entries
     : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">${template.kind === 'container' ? 'Open the trackers' : 'Log an entry'}</a></div>`;
-  const body = `${toolbarHtml(formProperties(template))}
+  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template)}`)}
   <main class="layout form-layout entries-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
@@ -909,7 +932,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   const publishedText = published
     ? `Version ${published.templateVersion}, from draft revision ${published.sourceRevision}`
     : 'Not published yet';
-  const body = `${toolbarHtml(formProperties(record))}
+  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(record)}`)}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
@@ -1078,7 +1101,7 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
     )).join('')
     : '<p class="builder-help">No forms exist yet to add.</p>';
   const lifecycle = template.archived === true ? 'restore' : 'archive';
-  const body = `${toolbarHtml()}
+  const body = `${toolbarHtml(options.jumpMenu || '')}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}</div>
@@ -1205,7 +1228,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
 }
 
 function renderArchivedFormPage(template, options = {}) {
-  const body = `${toolbarHtml(formProperties(template))}
+  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template)}`)}
   <main class="layout form-layout">
     <header class="topbar">${formBreadcrumbs(template)}</header>
     ${formHubNav(template.templateId, 'log', options.canManage)}
@@ -2226,6 +2249,13 @@ function createFormsRouter(options) {
     const cspNonce = crypto.randomBytes(18).toString('base64url');
     formHeaders(res, cspNonce);
     const all = await registry.listManagementTemplates();
+    const jumpMenu = trackerJumpMenu(all.map((candidate) => ({
+      templateId: candidate.draft.templateId,
+      title: candidate.draft.title,
+      kind: candidate.draft.kind === 'container' ? 'container' : 'form',
+      containerId: candidate.draft.containerId || null,
+      state: candidate.state,
+    })), record.draft);
     if (record.draft.kind === 'container') {
       const memberChoices = all
         .filter((candidate) => candidate.draft.kind !== 'container' && candidate.state !== 'archived')
@@ -2239,6 +2269,7 @@ function createFormsRouter(options) {
         customThemeCss,
         cspNonce,
         memberChoices,
+        jumpMenu,
         ...responseOptions,
       }));
       return;
@@ -2264,6 +2295,7 @@ function createFormsRouter(options) {
       parents,
       children,
       relatedForms: {container: await containerCrumbFor(record.draft), related: []},
+      jumpMenu,
       ...responseOptions,
     }));
   }
@@ -2582,6 +2614,7 @@ function createFormsRouter(options) {
         res.status(200).type('html').send(renderContainerPage(template, members, {
           customThemeCss, cspNonce, canManage, recentTagged, csrfToken,
           timezone: serverTimezone, now: currentDate(),
+          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         }));
         return;
       }
@@ -2597,6 +2630,7 @@ function createFormsRouter(options) {
         timezone: serverTimezone,
         canManage,
         relatedForms: await relatedFormsFor(req, template),
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         now: currentDate(),
       }));
     } catch (error) {
@@ -2621,6 +2655,7 @@ function createFormsRouter(options) {
         emitAudit(req, 'form.submissions.list', 'accepted', template);
         res.status(200).type('html').send(renderEntriesPage(template, submissions, {
           customThemeCss, cspNonce, timezone: serverTimezone, canManage, csrfToken,
+          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         }));
         return;
       }
@@ -2638,6 +2673,7 @@ function createFormsRouter(options) {
         canManage,
         csrfToken,
         relatedForms: {container: await containerCrumbFor(template), related: []},
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
       }));
     } catch (error) {
       next(error);
@@ -3013,6 +3049,7 @@ function createFormsRouter(options) {
         cspNonce,
         canEdit,
         relatedForms: await relatedFormsFor(req, template),
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         timezone: serverTimezone,
       }));
     } catch (error) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1321,7 +1321,7 @@ function toolbarHtml(extraButtons = '', options = {}) {
   // operating system, so it cannot take the toolbar's translucency and blur. These
   // match Properties and the contents menu instead.
   const navMenu = navLinks.length > 1
-    ? `<details class="doc-properties toolbar-menu" data-nav-menu>
+    ? `<details class="doc-properties toolbar-menu" name="lookie-toolbar" data-nav-menu>
       <summary class="toolbar-btn" data-nav-label aria-label="Go to section">${escapeHtml(navLinks[0].label)}</summary>
       <div class="toolbar-menu-list" role="menu">${navLinks.map((link) =>
         `<a role="menuitem" data-nav-item href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a>`).join('')}</div>
@@ -1332,7 +1332,7 @@ function toolbarHtml(extraButtons = '', options = {}) {
     ${extraButtons}
     ${annotationModeButton}
     ${annotationChip}
-    <details class="doc-properties toolbar-menu" data-theme-menu>
+    <details class="doc-properties toolbar-menu" name="lookie-toolbar" data-theme-menu>
       <summary class="toolbar-btn" data-theme-label aria-label="Select color theme">${themeNames}</summary>
       <div class="toolbar-menu-list" role="menu">${themeItems}</div>
     </details>
@@ -1535,7 +1535,7 @@ function jsonForInlineScript(value) {
 // mtime, a form has a revision and a destination.
 function propertiesMenu(rows) {
   if (!rows.length) return '';
-  return `<details class="doc-properties toolbar-properties">
+  return `<details class="doc-properties toolbar-properties" name="lookie-toolbar">
       <summary class="toolbar-btn">Properties</summary>
       <dl class="doc-properties-grid">${rows
         .map(([label, value]) => `<div><dt>${label}</dt><dd>${value}</dd></div>`)
@@ -1836,7 +1836,7 @@ function renderDocumentPage({ repo, repoRoot, repoMappings = null, canResolveLin
     </article>` : ''}`;
 
   const extraButtons = [
-    hasToc ? '<details class="doc-properties toolbar-toc" data-toc-menu><summary class="toolbar-btn" data-toc-toggle aria-label="Table of contents">☰</summary><nav class="toc-list" data-toc-list aria-label="Table of contents"></nav></details>' : '',
+    hasToc ? '<details class="doc-properties toolbar-toc" name="lookie-toolbar" data-toc-menu><summary class="toolbar-btn" data-toc-toggle aria-label="Table of contents">☰</summary><nav class="toc-list" data-toc-list aria-label="Table of contents"></nav></details>' : '',
     supportsRawToggle ? `<button type="button" class="toolbar-btn" data-raw-toggle aria-label="Toggle raw and rendered views" data-pretty-label="${isYaml ? 'Pretty' : 'Rendered'}">${isYaml ? 'Pretty' : 'Raw'}</button>` : '',
     rawHtmlHref ? `<a class="toolbar-btn" href="${escapeHtml(rawHtmlHref)}" target="_blank" rel="noopener" aria-label="Open raw HTML in new tab">Open raw</a>` : '',
     editHref ? `<a class="toolbar-btn" href="${escapeHtml(editHref)}" aria-label="Edit file">Edit</a>` : '',

--- a/public/style.css
+++ b/public/style.css
@@ -2821,6 +2821,14 @@ tbody tr:last-child td {
    element, translucent like the toolbar so content reads as sliding under it. */
 .form-layout > .form-hub-nav { position: sticky; top: calc(var(--toolbar-height, 3.1rem) + 0.5rem); z-index: 15; backdrop-filter: blur(6px); background: color-mix(in srgb, var(--bg-elev) 82%, transparent); margin: 0 0 1rem; }
 
+/* #269: tracker jump menu — the Files contextual-menu idiom for the trackers world. */
+.tracker-jump-list { max-height: 60vh; overflow-y: auto; min-width: 12rem; }
+.tracker-jump-list .tracker-jump-group { font-weight: 600; }
+.tracker-jump-list .tracker-jump-group:not(:first-child) { border-top: 1px solid var(--border); margin-top: 0.3rem; padding-top: 0.45rem; }
+.tracker-jump-list .tracker-jump-member { padding-left: 1.4rem; }
+.tracker-jump-list .tracker-jump-head { display: block; font-size: 0.72rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-soft); border-top: 1px solid var(--border); margin-top: 0.3rem; padding: 0.45rem 0.6rem 0.1rem; }
+.tracker-jump-list [aria-current="page"] { color: var(--accent); }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/document-header.test.js
+++ b/test/document-header.test.js
@@ -34,7 +34,7 @@ test('file facts live in the toolbar Properties control, not the header', () => 
   // The old meta line is gone...
   assert.doesNotMatch(html, /<p class="doc-meta">/);
   // ...and the same facts are available, collapsed, in Properties.
-  assert.match(html, /<details class="doc-properties toolbar-properties">/);
+  assert.match(html, /<details class="doc-properties toolbar-properties" name="lookie-toolbar">/);
   assert.match(html, /<summary class="toolbar-btn">Properties<\/summary>/);
   assert.match(html, /<dt>Size<\/dt><dd>4\.1 KB<\/dd>/);
   assert.match(html, /<dt>Modified<\/dt><dd>2026-07-21<\/dd>/);

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -1956,7 +1956,10 @@ test('form and receipt pages render tag-based related-forms navigation (#234 int
     const links = [...document.querySelectorAll('.related-forms .related-form-link')];
     assert.deepEqual(links.map((a) => a.textContent), ['Mobility Log'], 'same-tag sibling only');
     assert.equal(links[0].getAttribute('href'), '/forms/mobility-log');
-    assert.ok(!page.includes('Pantry Log'), 'unrelated tags stay out');
+    // #269: the toolbar jump menu lists every tracker, so scope the exclusion
+    // to the related-forms strip — its guarantee, not the whole page's.
+    const strip = page.match(/<nav class="related-forms"[\s\S]*?<\/nav>/);
+    assert.ok(strip && !strip[0].includes('Pantry Log'), 'unrelated tags stay out of the related strip');
 
     // receipt carries the same nav
     const accepted = await server.request('/forms/gym-session-entry', {
@@ -2050,6 +2053,11 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     const containerPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
     assert.match(containerPage, /container-member-configure/);
+    // #269: the toolbar carries the contextual jump menu (Files idiom) with exclusivity
+    assert.match(containerPage, /data-tracker-menu/);
+    assert.match(containerPage, /tracker-jump-member/);
+    const exclusives = (containerPage.match(/name="lookie-toolbar"/g) || []).length;
+    assert.ok(exclusives >= 3, `expected >=3 exclusive toolbar disclosures, got ${exclusives}`);
     // #262: trails encode containment — container page links home; member pages carry the container crumb
     assert.match(containerPage, /<nav class="breadcrumbs"><a href="\/forms">Trackers<\/a>/);
     const memberPage = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();


### PR DESCRIPTION
Closes #269. Closes #263. Operator: "see how we are doing it with the files portion of lookie" — the toolbar changes per context there (Raw/Edit/Properties/ToC appear per file type) while core switches stay. Mirrored for trackers:

- **Jump menu** on tracker-plane pages (tracker, group, history, configure, receipts): summary = the current group; the list is the whole tree — groups as bold section links, member trackers beneath, then Ungrouped — one tap to switch anywhere. Same `toolbar-menu` classes and mechanics as the Files menus.
- **#263 fixed**: every toolbar disclosure (nav, theme, Properties, ToC, jump) carries `name="lookie-toolbar"` — native exclusive-disclosure semantics; opening one closes the rest (Playwright verification on live post-deploy attached to #263).
- The sticky segmented bar (#268) stays untouched — operator likes it where it is.

**Test gates:** container test asserts the jump menu + member items + ≥3 exclusive disclosures; the tag-strip exclusion test now scopes to the strip (the jump menu legitimately lists every tracker page-wide). Suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
