### PR TITLE
feat(forms): creation follows containment — slug IDs, group-joined trackers

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -137,7 +137,10 @@ function containerHubNav(templateId, active, canManage) {
   const links = [
     ['view', href, 'Trackers'],
     ['history', `${href}/entries`, 'History'],
-    ...(canManage ? [['configure', `${href}/configure`, 'Configure']] : []),
+    ...(canManage ? [
+      ['configure', `${href}/configure`, 'Configure'],
+      ['new', `/forms/new?group=${encodeURIComponent(templateId)}`, 'New tracker'],
+    ] : []),
   ];
   return `<nav class="form-hub-nav" aria-label="Group views">${links.map(([key, linkHref, label]) =>
     `<a class="${key}-link" href="${linkHref}"${key === active ? ' aria-current="page"' : ''}>${label}</a>`
@@ -1174,7 +1177,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
       `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(template.templateId)}"><span class="container-member-title">${escapeHtml(template.title)}</span><span aria-hidden="true">›</span></a>`
     )),
   ].join('');
-  const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first tracker' : 'No trackers available'}</h2><p>${canCreate ? 'Start with a simple draft, then shape its fields in the builder.' : 'There are no active trackers you can log to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new">New tracker</a>' : ''}</div>`;
+  const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first group' : 'No trackers available'}</h2><p>${canCreate ? 'Groups hold your trackers — make one, then add trackers inside it.' : 'There are no active trackers you can log to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new?kind=container">New group</a>' : ''}</div>`;
   const manageHtml = managed
     ? `<details class="forms-index-manage"><summary>Manage templates <span>${active.filter((template) => template.management).length}</span></summary><div class="forms-index-list">${active.filter((template) => template.management).map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div>${archived.length ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>` : ''}</details>`
     : '';
@@ -1183,7 +1186,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     <header class="topbar forms-index-header">
       <div><h1>Trackers</h1><p class="subtitle">${managed ? 'Tap a group to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
-    <nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new">New tracker</a><a class="configure-link" href="/forms/new?kind=container">New group</a>' : ''}</nav>
+    <nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new?kind=container">New group</a>' : ''}</nav>
     <section class="content form-card container-card">
       <div class="container-members">${rows || emptyState}</div>
     </section>
@@ -1210,9 +1213,10 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
       ${builderErrors(options.errors)}
       <form method="post" action="/forms">
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-        <label><span>Template ID</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*" required autofocus></label>
-        <label><span>Title</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required></label>
-        <label><span>Kind</span><select name="kind"><option value="">Form</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>
+        <label><span>Name</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required autofocus></label>
+        <label><span>ID (optional)</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*"></label>
+        <p class="builder-help">Leave the ID blank and it derives from the name (#279).</p>
+        ${options.group ? `<input type="hidden" name="group" value="${escapeHtml(options.group.templateId)}"><p class="builder-help">Joining group: <strong>${escapeHtml(options.group.title || options.group.templateId)}</strong></p>` : `<label><span>Kind</span><select name="kind"><option value="">Form</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>`}
         <label><span>Destination</span><select name="destinationId">${destinationOptions}</select></label>
         <p class="builder-help">Destination applies to trackers only — groups hold trackers, not entries.</p>
         <p class="builder-help">Only deployment-approved destination aliases are available; a filesystem path is never accepted.</p>
@@ -2203,7 +2207,7 @@ function createFormsRouter(options) {
 
   function validBuilderBody(body, create = false) {
     const fixed = create
-      ? new Set(['_csrf', 'templateId', 'title', 'destinationId', 'kind'])
+      ? new Set(['_csrf', 'templateId', 'title', 'destinationId', 'kind', 'group'])
       : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container', 'parent']);
     // An author SELECTS an installed theme; they can never introduce one. Anything
     // outside the server's list is refused rather than quietly ignored.
@@ -2328,8 +2332,16 @@ function createFormsRouter(options) {
       if (!browserAuthenticated(req, res, type)) return;
       if (!await canCreateTemplate(req)) return formNotFound(req, res, type);
       emitAudit(req, type, 'accepted');
-      // #260: the root's New container action lands here preselected.
-      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : ''});
+      // #260: the root's New group action lands here preselected.
+      // #279: arriving from a group page pre-joins the new tracker to it.
+      let group = null;
+      if (typeof req.query.group === 'string' && isDefinitionId(req.query.group)) {
+        const target = await registry.getTemplate(req.query.group);
+        if (target && target.kind === 'container' && target.archived !== true) {
+          group = {templateId: target.templateId, title: target.title};
+        }
+      }
+      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : '', group});
     } catch (error) {
       next(error);
     }
@@ -2350,18 +2362,31 @@ function createFormsRouter(options) {
         res.status(400).type('text/plain').send('Invalid form body.');
         return;
       }
-      const templateId = postedString(req.body, 'templateId');
+      const title = postedString(req.body, 'title');
+      // #279: the ID is optional — blank derives a deduped slug from the name.
+      let templateId = postedString(req.body, 'templateId');
+      if (!templateId) {
+        let slug = String(title).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60);
+        if (!/^[a-z]/.test(slug)) slug = `tracker${slug ? `-${slug}` : ''}`;
+        templateId = slug;
+        for (let suffix = 2; await registry.getTemplate(templateId); suffix += 1) {
+          templateId = `${slug}-${suffix}`;
+        }
+      }
       const kind = postedString(req.body, 'kind');
+      const group = postedString(req.body, 'group');
       // #234: the GUI creates containers through the same flow — no starter field,
       // no destination; the Configure page then manages members.
       const body = kind === 'container'
-        ? {templateId, grammarVersion: 1, title: postedString(req.body, 'title'), kind: 'container'}
+        ? {templateId, grammarVersion: 1, title, kind: 'container'}
         : {
           templateId,
           grammarVersion: 1,
           destinationId: postedString(req.body, 'destinationId'),
-          title: postedString(req.body, 'title'),
+          title,
           fields: [{id: 'entry', type: 'short-text', label: 'Entry', required: true}],
+          // #279: created from inside a group — joins it (registry fail-closes bad ids)
+          ...(group ? {containerId: group} : {}),
         };
       const record = await createTemplateThroughApi(req, body);
       emitAudit(req, type, 'accepted', record.draft);

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -363,8 +363,8 @@ test('forms index offers its single API-backed creation path only to managers an
     assert.equal(deniedIndex.document.querySelector('a[href="/forms/new"]'), null);
     assert.equal((await server.request('/forms/new', {headers: {'X-No-Manage': 'yes'}})).status, 404);
     const emptyIndex = await browserPage(await server.request('/forms'));
-    assert.match(emptyIndex.document.body.textContent, /Create your first tracker/);
-    assert.ok(emptyIndex.document.querySelector('a[href="/forms/new"]'));
+    assert.match(emptyIndex.document.body.textContent, /Create your first group/);
+    assert.ok(emptyIndex.document.querySelector('a[href="/forms/new?kind=container"]'));
     let firstRun = await browserPage(await server.request('/forms/new'));
     const cookie = firstRun.cookie;
     assert.match(firstRun.document.querySelector('h1').textContent, /New template/);
@@ -425,7 +425,8 @@ test('forms index separates archived templates and removes management detail for
     const manageCards = managerIndex.document.querySelectorAll('.forms-index-manage .forms-index-item');
     const archivedCards = managerIndex.document.querySelectorAll('.forms-index-archived .forms-index-item');
     assert.equal(manageCards.length - archivedCards.length, 2);
-    assert.ok(managerIndex.document.querySelector('a[href="/forms/new"]'));
+    assert.equal(managerIndex.document.querySelector('a[href="/forms/new"]'), null);
+    assert.ok(managerIndex.document.querySelector('a[href="/forms/new?kind=container"]'));
     assert.ok(managerIndex.document.querySelector('a[href="/forms/new?kind=container"]'));
     const trainingCard = [...managerIndex.document.querySelectorAll('.forms-index-item')]
       .find((card) => /Training <log>/.test(card.querySelector('.forms-index-title h2').textContent));

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2167,3 +2167,37 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     await cleanup(fixture, server);
   }
 });
+
+test('creation follows containment: slug-derived IDs and group-joined trackers (#279)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {formsTimezone: 'America/New_York'});
+  try {
+    const context = await getBrowserContext(server);
+    const post = (body) => server.request('/forms', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: new URLSearchParams(body),
+    });
+    // group via the GUI, no ID typed — slug derives from the name
+    const group = await post({_csrf: context.token, title: 'Gym & Fitness!', kind: 'container'});
+    assert.equal(group.status, 303);
+    assert.match(group.headers.get('location'), /^\/forms\/gym-fitness\/configure$/);
+    // tracker created from inside the group joins it; duplicate name gets a suffix
+    const first = await post({_csrf: context.token, title: 'Rowing', destinationId: 'default', group: 'gym-fitness'});
+    assert.equal(first.status, 303);
+    const second = await post({_csrf: context.token, title: 'Rowing', destinationId: 'default', group: 'gym-fitness'});
+    assert.equal(second.status, 303);
+    assert.match(second.headers.get('location'), /^\/forms\/rowing-2\/configure$/);
+    const rowing = JSON.parse(await (await server.request('/api/forms/templates/rowing')).text()).template;
+    assert.equal(rowing.containerId, 'gym-fitness');
+    // group page carries the New tracker action, preset to the group
+    const groupPage = await (await server.request('/forms/gym-fitness', {headers: {Cookie: context.cookie}})).text();
+    assert.match(groupPage, /href="\/forms\/new\?group=gym-fitness"/);
+    // the create page shows the joining note
+    const createPage = await (await server.request('/forms/new?group=gym-fitness', {headers: {Cookie: context.cookie}})).text();
+    assert.match(createPage, /Joining group/);
+    assert.match(createPage, /Gym &amp; Fitness!/);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});


### PR DESCRIPTION
Closes #279. Operator: "new tracker should really only be new group. And the id should get auto-assigned from a shortname???? Not sure about that last part. then new tracker could be added from inside the group menu."

- **Root**: New group only (the root is the groups page); empty-state CTA follows ("Create your first group").
- **Group pages**: sticky bar gains **New tracker** → `/forms/new?group=<id>`; the create page shows "Joining group: <title>", hides Kind, and the created tracker lands in that group (create API containerId, fail-closed).
- **Slug-derived IDs** (the "not sure" part, done reversibly): the ID field is optional — blank derives from the name ("Gym & Fitness!" → `gym-fitness`), deduped with -2/-3; typing an ID works unchanged.

**Test gates:** new end-to-end test (slug derivation, dedupe suffix, group join, New-tracker action, joining note). Suite 201 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
