### PR TITLE
feat(forms): toolbar group buttons — current group lit; Properties on groups

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -381,7 +381,7 @@ function renderContainerPage(template, members, options = {}) {
       </details>`
     )).join('')
     : '<p class="container-empty">No trackers in this group yet. Add some from its Configure page.</p>';
-  const body = `${toolbarHtml(options.jumpMenu || '')}
+  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template, {memberCount: members.length})}`)}
   <main class="layout form-layout container-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
@@ -530,42 +530,40 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
 // no size or mtime -- but the same question: what is actually true of this thing,
 // as opposed to what its title says.
 function trackerJumpMenu(templates, current) {
-  // #269: the toolbar's contextual navigation for the trackers world — the same
-  // idiom as the Files ToC menu: core switches stay, this appears in context.
-  // Lists every group with its trackers, then ungrouped, for one-tap jumps.
+  // #271: direct group buttons in the toolbar — Gym / Health, whichever you're
+  // on lit up. Dynamic: rendered from the live template list, so a new group
+  // appears here the moment it exists. Plain links (no disclosure), so the
+  // #263 exclusive-menu group is unaffected. Replaces the #269 dropdown tree.
   const list = Array.isArray(templates) ? templates.filter((t) => t.state !== 'archived') : [];
-  if (!list.length) return '';
-  const groups = list.filter((t) => t.kind === 'container');
-  const groupIds = new Set(groups.map((t) => t.templateId));
-  const ungrouped = list.filter((t) => t.kind !== 'container' && !(t.containerId && groupIds.has(t.containerId)));
-  const item = (t, cls = '') => `<a role="menuitem" class="tracker-jump-item${cls}"${current && current.templateId === t.templateId ? ' aria-current="page"' : ''} href="/forms/${encodeURIComponent(t.templateId)}">${escapeHtml(t.title)}</a>`;
-  const sections = [
-    ...groups.map((group) => `${item(group, ' tracker-jump-group')}${list.filter((t) => t.containerId === group.templateId).map((t) => item(t, ' tracker-jump-member')).join('')}`),
-    ungrouped.length ? `${groups.length ? '<span class="tracker-jump-head">Ungrouped</span>' : ''}${ungrouped.map((t) => item(t)).join('')}` : '',
-  ].join('');
-  const label = current
-    ? (current.kind === 'container' ? current.title : ((current.containerId && (groups.find((g) => g.templateId === current.containerId) || {}).title) || current.title))
-    : 'Trackers';
-  return `<details class="doc-properties toolbar-menu" name="lookie-toolbar" data-tracker-menu>
-      <summary class="toolbar-btn" aria-label="Jump to a tracker or group">${escapeHtml(label)}</summary>
-      <div class="toolbar-menu-list tracker-jump-list" role="menu">${sections}</div>
-    </details>`;
+  const groups = list.filter((t) => t.kind === 'container')
+    .sort((a, b) => String(a.title).localeCompare(String(b.title)));
+  if (!groups.length) return '';
+  const currentGroupId = current
+    ? (current.kind === 'container' ? current.templateId : current.containerId || null)
+    : null;
+  return groups.map((group) =>
+    `<a class="toolbar-btn group-nav-btn" href="/forms/${encodeURIComponent(group.templateId)}"${group.templateId === currentGroupId ? ' aria-current="page"' : ''}>${escapeHtml(group.title)}</a>`
+  ).join('');
 }
 
-function formProperties(record) {
+function formProperties(record, extras = {}) {
   const template = (record && record.draft) || record;
   if (!template) return '';
   const published = record && record.publishedVersion;
   const presentation = template.presentation || {};
+  const isGroup = template.kind === 'container';
   const rows = [
-    ['Form', escapeHtml(template.templateId)],
+    [isGroup ? 'Group' : 'Form', escapeHtml(template.templateId)],
     ['Revision', escapeHtml(String(template.revision))],
     ['Published', published
       ? escapeHtml(`v${published.templateVersion} from revision ${published.sourceRevision}`)
       : 'not published'],
-    ['Destination', escapeHtml(template.destinationId || 'default')],
+    // #271: a group has no destination or fields of its own — report members.
+    ...(isGroup ? [] : [['Destination', escapeHtml(template.destinationId || 'default')]]),
     ['Owner', escapeHtml(template.ownerId)],
-    ['Fields', escapeHtml(String((template.fields || []).filter((field) => !field.isDestroyed).length))],
+    isGroup
+      ? ['Trackers', escapeHtml(String(extras.memberCount ?? 0))]
+      : ['Fields', escapeHtml(String((template.fields || []).filter((field) => !field.isDestroyed).length))],
   ];
   // Only report a theme that is actually installed. An unknown or malformed slug
   // does not apply -- the form renders in the viewer's theme -- so printing it here
@@ -1101,7 +1099,7 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
     )).join('')
     : '<p class="builder-help">No forms exist yet to add.</p>';
   const lifecycle = template.archived === true ? 'restore' : 'archive';
-  const body = `${toolbarHtml(options.jumpMenu || '')}
+  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(record, {memberCount: (options.memberChoices || []).filter((choice) => choice.checked).length})}`)}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}</div>

--- a/public/style.css
+++ b/public/style.css
@@ -2821,13 +2821,9 @@ tbody tr:last-child td {
    element, translucent like the toolbar so content reads as sliding under it. */
 .form-layout > .form-hub-nav { position: sticky; top: calc(var(--toolbar-height, 3.1rem) + 0.5rem); z-index: 15; backdrop-filter: blur(6px); background: color-mix(in srgb, var(--bg-elev) 82%, transparent); margin: 0 0 1rem; }
 
-/* #269: tracker jump menu — the Files contextual-menu idiom for the trackers world. */
-.tracker-jump-list { max-height: 60vh; overflow-y: auto; min-width: 12rem; }
-.tracker-jump-list .tracker-jump-group { font-weight: 600; }
-.tracker-jump-list .tracker-jump-group:not(:first-child) { border-top: 1px solid var(--border); margin-top: 0.3rem; padding-top: 0.45rem; }
-.tracker-jump-list .tracker-jump-member { padding-left: 1.4rem; }
-.tracker-jump-list .tracker-jump-head { display: block; font-size: 0.72rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-soft); border-top: 1px solid var(--border); margin-top: 0.3rem; padding: 0.45rem 0.6rem 0.1rem; }
-.tracker-jump-list [aria-current="page"] { color: var(--accent); }
+/* #271: direct group buttons in the toolbar — current group lit. */
+.viewer-toolbar .group-nav-btn { text-decoration: none; }
+.viewer-toolbar .group-nav-btn[aria-current="page"] { background: color-mix(in srgb, var(--accent) 22%, transparent); border-color: var(--accent); color: var(--accent); }
 
 /* ============================================================================
    Document components

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2053,11 +2053,15 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     const containerPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
     assert.match(containerPage, /container-member-configure/);
-    // #269: the toolbar carries the contextual jump menu (Files idiom) with exclusivity
-    assert.match(containerPage, /data-tracker-menu/);
-    assert.match(containerPage, /tracker-jump-member/);
+    // #271: direct group buttons in the toolbar, current group lit; groups carry Properties
+    assert.match(containerPage, /group-nav-btn" href="\/forms\/gym" aria-current="page"/);
+    assert.match(containerPage, /toolbar-properties/);
+    assert.match(containerPage, /<dt>Group<\/dt>|Group<\/dt>/);
     const exclusives = (containerPage.match(/name="lookie-toolbar"/g) || []).length;
     assert.ok(exclusives >= 3, `expected >=3 exclusive toolbar disclosures, got ${exclusives}`);
+    // the member form's toolbar lights its group too
+    const memberToolbar = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    assert.match(memberToolbar, /group-nav-btn" href="\/forms\/gym" aria-current="page"/);
     // #262: trails encode containment — container page links home; member pages carry the container crumb
     assert.match(containerPage, /<nav class="breadcrumbs"><a href="\/forms">Trackers<\/a>/);
     const memberPage = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();


### PR DESCRIPTION
Closes #271 (operator course-correction on #269's dropdown shape).

- **Group buttons in the toolbar**: Gym / Health as direct `toolbar-btn` links on every tracker-plane page, sorted, rendered from the live template list — dynamic as groups are added. The current context's group is lit (`aria-current` + accent styling). One tap back to a group's start from anywhere.
- **Properties on groups**: the disclosure now renders on group pages and group Configure — Group id, revision, published, owner, and Trackers (member count) instead of destination/fields.
- Plain links, not disclosures — #263's exclusive group (`name="lookie-toolbar"`) is unaffected.

**Test gates:** container test asserts the lit group button on both the group page and a member tracker's page, plus group Properties. Suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
