### PR TITLE
feat(forms): groups stack in one theme-style dropdown; + New group

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -526,21 +526,28 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
 // A form's facts, in the same shape documents use. Different values -- a form has
 // no size or mtime -- but the same question: what is actually true of this thing,
 // as opposed to what its title says.
-function trackerJumpMenu(templates, current) {
-  // #271: direct group buttons in the toolbar — Gym / Health, whichever you're
-  // on lit up. Dynamic: rendered from the live template list, so a new group
-  // appears here the moment it exists. Plain links (no disclosure), so the
-  // #263 exclusive-menu group is unaffected. Replaces the #269 dropdown tree.
+function trackerJumpMenu(templates, current, options = {}) {
+  // #275: groups stack in ONE dropdown, the theme-menu idiom — summary shows the
+  // current group, the list is groups only (no tracker tree), current lit by the
+  // shared [aria-current] menu styling. Touchscreen-size stacked rows. Creators
+  // get "+ New group" at the bottom. Replaces the #271 side-by-side buttons.
   const list = Array.isArray(templates) ? templates.filter((t) => t.state !== 'archived') : [];
   const groups = list.filter((t) => t.kind === 'container')
     .sort((a, b) => String(a.title).localeCompare(String(b.title)));
-  if (!groups.length) return '';
+  if (!groups.length && !options.canCreate) return '';
   const currentGroupId = current
     ? (current.kind === 'container' ? current.templateId : current.containerId || null)
     : null;
-  return groups.map((group) =>
-    `<a class="toolbar-btn group-nav-btn" href="/forms/${encodeURIComponent(group.templateId)}"${group.templateId === currentGroupId ? ' aria-current="page"' : ''}>${escapeHtml(group.title)}</a>`
-  ).join('');
+  const currentGroup = groups.find((group) => group.templateId === currentGroupId);
+  const items = groups.map((group) =>
+    `<a role="menuitem" href="/forms/${encodeURIComponent(group.templateId)}"${group === currentGroup ? ' aria-current="page"' : ''}>${escapeHtml(group.title)}</a>`
+  ).join('') + (options.canCreate
+    ? '<a role="menuitem" class="group-menu-new" href="/forms/new?kind=container">+ New group</a>'
+    : '');
+  return `<details class="doc-properties toolbar-menu" name="lookie-toolbar" data-group-menu>
+      <summary class="toolbar-btn" aria-label="Switch group">${escapeHtml(currentGroup ? currentGroup.title : 'Groups')}</summary>
+      <div class="toolbar-menu-list" role="menu">${items}</div>
+    </details>`;
 }
 
 function formProperties(record, extras = {}) {
@@ -2250,7 +2257,7 @@ function createFormsRouter(options) {
       kind: candidate.draft.kind === 'container' ? 'container' : 'form',
       containerId: candidate.draft.containerId || null,
       state: candidate.state,
-    })), record.draft);
+    })), record.draft, {canCreate: true});
     if (record.draft.kind === 'container') {
       const memberChoices = all
         .filter((candidate) => candidate.draft.kind !== 'container' && candidate.state !== 'archived')
@@ -2609,7 +2616,7 @@ function createFormsRouter(options) {
         res.status(200).type('html').send(renderContainerPage(template, members, {
           customThemeCss, cspNonce, canManage, recentTagged, csrfToken,
           timezone: serverTimezone, now: currentDate(),
-          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
+          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
         }));
         return;
       }
@@ -2625,7 +2632,7 @@ function createFormsRouter(options) {
         timezone: serverTimezone,
         canManage,
         relatedForms: await relatedFormsFor(req, template),
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
         now: currentDate(),
       }));
     } catch (error) {
@@ -2650,7 +2657,7 @@ function createFormsRouter(options) {
         emitAudit(req, 'form.submissions.list', 'accepted', template);
         res.status(200).type('html').send(renderEntriesPage(template, submissions, {
           customThemeCss, cspNonce, timezone: serverTimezone, canManage, csrfToken,
-          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
+          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
         }));
         return;
       }
@@ -2668,7 +2675,7 @@ function createFormsRouter(options) {
         canManage,
         csrfToken,
         relatedForms: {container: await containerCrumbFor(template), related: []},
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
       }));
     } catch (error) {
       next(error);
@@ -3044,7 +3051,7 @@ function createFormsRouter(options) {
         cspNonce,
         canEdit,
         relatedForms: await relatedFormsFor(req, template),
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
         timezone: serverTimezone,
       }));
     } catch (error) {

--- a/public/style.css
+++ b/public/style.css
@@ -2821,9 +2821,9 @@ tbody tr:last-child td {
    element, translucent like the toolbar so content reads as sliding under it. */
 .form-layout > .form-hub-nav { position: sticky; top: calc(var(--toolbar-height, 3.1rem) + 0.5rem); z-index: 15; backdrop-filter: blur(6px); background: color-mix(in srgb, var(--bg-elev) 82%, transparent); margin: 0 0 1rem; }
 
-/* #271: direct group buttons in the toolbar — current group lit. */
-.viewer-toolbar .group-nav-btn { text-decoration: none; }
-.viewer-toolbar .group-nav-btn[aria-current="page"] { background: color-mix(in srgb, var(--accent) 22%, transparent); border-color: var(--accent); color: var(--accent); }
+/* #275: groups stack in one theme-style dropdown; the shared [aria-current]
+   menu styling lights the current one. New-group row reads as an action. */
+.toolbar-menu[data-group-menu] .group-menu-new { border-top: 1px solid var(--border); margin-top: 0.2rem; padding-top: 0.5rem; color: var(--accent); }
 
 /* ============================================================================
    Document components

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2053,15 +2053,18 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     const containerPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
     assert.match(containerPage, /container-member-configure/);
-    // #271: direct group buttons in the toolbar, current group lit; groups carry Properties
-    assert.match(containerPage, /group-nav-btn" href="\/forms\/gym" aria-current="page"/);
+    // #275: groups stack in one theme-style dropdown, current lit; groups carry Properties
+    assert.match(containerPage, /data-group-menu/);
+    assert.match(containerPage, /href="\/forms\/gym" aria-current="page"/);
+    assert.match(containerPage, /group-menu-new" href="\/forms\/new\?kind=container"/);
+    assert.doesNotMatch(containerPage, /tracker-jump-member/);
     assert.match(containerPage, /toolbar-properties/);
     assert.match(containerPage, /<dt>Group<\/dt>|Group<\/dt>/);
     const exclusives = (containerPage.match(/name="lookie-toolbar"/g) || []).length;
     assert.ok(exclusives >= 3, `expected >=3 exclusive toolbar disclosures, got ${exclusives}`);
-    // the member form's toolbar lights its group too
+    // the member form's dropdown lights its group too
     const memberToolbar = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
-    assert.match(memberToolbar, /group-nav-btn" href="\/forms\/gym" aria-current="page"/);
+    assert.match(memberToolbar, /href="\/forms\/gym" aria-current="page"/);
     // #273: the ancestor path is gone — the heading is title-only; the toolbar navigates
     assert.match(containerPage, /<nav class="breadcrumbs"><h1 class="crumb-title">/);
     assert.doesNotMatch(containerPage, /breadcrumbs"><a href="\/forms">Trackers/);


### PR DESCRIPTION
Closes #275. Operator: groups "can stack on each other, just like the themes do... AND light up in the dropdown like they do (just not a tree of all the forms in the group)" — then "doesn't need to be big... the big stuff below is more important."

- One compact `data-group-menu` dropdown replaces the #272 side-by-side buttons: summary = current group, stacked list of groups only, current lit via the shared `[aria-current]` menu styling (same as the active theme). Standard theme-menu row sizing — the page below keeps the big targets.
- **"+ New group"** bottom row (creators only) → `/forms/new?kind=container`.
- Participates in the `name="lookie-toolbar"` exclusive set (#263 holds).

**Test gates:** dropdown present, gym lit on both group and member pages, New-group row, no tracker tree. Suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
