### PR TITLE
feat(forms): hierarchy lives in the bars — Groups and up tabs; dropdown retired

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -134,7 +134,10 @@ function formBreadcrumbs(template, options = {}) {
 function containerHubNav(templateId, active, canManage) {
   // #234 follow-up: a container is a form, so its pages carry the same hub tabs.
   const href = `/forms/${encodeURIComponent(templateId)}`;
+  // #285: hierarchy lives in the bars — a group's bar leads with Groups (the
+  // main page), a tracker's leads with its group. The toolbar dropdown retired.
   const links = [
+    ['groups', '/forms', 'Groups'],
     ['view', href, 'Trackers'],
     ['history', `${href}/entries`, 'History'],
     ...(canManage ? [
@@ -147,9 +150,15 @@ function containerHubNav(templateId, active, canManage) {
   ).join('')}</nav>`;
 }
 
-function formHubNav(templateId, active, canManage) {
+function formHubNav(templateId, active, canManage, group) {
   const formHref = `/forms/${encodeURIComponent(templateId)}`;
+  // #284: the way UP rides the sticky bar — the tracker's group, or the root
+  // for ungrouped trackers. Always on screen; no dead ends inside a tracker.
+  const up = group
+    ? ['up', `/forms/${encodeURIComponent(group.templateId)}`, `← ${escapeHtml(group.title)}`]
+    : ['up', '/forms', '← Trackers'];
   const links = [
+    up,
     ['log', formHref, 'Log an entry'],
     ['history', `${formHref}/entries`, 'History'],
     ...(canManage ? [['configure', `${formHref}/configure`, 'Configure']] : []),
@@ -381,7 +390,7 @@ function renderContainerPage(template, members, options = {}) {
       </details>`
     )).join('')
     : '<p class="container-empty">No trackers in this group yet. Add some from its Configure page.</p>';
-  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template, {memberCount: members.length})}`)}
+  const body = `${toolbarHtml(formProperties(template, {memberCount: members.length}))}
   <main class="layout form-layout container-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
@@ -488,12 +497,12 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   const submitLabel = editing
     ? 'Save correction'
     : configuredSubmitLabel || 'Submit';
-  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template)}`)}
+  const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
     </header>
-    ${formHubNav(template.templateId, 'log', options.canManage)}
+    ${formHubNav(template.templateId, 'log', options.canManage, options.relatedForms && options.relatedForms.container)}
 
     <section class="content form-card">
       ${template.description ? `<p class="form-description">${escapeHtml(template.description)}</p>` : ''}
@@ -529,30 +538,6 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
 // A form's facts, in the same shape documents use. Different values -- a form has
 // no size or mtime -- but the same question: what is actually true of this thing,
 // as opposed to what its title says.
-function trackerJumpMenu(templates, current, options = {}) {
-  // #275: groups stack in ONE dropdown, the theme-menu idiom — summary shows the
-  // current group, the list is groups only (no tracker tree), current lit by the
-  // shared [aria-current] menu styling. Touchscreen-size stacked rows. Creators
-  // get "+ New group" at the bottom. Replaces the #271 side-by-side buttons.
-  const list = Array.isArray(templates) ? templates.filter((t) => t.state !== 'archived') : [];
-  const groups = list.filter((t) => t.kind === 'container')
-    .sort((a, b) => String(a.title).localeCompare(String(b.title)));
-  if (!groups.length) return '';
-  const currentGroupId = current
-    ? (current.kind === 'container' ? current.templateId : current.containerId || null)
-    : null;
-  const currentGroup = groups.find((group) => group.templateId === currentGroupId);
-  // #277: "All trackers" leads — the way back to the main page from anywhere.
-  // New group left the menu (it lives on the root, where creation belongs).
-  const items = '<a role="menuitem" class="group-menu-root" href="/forms">All trackers</a>' + groups.map((group) =>
-    `<a role="menuitem" href="/forms/${encodeURIComponent(group.templateId)}"${group === currentGroup ? ' aria-current="page"' : ''}>${escapeHtml(group.title)}</a>`
-  ).join('');
-  return `<details class="doc-properties toolbar-menu" name="lookie-toolbar" data-group-menu>
-      <summary class="toolbar-btn" aria-label="Switch group">${escapeHtml(currentGroup ? currentGroup.title : 'Groups')}</summary>
-      <div class="toolbar-menu-list" role="menu">${items}</div>
-    </details>`;
-}
-
 function formProperties(record, extras = {}) {
   const template = (record && record.draft) || record;
   if (!template) return '';
@@ -622,7 +607,7 @@ function renderReceiptPage(template, record, options = {}) {
   const editHref = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}/edit`;
   const canEdit = options.canEdit !== false;
   const received = formatRecordTime(record, options.timezone).dateTimeLabel;
-  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template)}`)}
+  const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {leadLabel: template ? undefined : 'Form receipt', container: options.relatedForms && options.relatedForms.container})}
@@ -790,12 +775,12 @@ function renderEntriesPage(template, records, options = {}) {
   const content = records.length > 0
     ? entries
     : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">${template.kind === 'container' ? 'Open the trackers' : 'Log an entry'}</a></div>`;
