### PR TITLE
feat(forms): theme consistency, Groups root, lifecycle to Configure

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -568,11 +568,26 @@ function formProperties(record, extras = {}) {
 
 function themeDefaults(template) {
   const presentation = template && template.presentation;
-  if (!presentation) return {};
   const out = {};
-  if (typeof presentation.theme === 'string') out.scheme = presentation.theme;
-  if (presentation.themeMode === 'dark' || presentation.themeMode === 'light') out.mode = presentation.themeMode;
+  if (presentation) {
+    if (typeof presentation.theme === 'string') out.scheme = presentation.theme;
+    if (presentation.themeMode === 'dark' || presentation.themeMode === 'light') out.mode = presentation.themeMode;
+  }
+  // #289: view routes attach the group's theme — a themeless tracker renders in
+  // its group's look instead of the viewer default. Configure never attaches it,
+  // so the builder keeps reporting only what is actually saved.
+  if (template && template.__groupTheme) {
+    if (!out.scheme && template.__groupTheme.scheme) out.scheme = template.__groupTheme.scheme;
+    if (!out.mode && template.__groupTheme.mode) out.mode = template.__groupTheme.mode;
+  }
   return out;
+}
+
+function withGroupTheme(template, container) {
+  if (!template || !container) return template;
+  const group = themeDefaults(container);
+  if (!group.scheme && !group.mode) return template;
+  return {...template, __groupTheme: group};
 }
 
 function displayValue(entry, timeZone) {
@@ -896,6 +911,23 @@ function builderField(field, fieldIndex, fieldCount) {
   </details>`;
 }
 
+function configureLifecycle(template, csrfToken) {
+  // #291: lifecycle lives with Configure — Clone and Archive moved here when
+  // the root Manage section retired.
+  const templateId = encodeURIComponent(template.templateId);
+  return `<div class="configure-lifecycle" aria-label="Lifecycle">
+    <form method="post" action="/forms/${templateId}/clone">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <button type="submit">Clone</button>
+    </form>
+    <form method="post" action="/forms/${templateId}/archive">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+      <button type="submit">Archive</button>
+    </form>
+  </div>`;
+}
+
 function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   const template = record.draft;
   const configureHref = `/forms/${encodeURIComponent(template.templateId)}/configure`;
@@ -964,6 +996,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
           <button class="button-link builder-publish-action" type="submit">Publish saved draft</button>
         </form>
+        ${configureLifecycle(template, csrfToken)}
       </section>
     </section>
   </main>
@@ -1163,13 +1196,16 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     )),
   ].join('');
   const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first group' : 'No trackers available'}</h2><p>${canCreate ? 'Groups hold your trackers — make one, then add trackers inside it.' : 'There are no active trackers you can log to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new?kind=container">New group</a>' : ''}</div>`;
-  const manageHtml = managed
-    ? `<details class="forms-index-manage"><summary>Manage templates <span>${active.filter((template) => template.management).length}</span></summary><div class="forms-index-list">${active.filter((template) => template.management).map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div>${archived.length ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>` : ''}</details>`
+  // #291: the Manage section (and with it the #257 root quick-configure surface)
+  // is retired — lifecycle actions live on each Configure page now. Archived
+  // stays reachable here, collapsed.
+  const manageHtml = managed && archived.length
+    ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>`
     : '';
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout forms-index-layout">
     <header class="topbar forms-index-header">
-      <div><h1>Trackers</h1><p class="subtitle">${managed ? 'Tap a group to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
+      <div><h1>Groups</h1><p class="subtitle">${managed ? 'Tap a group to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
     ${canCreate ? '<nav class="form-hub-nav" aria-label="Tracker views"><a class="configure-link" href="/forms/new?kind=container">New group</a></nav>' : ''}
     <section class="content form-card container-card">
@@ -1179,7 +1215,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   </main>
   ${themeScript(options.cspNonce)}`;
   return baseHtml({
-    title: 'Trackers',
+    title: 'Groups',
     body,
     customThemeCss: options.customThemeCss,
     cspNonce: options.cspNonce,
@@ -1215,12 +1251,15 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
       </form>
     </section>
   </main>
-  ${themeScript(options.cspNonce)}`;
+  ${themeScript(options.cspNonce, (options.group && options.group.theme) || {})}`;
+  const groupTheme = (options.group && options.group.theme) || {};
   return baseHtml({
-    title: 'New form template',
+    title: lead,
     body,
     customThemeCss: options.customThemeCss,
     cspNonce: options.cspNonce,
+    defaultScheme: groupTheme.scheme || null,
+    defaultMode: groupTheme.mode || null,
   });
 }
 
@@ -2237,8 +2276,9 @@ function createFormsRouter(options) {
   async function containerCrumbFor(template) {
     if (!template || !template.containerId) return null;
     const container = await registry.getTemplate(template.containerId);
+    // #289: full template — the theme fallback needs presentation, not just the name.
     return container && container.kind === 'container' && container.archived !== true
-      ? {templateId: container.templateId, title: container.title}
+      ? container
       : null;
   }
 
@@ -2320,7 +2360,7 @@ function createFormsRouter(options) {
       if (typeof req.query.group === 'string' && isDefinitionId(req.query.group)) {
         const target = await registry.getTemplate(req.query.group);
         if (target && target.kind === 'container' && target.archived !== true) {
-          group = {templateId: target.templateId, title: target.title};
+          group = {templateId: target.templateId, title: target.title, theme: themeDefaults(target)};
         }
       }
       sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : '', group});
@@ -2634,13 +2674,14 @@ function createFormsRouter(options) {
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.render', 'accepted', template);
-      res.status(200).type('html').send(renderFormPage(template, csrfToken, {}, [], {
+      const relatedForms = await relatedFormsFor(req, template);
+      res.status(200).type('html').send(renderFormPage(withGroupTheme(template, relatedForms.container), csrfToken, {}, [], {
         customThemeCss,
         cspNonce,
         recentRecords,
         timezone: serverTimezone,
         canManage,
-        relatedForms: await relatedFormsFor(req, template),
+        relatedForms,
         now: currentDate(),
       }));
     } catch (error) {
@@ -2675,13 +2716,14 @@ function createFormsRouter(options) {
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.submissions.list', 'accepted', template);
-      res.status(200).type('html').send(renderEntriesPage(template, submissions, {
+      const relatedForms = {container: await containerCrumbFor(template), related: []};
+      res.status(200).type('html').send(renderEntriesPage(withGroupTheme(template, relatedForms.container), submissions, {
         customThemeCss,
         cspNonce,
         timezone: serverTimezone,
         canManage,
         csrfToken,
-        relatedForms: {container: await containerCrumbFor(template), related: []},
+        relatedForms,
       }));
     } catch (error) {
       next(error);
@@ -3052,11 +3094,12 @@ function createFormsRouter(options) {
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.receipt.read', 'accepted', record);
-      res.status(200).type('html').send(renderReceiptPage(template, record, {
+      const receiptRelated = await relatedFormsFor(req, template);
+      res.status(200).type('html').send(renderReceiptPage(withGroupTheme(template, receiptRelated.container), record, {
         customThemeCss,
         cspNonce,
         canEdit,
-        relatedForms: await relatedFormsFor(req, template),
+        relatedForms: receiptRelated,
         timezone: serverTimezone,
       }));
     } catch (error) {

--- a/public/style.css
+++ b/public/style.css
@@ -2822,6 +2822,18 @@ tbody tr:last-child td {
 .form-layout > .form-hub-nav { position: sticky; top: calc(var(--toolbar-height, 3.1rem) + 0.5rem); z-index: 15; backdrop-filter: blur(6px); background: color-mix(in srgb, var(--bg-elev) 82%, transparent); margin: 0 0 1rem; }
 
 
+/* #289: forms pages keep the platform heading face under every theme (themes
+   reset --heading-font for document pages; the trackers world stays uniform).
+   #290: the root's New group tab takes the primary-action emphasis, in-spec. */
+.form-layout { --heading-font: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif; }
+.forms-index-layout .form-hub-nav .configure-link { background: var(--accent); color: var(--bg); }
+
+/* #291: member name owns the row (thumb-size quick-entry); chevron zone toggles.
+   Lifecycle actions on Configure. */
+.form-layout .container-member-row > .container-member .container-member-title { flex: 1; padding: 0.9rem 0; margin: -0.9rem 0; }
+.form-layout .container-member-row > .container-member span[aria-hidden] { padding: 0.9rem 0 0.9rem 1.4rem; margin: -0.9rem 0; }
+.form-layout .configure-lifecycle { display: flex; gap: 0.8rem; margin-top: 0.9rem; padding-top: 0.9rem; border-top: 1px solid var(--border); }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -420,24 +420,15 @@ test('forms index separates archived templates and removes management detail for
     assert.equal(submitted.status, 303);
 
     const managerIndex = await browserPage(await server.request('/forms'));
-    // #260: the browse view is tap-in rows; managed cards sit in the Manage section
+    // #291: tap-in rows only — the Manage section is retired; archived stays collapsed
     assert.equal(managerIndex.document.querySelectorAll('.container-members .forms-root-row').length, 2);
-    const manageCards = managerIndex.document.querySelectorAll('.forms-index-manage .forms-index-item');
-    const archivedCards = managerIndex.document.querySelectorAll('.forms-index-archived .forms-index-item');
-    assert.equal(manageCards.length - archivedCards.length, 2);
+    assert.equal(managerIndex.document.querySelector('.forms-index-manage'), null);
     assert.equal(managerIndex.document.querySelector('a[href="/forms/new"]'), null);
     assert.ok(managerIndex.document.querySelector('a[href="/forms/new?kind=container"]'));
-    assert.ok(managerIndex.document.querySelector('a[href="/forms/new?kind=container"]'));
-    const trainingCard = [...managerIndex.document.querySelectorAll('.forms-index-item')]
-      .find((card) => /Training <log>/.test(card.querySelector('.forms-index-title h2').textContent));
-    assert.ok(trainingCard);
-    assert.match(trainingCard.textContent, /Draft\s*r1/);
-    assert.match(trainingCard.textContent, /Destination\s*gym-log/);
-    assert.match(trainingCard.textContent, /Entries\s*1/);
-    assert.deepEqual(
-      [...trainingCard.querySelectorAll('.forms-index-actions a, .forms-index-actions button')].map((node) => node.textContent.trim()),
-      ['Open', 'History', 'Configure', 'Clone', 'Archive'],
-    );
+    // lifecycle moved to Configure (#291): Clone + Archive live there now
+    const configureLifecycle = await browserPage(await server.request('/forms/training-log/configure'));
+    const lifecycleButtons = [...configureLifecycle.document.querySelectorAll('.configure-lifecycle button')].map((node) => node.textContent.trim());
+    assert.deepEqual(lifecycleButtons, ['Clone', 'Archive']);
     const archived = managerIndex.document.querySelector('.forms-index-archived');
     assert.ok(archived);
     assert.equal(archived.open, false);
@@ -455,8 +446,8 @@ test('forms index separates archived templates and removes management detail for
     );
     assert.doesNotMatch(submitOnly.document.body.textContent, /Old log|Entries|Destination|Configure|Archive/);
 
-    const cloneForm = trainingCard.querySelector('form[action$="/clone"]');
-    const clonedResponse = await browserPost(server, cloneForm.getAttribute('action'), formValues(cloneForm), managerIndex.cookie);
+    const cloneForm = configureLifecycle.document.querySelector('.configure-lifecycle form[action$="/clone"]');
+    const clonedResponse = await browserPost(server, cloneForm.getAttribute('action'), formValues(cloneForm), configureLifecycle.cookie);
     assert.equal(clonedResponse.status, 303);
     assert.match(clonedResponse.headers.get('location'), /^\/forms\/training-log-copy\/configure$/);
     assert.equal((await server.registry.getTemplate('training-log-copy')).revision, 1);
@@ -655,14 +646,11 @@ test('root quick-configure: inline basics + membership, publishes in one tap (#2
       ownerId: 'operator', revision: 1, grammarVersion: 1, title: 'Fitness', kind: 'container',
     });
 
-    // the root carries quick-configure sections with the basics controls
+    // #291: the root quick-configure surface is retired — the basics endpoint
+    // remains (this test drives it directly), and the root shows no manage UI
     const root = await browserPage(await server.request('/forms'));
-    const quick = root.document.querySelectorAll('.quick-configure');
-    assert.ok(quick.length >= 3, `expected quick-configure per managed card, got ${quick.length}`);
-    assert.ok(root.document.querySelector('.quick-configure-form input[name="title"]'));
-    assert.ok(root.document.querySelector('.quick-configure-form select[name="container"]'));
-    assert.ok(root.document.querySelector('.quick-configure-form select[name="parent"]'));
-    assert.ok(root.document.querySelector('.quick-configure-members input[name="member"]'));
+    assert.equal(root.document.querySelector('.quick-configure'), null);
+    assert.equal(root.document.querySelector('.forms-index-manage'), null);
 
     // #251 regression: a FULL configure save with the parent select present must not 400
     const configure = await browserPage(await server.request('/forms/training-log/configure'));
@@ -672,14 +660,15 @@ test('root quick-configure: inline basics + membership, publishes in one tap (#2
     assert.equal(fullSave.status, 200);
 
     // basics save on a form: title + container membership, published, back to the root
-    // (refetched — the full save above bumped the draft revision)
-    const rootFresh = await browserPage(await server.request('/forms'));
-    const trainingForm = [...rootFresh.document.querySelectorAll('.quick-configure-form')]
-      .find((form) => form.action.includes('/forms/training-log/'));
-    const values = formValues(trainingForm, 'basics');
-    values.set('title', 'Training log (renamed)');
-    values.set('container', 'fitness');
-    const saved = await browserPost(server, '/forms/training-log/configure', values, rootFresh.cookie);
+    // (driven directly against the basics endpoint — its GUI surface retired in #291)
+    const fresh = await browserPage(await server.request('/forms/training-log/configure'));
+    const freshToken = formValues(fresh.document.querySelector('.builder-form')).get('_csrf');
+    const trainingRev = (await server.registry.getManagementTemplate('training-log')).draft.revision;
+    const values = new URLSearchParams({
+      _csrf: freshToken, _action: 'basics', revision: String(trainingRev),
+      title: 'Training log (renamed)', theme: '', themeMode: '', container: 'fitness', parent: '',
+    });
+    const saved = await browserPost(server, '/forms/training-log/configure', values, fresh.cookie);
     assert.equal(saved.status, 303);
     assert.equal(saved.headers.get('location'), '/forms');
     const record = await server.registry.getManagementTemplate('training-log');
@@ -688,14 +677,16 @@ test('root quick-configure: inline basics + membership, publishes in one tap (#2
     assert.equal(record.state, 'published');
     assert.deepEqual(record.draft.fields.map((field) => field.id), ['lift', 'notes'], 'basics save must not touch fields');
 
-    // container basics: member checkboxes drive membership diffs, then 303 to the root
-    const root2 = await browserPage(await server.request('/forms'));
-    const containerForm = [...root2.document.querySelectorAll('.quick-configure-form')]
-      .find((form) => form.action.includes('/forms/fitness/'));
-    const containerValues = formValues(containerForm, 'basics');
-    containerValues.delete('member');
+    // container basics: membership diffs via the basics action, then 303 to the root
+    const fresh2 = await browserPage(await server.request('/forms/fitness/configure'));
+    const fresh2Token = (fresh2.html.match(/name="_csrf" value="([^"]+)"/) || [])[1];
+    const fitnessRev = (await server.registry.getManagementTemplate('fitness')).draft.revision;
+    const containerValues = new URLSearchParams({
+      _csrf: fresh2Token, _action: 'basics', revision: String(fitnessRev),
+      title: 'Fitness', theme: '', themeMode: '',
+    });
     containerValues.append('member', 'cardio-log');
-    const containerSaved = await browserPost(server, '/forms/fitness/configure', containerValues, root2.cookie);
+    const containerSaved = await browserPost(server, '/forms/fitness/configure', containerValues, fresh2.cookie);
     assert.equal(containerSaved.status, 303);
     const cardio = await server.registry.getManagementTemplate('cardio-log');
     assert.equal(cardio.draft.containerId, 'fitness');


### PR DESCRIPTION
Closes #289. Closes #290. Closes #291.

**#289 (Playwright-audited theme consistency):** forms pages keep Space Grotesk headings under every theme; `/forms/new?group=` carries the group theme; themeless trackers render in their group's theme on view surfaces (Configure stays honest — never displays inherited theme as saved).
**#290:** New group takes the existing primary-action accent style.
**#291:** root says **Groups**; Manage section retired (resolves #257's pending verdict: quick-configure surface killed, basics endpoint remains); archived stays collapsed; **Clone/Archive move to Configure pages**; member-row names own the row (thumb-size quick-entry hit area — precise clicks worked in both engines, thumbs didn't).

**Test gates:** test 4 and the #257 test rewritten to the new surfaces (lifecycle on Configure, basics endpoint driven directly with fresh CSRF pairs). Suite 201 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
