### PR TITLE
feat(forms): All trackers row leads the group dropdown; New group out

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -534,16 +534,16 @@ function trackerJumpMenu(templates, current, options = {}) {
   const list = Array.isArray(templates) ? templates.filter((t) => t.state !== 'archived') : [];
   const groups = list.filter((t) => t.kind === 'container')
     .sort((a, b) => String(a.title).localeCompare(String(b.title)));
-  if (!groups.length && !options.canCreate) return '';
+  if (!groups.length) return '';
   const currentGroupId = current
     ? (current.kind === 'container' ? current.templateId : current.containerId || null)
     : null;
   const currentGroup = groups.find((group) => group.templateId === currentGroupId);
-  const items = groups.map((group) =>
+  // #277: "All trackers" leads — the way back to the main page from anywhere.
+  // New group left the menu (it lives on the root, where creation belongs).
+  const items = '<a role="menuitem" class="group-menu-root" href="/forms">All trackers</a>' + groups.map((group) =>
     `<a role="menuitem" href="/forms/${encodeURIComponent(group.templateId)}"${group === currentGroup ? ' aria-current="page"' : ''}>${escapeHtml(group.title)}</a>`
-  ).join('') + (options.canCreate
-    ? '<a role="menuitem" class="group-menu-new" href="/forms/new?kind=container">+ New group</a>'
-    : '');
+  ).join('');
   return `<details class="doc-properties toolbar-menu" name="lookie-toolbar" data-group-menu>
       <summary class="toolbar-btn" aria-label="Switch group">${escapeHtml(currentGroup ? currentGroup.title : 'Groups')}</summary>
       <div class="toolbar-menu-list" role="menu">${items}</div>
@@ -2257,7 +2257,7 @@ function createFormsRouter(options) {
       kind: candidate.draft.kind === 'container' ? 'container' : 'form',
       containerId: candidate.draft.containerId || null,
       state: candidate.state,
-    })), record.draft, {canCreate: true});
+    })), record.draft);
     if (record.draft.kind === 'container') {
       const memberChoices = all
         .filter((candidate) => candidate.draft.kind !== 'container' && candidate.state !== 'archived')
@@ -2616,7 +2616,7 @@ function createFormsRouter(options) {
         res.status(200).type('html').send(renderContainerPage(template, members, {
           customThemeCss, cspNonce, canManage, recentTagged, csrfToken,
           timezone: serverTimezone, now: currentDate(),
-          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
+          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         }));
         return;
       }
@@ -2632,7 +2632,7 @@ function createFormsRouter(options) {
         timezone: serverTimezone,
         canManage,
         relatedForms: await relatedFormsFor(req, template),
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         now: currentDate(),
       }));
     } catch (error) {
@@ -2657,7 +2657,7 @@ function createFormsRouter(options) {
         emitAudit(req, 'form.submissions.list', 'accepted', template);
         res.status(200).type('html').send(renderEntriesPage(template, submissions, {
           customThemeCss, cspNonce, timezone: serverTimezone, canManage, csrfToken,
-          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
+          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         }));
         return;
       }
@@ -2675,7 +2675,7 @@ function createFormsRouter(options) {
         canManage,
         csrfToken,
         relatedForms: {container: await containerCrumbFor(template), related: []},
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
       }));
     } catch (error) {
       next(error);
@@ -3051,7 +3051,7 @@ function createFormsRouter(options) {
         cspNonce,
         canEdit,
         relatedForms: await relatedFormsFor(req, template),
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template, {canCreate: await canCreateTemplate(req)}),
+        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         timezone: serverTimezone,
       }));
     } catch (error) {

--- a/public/style.css
+++ b/public/style.css
@@ -2823,7 +2823,7 @@ tbody tr:last-child td {
 
 /* #275: groups stack in one theme-style dropdown; the shared [aria-current]
    menu styling lights the current one. New-group row reads as an action. */
-.toolbar-menu[data-group-menu] .group-menu-new { border-top: 1px solid var(--border); margin-top: 0.2rem; padding-top: 0.5rem; color: var(--accent); }
+.toolbar-menu[data-group-menu] .group-menu-root { border-bottom: 1px solid var(--border); margin-bottom: 0.2rem; padding-bottom: 0.5rem; }
 
 /* ============================================================================
    Document components

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2056,7 +2056,8 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     // #275: groups stack in one theme-style dropdown, current lit; groups carry Properties
     assert.match(containerPage, /data-group-menu/);
     assert.match(containerPage, /href="\/forms\/gym" aria-current="page"/);
-    assert.match(containerPage, /group-menu-new" href="\/forms\/new\?kind=container"/);
+    assert.match(containerPage, /group-menu-root" href="\/forms">All trackers</);
+    assert.doesNotMatch(containerPage, /group-menu-new/);
     assert.doesNotMatch(containerPage, /tracker-jump-member/);
     assert.match(containerPage, /toolbar-properties/);
     assert.match(containerPage, /<dt>Group<\/dt>|Group<\/dt>/);


### PR DESCRIPTION
Closes #277. Operator: "how do we get back to the main trackers page? New group doesn't need to be in the top menu... New group should be in the main page....(which we can't navigate back to)"

- **All trackers** → `/forms` leads the group dropdown with a divider beneath — the way home from any group, tracker, history, receipt, or configure page.
- **+ New group** removed from the dropdown; it stays on the root's bar (Browse | New tracker | New group), which is now reachable again.

**Test gates:** dropdown asserts All-trackers row present, New-group row absent. Suite 200 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
