### PR TITLE
feat(forms): drop the breadcrumb path — the toolbar superseded it

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -118,20 +118,17 @@ function formHeaders(res, cspNonce) {
 }
 
 function formBreadcrumbs(template, options = {}) {
-  const crumbs = [`<a href="/forms">Trackers</a>`];
-  // #262: the trail IS the containment hierarchy — a form inside a container
-  // carries its container as a tappable ancestor on every page.
-  if (options.container) {
-    crumbs.push(`<a href="/forms/${encodeURIComponent(options.container.templateId)}">${escapeHtml(options.container.title)}</a>`);
-  }
+  // #273: the ancestor path is gone — the toolbar's Trackers menu and lit group
+  // buttons (#272) carry that navigation now. What remains is the page's name.
   if (template) {
     const href = `/forms/${encodeURIComponent(template.templateId)}`;
     const label = options.leadLabel ? escapeHtml(options.leadLabel) : escapeHtml(template.title);
-    crumbs.push(`<h1 class="crumb-title"><a href="${href}" aria-current="page">${label}</a></h1>`);
-  } else if (options.leadLabel) {
-    crumbs.push(`<h1 class="crumb-title"><span aria-current="page">${escapeHtml(options.leadLabel)}</span></h1>`);
+    return `<nav class="breadcrumbs"><h1 class="crumb-title"><a href="${href}" aria-current="page">${label}</a></h1></nav>`;
   }
-  return `<nav class="breadcrumbs">${crumbs.join('<span class="sep">/</span>')}</nav>`;
+  if (options.leadLabel) {
+    return `<nav class="breadcrumbs"><h1 class="crumb-title"><span aria-current="page">${escapeHtml(options.leadLabel)}</span></h1></nav>`;
+  }
+  return '';
 }
 
 function containerHubNav(templateId, active, canManage) {

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -640,7 +640,7 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     // Header is a breadcrumb ending in the form title (the coloured current crumb),
     // matching the document header. Sub-view is shown by the hub-nav tabs.
     assert.equal(formDocument.querySelector('.topbar .crumb-title').textContent, 'Gym Session Entry');
-    assert.equal(formDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]').textContent, 'Trackers');
+    assert.equal(formDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]'), null);
     assert.equal(formDocument.querySelector('.form-primary-action').textContent, 'Submit');
     assert.equal(formDocument.querySelector('label[for="field-notes"]').textContent, '<em>Notes</em> *');
     assert.match(formHtml, /&lt;em&gt;Notes&lt;\/em&gt;/);
@@ -667,7 +667,7 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
     const receiptHtml = await receiptResponse.text();
     const receiptDocument = assertSharedFormsShell(receiptResponse, receiptHtml, customThemeMarker);
     assert.equal(receiptDocument.querySelector('.topbar .crumb-title').textContent, 'Gym Session Entry');
-    assert.equal(receiptDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]').textContent, 'Trackers');
+    assert.equal(receiptDocument.querySelector('.topbar .breadcrumbs a[href="/forms"]'), null);
     assert.equal(
       receiptDocument.querySelector('.form-primary-action').getAttribute('href'),
       '/forms/gym-session-entry'
@@ -2062,12 +2062,11 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     // the member form's toolbar lights its group too
     const memberToolbar = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
     assert.match(memberToolbar, /group-nav-btn" href="\/forms\/gym" aria-current="page"/);
-    // #262: trails encode containment — container page links home; member pages carry the container crumb
-    assert.match(containerPage, /<nav class="breadcrumbs"><a href="\/forms">Trackers<\/a>/);
+    // #273: the ancestor path is gone — the heading is title-only; the toolbar navigates
+    assert.match(containerPage, /<nav class="breadcrumbs"><h1 class="crumb-title">/);
+    assert.doesNotMatch(containerPage, /breadcrumbs"><a href="\/forms">Trackers/);
     const memberPage = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
-    assert.match(memberPage, /<a href="\/forms\/gym">Gym<\/a>/);
-    const memberEntries = await (await server.request('/forms/gym-session-entry/entries', {headers: {Cookie: context.cookie}})).text();
-    assert.match(memberEntries, /<a href="\/forms\/gym">Gym<\/a>/);
+    assert.doesNotMatch(memberPage, /<span class="sep">/);
 
     // container Configure: member checkboxes; unchecking releases membership
     const configure = await (await server.request('/forms/gym/configure', {headers: {Cookie: context.cookie}})).text();


### PR DESCRIPTION
Closes #273. Operator, looking at /forms/meds: "I think we could dump this navigation path stuff too" — the `Trackers / Health / Medications — Dose Log` line, which also wraps into a four-line stack at phone width.

The path duplicated what the toolbar now owns (Trackers menu → root; lit group buttons → where you are + group jumps, #272; bottom strip → siblings). `formBreadcrumbs` renders the title heading only; ancestor links and separators are gone. Route plumbing feeding the related strip stays.

**Test gates:** crumb assertions inverted (no ancestor links, no separators; title heading present). Suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