-  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template)}`)}
+  const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout entries-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
     </header>
-    ${template.kind === 'container' ? containerHubNav(template.templateId, 'history', options.canManage) : formHubNav(template.templateId, 'history', options.canManage)}
+    ${template.kind === 'container' ? containerHubNav(template.templateId, 'history', options.canManage) : formHubNav(template.templateId, 'history', options.canManage, options.relatedForms && options.relatedForms.container)}
     <section class="content form-card entries-card">${content}</section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;
@@ -937,12 +922,12 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   const publishedText = published
     ? `Version ${published.templateVersion}, from draft revision ${published.sourceRevision}`
     : 'Not published yet';
-  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(record)}`)}
+  const body = `${toolbarHtml(formProperties(record))}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
     </header>
-    ${formHubNav(template.templateId, 'configure', true)}
+    ${formHubNav(template.templateId, 'configure', true, options.relatedForms && options.relatedForms.container)}
     <section class="content form-card builder-card">
       <dl class="builder-revisions">
         <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
@@ -1106,7 +1091,7 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
     )).join('')
     : '<p class="builder-help">No forms exist yet to add.</p>';
   const lifecycle = template.archived === true ? 'restore' : 'archive';
-  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(record, {memberCount: (options.memberChoices || []).filter((choice) => choice.checked).length})}`)}
+  const body = `${toolbarHtml(formProperties(record, {memberCount: (options.memberChoices || []).filter((choice) => choice.checked).length}))}
   <main class="layout form-layout builder-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}</div>
@@ -1210,7 +1195,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
   const escapeNav = options.group
     ? containerHubNav(options.group.templateId, 'new', true)
     : `<nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms">Browse</a><a class="configure-link" href="/forms/new?kind=container" aria-current="page">New group</a></nav>`;
-  const body = `${toolbarHtml(options.jumpMenu || '')}
+  const body = `${toolbarHtml()}
   <main class="layout form-layout builder-layout">
     <header class="topbar">${formBreadcrumbs(null, {leadLabel: lead})}</header>
     ${escapeNav}
@@ -1240,7 +1225,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
 }
 
 function renderArchivedFormPage(template, options = {}) {
-  const body = `${toolbarHtml(`${options.jumpMenu || ''}${formProperties(template)}`)}
+  const body = `${toolbarHtml(formProperties(template))}
   <main class="layout form-layout">
     <header class="topbar">${formBreadcrumbs(template)}</header>
     ${formHubNav(template.templateId, 'log', options.canManage)}
@@ -2261,13 +2246,6 @@ function createFormsRouter(options) {
     const cspNonce = crypto.randomBytes(18).toString('base64url');
     formHeaders(res, cspNonce);
     const all = await registry.listManagementTemplates();
-    const jumpMenu = trackerJumpMenu(all.map((candidate) => ({
-      templateId: candidate.draft.templateId,
-      title: candidate.draft.title,
-      kind: candidate.draft.kind === 'container' ? 'container' : 'form',
-      containerId: candidate.draft.containerId || null,
-      state: candidate.state,
-    })), record.draft);
     if (record.draft.kind === 'container') {
       const memberChoices = all
         .filter((candidate) => candidate.draft.kind !== 'container' && candidate.state !== 'archived')
@@ -2281,7 +2259,6 @@ function createFormsRouter(options) {
         customThemeCss,
         cspNonce,
         memberChoices,
-        jumpMenu,
         ...responseOptions,
       }));
       return;
@@ -2307,7 +2284,6 @@ function createFormsRouter(options) {
       parents,
       children,
       relatedForms: {container: await containerCrumbFor(record.draft), related: []},
-      jumpMenu,
       ...responseOptions,
     }));
   }
@@ -2341,15 +2317,13 @@ function createFormsRouter(options) {
       // #260: the root's New group action lands here preselected.
       // #279: arriving from a group page pre-joins the new tracker to it.
       let group = null;
-      let jumpMenu = '';
       if (typeof req.query.group === 'string' && isDefinitionId(req.query.group)) {
         const target = await registry.getTemplate(req.query.group);
         if (target && target.kind === 'container' && target.archived !== true) {
           group = {templateId: target.templateId, title: target.title};
-          jumpMenu = trackerJumpMenu(await listTemplatesThroughApi(req), target);
         }
       }
-      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : '', group, jumpMenu});
+      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : '', group});
     } catch (error) {
       next(error);
     }
@@ -2652,7 +2626,6 @@ function createFormsRouter(options) {
         res.status(200).type('html').send(renderContainerPage(template, members, {
           customThemeCss, cspNonce, canManage, recentTagged, csrfToken,
           timezone: serverTimezone, now: currentDate(),
-          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         }));
         return;
       }
