### PR TITLE
feat(forms): drop Browse from the root bar; create-page escape says Groups

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -1171,7 +1171,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     <header class="topbar forms-index-header">
       <div><h1>Trackers</h1><p class="subtitle">${managed ? 'Tap a group to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
-    <nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms" aria-current="page">Browse</a>${canCreate ? '<a class="configure-link" href="/forms/new?kind=container">New group</a>' : ''}</nav>
+    ${canCreate ? '<nav class="form-hub-nav" aria-label="Tracker views"><a class="configure-link" href="/forms/new?kind=container">New group</a></nav>' : ''}
     <section class="content form-card container-card">
       <div class="container-members">${rows || emptyState}</div>
     </section>
@@ -1194,7 +1194,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
   const lead = options.group ? 'New tracker' : (options.kind === 'container' ? 'New group' : 'New template');
   const escapeNav = options.group
     ? containerHubNav(options.group.templateId, 'new', true)
-    : `<nav class="form-hub-nav" aria-label="Tracker views"><a class="view-link" href="/forms">Browse</a><a class="configure-link" href="/forms/new?kind=container" aria-current="page">New group</a></nav>`;
+    : `<nav class="form-hub-nav" aria-label="Tracker views"><a class="groups-link" href="/forms">Groups</a><a class="configure-link" href="/forms/new?kind=container" aria-current="page">New group</a></nav>`;
   const body = `${toolbarHtml()}
   <main class="layout form-layout builder-layout">
     <header class="topbar">${formBreadcrumbs(null, {leadLabel: lead})}</header>

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2199,7 +2199,7 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
     assert.match(createPage, /groups-link" href="\/forms">Groups</);
     // the root create page carries the Browse escape
     const rootCreate = await (await server.request('/forms/new?kind=container', {headers: {Cookie: context.cookie}})).text();
-    assert.match(rootCreate, /href="\/forms">Browse</);
+    assert.match(rootCreate, /groups-link" href="\/forms">Groups</);
     assert.match(rootCreate, /New group/);
   } finally {
     await cleanup(fixture, server);


### PR DESCRIPTION
Closes #287. Operator: "the trackers page, browse is totally unnecessary...."

- Root bar: **New group** only (Browse linked to the page it sat on; submit-only viewers get no bar at all).
- Root create page's escape tab renamed **Groups** — the same parent label the group bars use.

**Test gates:** rootCreate asserts the Groups escape. Suite 201 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
