### PR TITLE
feat(forms): the sticky bar persists into /forms/new — no dead ends

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -1205,9 +1205,15 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
   const destinationOptions = destinationIds.map((destinationId) =>
     `<option value="${escapeHtml(destinationId)}"${options.destinationId === destinationId ? ' selected' : ''}>${escapeHtml(destinationId)}</option>`
   ).join('');
-  const body = `${toolbarHtml()}
+  // #281: no dead ends — the bar you arrived from persists, current tab lit.
+  const lead = options.group ? 'New tracker' : (options.kind === 'container' ? 'New group' : 'New template');
+  const escapeNav = options.group
+    ? containerHubNav(options.group.templateId, 'new', true)
+    : `<nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms">Browse</a><a class="configure-link" href="/forms/new?kind=container" aria-current="page">New group</a></nav>`;
+  const body = `${toolbarHtml(options.jumpMenu || '')}
   <main class="layout form-layout builder-layout">
-    <header class="topbar">${formBreadcrumbs(null, {leadLabel: 'New template'})}</header>
+    <header class="topbar">${formBreadcrumbs(null, {leadLabel: lead})}</header>
+    ${escapeNav}
     <section class="content form-card builder-card first-run-card">
       <p>Create a draft with one starter field. You can edit its fields immediately afterward.</p>
       ${builderErrors(options.errors)}
@@ -2335,13 +2341,15 @@ function createFormsRouter(options) {
       // #260: the root's New group action lands here preselected.
       // #279: arriving from a group page pre-joins the new tracker to it.
       let group = null;
+      let jumpMenu = '';
       if (typeof req.query.group === 'string' && isDefinitionId(req.query.group)) {
         const target = await registry.getTemplate(req.query.group);
         if (target && target.kind === 'container' && target.archived !== true) {
           group = {templateId: target.templateId, title: target.title};
+          jumpMenu = trackerJumpMenu(await listTemplatesThroughApi(req), target);
         }
       }
-      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : '', group});
+      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : '', group, jumpMenu});
     } catch (error) {
       next(error);
     }
@@ -2394,11 +2402,14 @@ function createFormsRouter(options) {
     } catch (error) {
       if (error && (error.code === 'EVALIDATION' || error.code === 'ECONFLICT')) {
         emitAudit(req, type, 'rejected_validation');
+        const errorGroup = postedString(req.body, 'group');
         sendCreateTemplate(res, issueContext(req, res), {
           errors: error.details || [{path: 'templateId', message: error.message}],
           templateId: postedString(req.body, 'templateId'),
           title: postedString(req.body, 'title'),
           destinationId: postedString(req.body, 'destinationId'),
+          kind: postedString(req.body, 'kind') === 'container' ? 'container' : '',
+          ...(errorGroup && isDefinitionId(errorGroup) ? {group: {templateId: errorGroup, title: errorGroup}} : {}),
         }, error.code === 'ECONFLICT' ? 409 : 422);
         return;
       }

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2193,10 +2193,17 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
     // group page carries the New tracker action, preset to the group
     const groupPage = await (await server.request('/forms/gym-fitness', {headers: {Cookie: context.cookie}})).text();
     assert.match(groupPage, /href="\/forms\/new\?group=gym-fitness"/);
-    // the create page shows the joining note
+    // the create page shows the joining note AND the group's bar persists (#281)
     const createPage = await (await server.request('/forms/new?group=gym-fitness', {headers: {Cookie: context.cookie}})).text();
     assert.match(createPage, /Joining group/);
     assert.match(createPage, /Gym &amp; Fitness!/);
+    assert.match(createPage, /href="\/forms\/gym-fitness\/entries"/);
+    assert.match(createPage, /group=gym-fitness" aria-current="page"/);
+    assert.match(createPage, /data-group-menu/);
+    // the root create page carries the Browse escape
+    const rootCreate = await (await server.request('/forms/new?kind=container', {headers: {Cookie: context.cookie}})).text();
+    assert.match(rootCreate, /href="\/forms">Browse</);
+    assert.match(rootCreate, /New group/);
   } finally {
     await cleanup(fixture, server);
   }


### PR DESCRIPTION
Closes #281. Operator: "should be able to get out of stuff... the navigation like trackers / history / configure should persist inside of stuff."

- `/forms/new?group=gym`: the group's sticky bar persists — Trackers | History | Configure | **New tracker (lit)** — plus the toolbar group dropdown. One tap back to anywhere.
- `/forms/new` / `?kind=container`: Browse (→ /forms) | New group (lit).
- Contextual headings (New tracker / New group / New template); POST error re-renders keep the bars.

**Test gates:** create-from-group page asserts the group's History link, the lit New-tracker tab, and the dropdown; root create asserts the Browse escape. Suite 201 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