@@ -2668,7 +2641,6 @@ function createFormsRouter(options) {
         timezone: serverTimezone,
         canManage,
         relatedForms: await relatedFormsFor(req, template),
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         now: currentDate(),
       }));
     } catch (error) {
@@ -2693,7 +2665,6 @@ function createFormsRouter(options) {
         emitAudit(req, 'form.submissions.list', 'accepted', template);
         res.status(200).type('html').send(renderEntriesPage(template, submissions, {
           customThemeCss, cspNonce, timezone: serverTimezone, canManage, csrfToken,
-          jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         }));
         return;
       }
@@ -2711,7 +2682,6 @@ function createFormsRouter(options) {
         canManage,
         csrfToken,
         relatedForms: {container: await containerCrumbFor(template), related: []},
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
       }));
     } catch (error) {
       next(error);
@@ -3087,7 +3057,6 @@ function createFormsRouter(options) {
         cspNonce,
         canEdit,
         relatedForms: await relatedFormsFor(req, template),
-        jumpMenu: trackerJumpMenu(await listTemplatesThroughApi(req), template),
         timezone: serverTimezone,
       }));
     } catch (error) {

--- a/public/style.css
+++ b/public/style.css
@@ -2821,9 +2821,6 @@ tbody tr:last-child td {
    element, translucent like the toolbar so content reads as sliding under it. */
 .form-layout > .form-hub-nav { position: sticky; top: calc(var(--toolbar-height, 3.1rem) + 0.5rem); z-index: 15; backdrop-filter: blur(6px); background: color-mix(in srgb, var(--bg-elev) 82%, transparent); margin: 0 0 1rem; }
 
-/* #275: groups stack in one theme-style dropdown; the shared [aria-current]
-   menu styling lights the current one. New-group row reads as an action. */
-.toolbar-menu[data-group-menu] .group-menu-root { border-bottom: 1px solid var(--border); margin-bottom: 0.2rem; padding-bottom: 0.5rem; }
 
 /* ============================================================================
    Document components

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -152,7 +152,7 @@ test('hub navigation and builder lifecycle preserve snapshots, option IDs, CAS, 
       const page = await browserPage(response);
       assert.deepEqual(
         [...page.document.querySelectorAll('.form-hub-nav a')].map((link) => link.textContent),
-        ['Log an entry', 'History', 'Configure'],
+        ['← Trackers', 'Log an entry', 'History', 'Configure'],
       );
     }
 

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2053,19 +2053,16 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     const containerPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
     assert.match(containerPage, /container-member-configure/);
-    // #275: groups stack in one theme-style dropdown, current lit; groups carry Properties
-    assert.match(containerPage, /data-group-menu/);
-    assert.match(containerPage, /href="\/forms\/gym" aria-current="page"/);
-    assert.match(containerPage, /group-menu-root" href="\/forms">All trackers</);
-    assert.doesNotMatch(containerPage, /group-menu-new/);
-    assert.doesNotMatch(containerPage, /tracker-jump-member/);
+    // #285: hierarchy lives in the bars — a group's bar leads with Groups; no dropdown
+    assert.match(containerPage, /groups-link" href="\/forms">Groups</);
+    assert.doesNotMatch(containerPage, /data-group-menu/);
     assert.match(containerPage, /toolbar-properties/);
     assert.match(containerPage, /<dt>Group<\/dt>|Group<\/dt>/);
     const exclusives = (containerPage.match(/name="lookie-toolbar"/g) || []).length;
     assert.ok(exclusives >= 3, `expected >=3 exclusive toolbar disclosures, got ${exclusives}`);
-    // the member form's dropdown lights its group too
+    // #284/#285: a tracker's bar leads with the way up to its group
     const memberToolbar = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
-    assert.match(memberToolbar, /href="\/forms\/gym" aria-current="page"/);
+    assert.match(memberToolbar, /up-link" href="\/forms\/gym">← Gym</);
     // #273: the ancestor path is gone — the heading is title-only; the toolbar navigates
     assert.match(containerPage, /<nav class="breadcrumbs"><h1 class="crumb-title">/);
     assert.doesNotMatch(containerPage, /breadcrumbs"><a href="\/forms">Trackers/);
@@ -2199,7 +2196,7 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
     assert.match(createPage, /Gym &amp; Fitness!/);
     assert.match(createPage, /href="\/forms\/gym-fitness\/entries"/);
     assert.match(createPage, /group=gym-fitness" aria-current="page"/);
-    assert.match(createPage, /data-group-menu/);
+    assert.match(createPage, /groups-link" href="\/forms">Groups</);
     // the root create page carries the Browse escape
     const rootCreate = await (await server.request('/forms/new?kind=container', {headers: {Cookie: context.cookie}})).text();
     assert.match(rootCreate, /href="\/forms">Browse</);


### PR DESCRIPTION
Closes #284. Closes #285.

- **Tracker bars lead with the way up** (#284): ← Gym | Log an entry | History | Configure (← Trackers when ungrouped) — on the tracker, its History, and its Configure. Always on screen.
- **Group bars lead with Groups** (#285) → the main page: Groups | Trackers | History | Configure | New tracker. Create pages inherit their bar (#281 doctrine).
- **The toolbar group dropdown is retired** (operator retraction of #275/#277, same evening). Group Properties (#271) and disclosure exclusivity (#263/#270) survive.

**Test gates:** member bar asserts ← Gym; group bar asserts Groups; dropdown absence asserted; tab-list expectations updated. Suite 201 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
