### PR TITLE
feat(forms): archived lives with its group; bar grammar; tinted NEW; no group-page recents

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -136,14 +136,14 @@ function containerHubNav(templateId, active, canManage) {
   const href = `/forms/${encodeURIComponent(templateId)}`;
   // #285: hierarchy lives in the bars — a group's bar leads with Groups (the
   // main page), a tracker's leads with its group. The toolbar dropdown retired.
+  // #293: same grammar as the tracker bar — up | main | do | history | admin;
+  // the action sits next to what it acts on, admin stays last.
   const links = [
     ['groups', '/forms', 'Groups'],
     ['view', href, 'Trackers'],
+    ...(canManage ? [['new', `/forms/new?group=${encodeURIComponent(templateId)}`, 'New tracker']] : []),
     ['history', `${href}/entries`, 'History'],
-    ...(canManage ? [
-      ['configure', `${href}/configure`, 'Configure'],
-      ['new', `/forms/new?group=${encodeURIComponent(templateId)}`, 'New tracker'],
-    ] : []),
+    ...(canManage ? [['configure', `${href}/configure`, 'Configure']] : []),
   ];
   return `<nav class="form-hub-nav" aria-label="Group views">${links.map(([key, linkHref, label]) =>
     `<a class="${key}-link" href="${linkHref}"${key === active ? ' aria-current="page"' : ''}>${label}</a>`
@@ -358,20 +358,16 @@ function renderFormPreview(member) {
   return `<fieldset disabled class="container-form-preview" aria-label="Preview of ${escapeHtml(member.title)}">${rows}</fieldset>`;
 }
 
-function renderContainerRecent(template, tagged, options = {}) {
-  // #248: a container's dashboard is the aggregate of its members' entries —
-  // the same recent-entries idiom normal forms use, rows chipped by member form.
-  const entriesHref = `/forms/${encodeURIComponent(template.templateId)}/entries`;
-  const content = tagged.length
-    ? `<div class="entry-list">${tagged.map(({ member, record }) =>
-      renderEntryRow(member, record, options.timezone, options.csrfToken, { now: options.now, memberTitle: member.title })).join('')}</div>`
-    : '<p class="recent-entries-empty">Entries from the forms above will appear here.</p>';
-  return `<aside class="recent-entries" aria-labelledby="recent-entries-heading">
-        <div class="recent-entries-heading">
-          <h2 id="recent-entries-heading">Recent entries</h2>
-          <a href="${entriesHref}">View all</a>
-        </div>
-        ${content}</aside>`;
+function renderArchivedMembers(archived, csrfToken) {
+  // #293: a group's archived trackers live WITH the group, restorable in place.
+  if (!archived.length) return '';
+  const rows = archived.map((member) => `<div class="archived-member-row"><span>${escapeHtml(member.title)}</span>
+    <form method="post" action="/forms/${encodeURIComponent(member.templateId)}/restore">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <input type="hidden" name="revision" value="${escapeHtml(member.revision)}">
+      <button type="submit">Restore</button>
+    </form></div>`).join('');
+  return `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="archived-member-list">${rows}</div></details>`;
 }
 
 function renderContainerPage(template, members, options = {}) {
@@ -398,7 +394,7 @@ function renderContainerPage(template, members, options = {}) {
     ${containerHubNav(template.templateId, 'view', options.canManage)}
     <section class="content form-card container-card">
       <div class="container-members">${cards}</div>
-      ${renderContainerRecent(template, options.recentTagged || [], options)}
+      ${renderArchivedMembers(options.archivedMembers || [], options.csrfToken)}
     </section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;
@@ -1199,8 +1195,10 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   // #291: the Manage section (and with it the #257 root quick-configure surface)
   // is retired — lifecycle actions live on each Configure page now. Archived
   // stays reachable here, collapsed.
-  const manageHtml = managed && archived.length
-    ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>`
+  const rootArchived = archived.filter((template) => template.kind === 'container'
+    || !(template.containerId && containerIds.has(template.containerId)));
+  const manageHtml = managed && rootArchived.length
+    ? `<details class="forms-index-archived"><summary>Show archived <span>${rootArchived.length}</span></summary><div class="forms-index-list">${rootArchived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>`
     : '';
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout forms-index-layout">
@@ -2658,13 +2656,19 @@ function createFormsRouter(options) {
       }
       if (template.kind === 'container') {
         const members = await containerMembersFor(req, template);
-        const recentTagged = await containerTaggedEntries(req, members, CONTAINER_RECENT_LIMIT);
+        // #293: no recent-entries aside here — the History tab owns it. Managers
+        // see the group's archived trackers, restorable in place.
+        const archivedMembers = canManage
+          ? (await registry.listManagementTemplates())
+            .filter((record) => record.draft.containerId === template.templateId && record.state === 'archived')
+            .map((record) => ({templateId: record.draft.templateId, title: record.draft.title, revision: record.draft.revision}))
+          : [];
         const csrfToken = issueContext(req, res);
         const cspNonce = crypto.randomBytes(18).toString('base64url');
         formHeaders(res, cspNonce);
         emitAudit(req, 'form.render', 'accepted', template);
         res.status(200).type('html').send(renderContainerPage(template, members, {
-          customThemeCss, cspNonce, canManage, recentTagged, csrfToken,
+          customThemeCss, cspNonce, canManage, archivedMembers, csrfToken,
           timezone: serverTimezone, now: currentDate(),
         }));
         return;

--- a/public/style.css
+++ b/public/style.css
@@ -2826,13 +2826,20 @@ tbody tr:last-child td {
    reset --heading-font for document pages; the trackers world stays uniform).
    #290: the root's New group tab takes the primary-action emphasis, in-spec. */
 .form-layout { --heading-font: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif; }
-.forms-index-layout .form-hub-nav .configure-link { background: var(--accent); color: var(--bg); }
+.forms-index-layout .form-hub-nav .configure-link,
+.form-layout .form-hub-nav .new-link { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); box-shadow: inset 0 0 0 1px var(--accent); border-radius: 8px; }
 
 /* #291: member name owns the row (thumb-size quick-entry); chevron zone toggles.
    Lifecycle actions on Configure. */
 .form-layout .container-member-row > .container-member .container-member-title { flex: 1; padding: 0.9rem 0; margin: -0.9rem 0; }
 .form-layout .container-member-row > .container-member span[aria-hidden] { padding: 0.9rem 0 0.9rem 1.4rem; margin: -0.9rem 0; }
 .form-layout .configure-lifecycle { display: flex; gap: 0.8rem; margin-top: 0.9rem; padding-top: 0.9rem; border-top: 1px solid var(--border); }
+
+/* #293: a group's archived trackers, restorable in place. */
+.form-layout .archived-member-list { display: grid; gap: 0.5rem; padding-top: 0.6rem; }
+.form-layout .archived-member-row { display: flex; align-items: center; justify-content: space-between; gap: 0.8rem; color: var(--text-soft); }
+.form-layout .container-card .forms-index-archived { margin-top: 1.1rem; }
+.form-layout .container-card .forms-index-archived > summary { cursor: pointer; color: var(--text-soft); font-size: 0.9rem; }
 
 /* ============================================================================
    Document components

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2031,9 +2031,9 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
       body: nativeBody(context.token),
     });
     assert.ok(logged.status === 200 || logged.status === 303, `submit status ${logged.status}`);
+    // #293: the group page carries no recent-entries aside — History owns it
     const dashboard = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
-    assert.match(dashboard, /recent-entries/);
-    assert.match(dashboard, /entry-form-chip">Gym Session Entry</);
+    assert.doesNotMatch(dashboard, /recent-entries/);
     const history = await server.request('/forms/gym/entries', {headers: {Cookie: context.cookie}});
     assert.equal(history.status, 200);
     const historyPage = await history.text();
@@ -2197,6 +2197,20 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
     assert.match(createPage, /href="\/forms\/gym-fitness\/entries"/);
     assert.match(createPage, /group=gym-fitness" aria-current="page"/);
     assert.match(createPage, /groups-link" href="\/forms">Groups</);
+    // #293: archive a group member — it lists on the GROUP page, not the root
+    const rowing2 = JSON.parse(await (await server.request('/api/forms/templates/rowing-2')).text()).template;
+    const archivedResp = await server.request('/api/forms/templates/rowing-2/archive', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token },
+      body: JSON.stringify({revision: rowing2.revision}),
+    });
+    assert.equal(archivedResp.status, 200);
+    const groupWithArchived = await (await server.request('/forms/gym-fitness', {headers: {Cookie: context.cookie}})).text();
+    assert.match(groupWithArchived, /archived-member-row/);
+    assert.match(groupWithArchived, /rowing-2\/restore/);
+    const rootAfterArchive = await (await server.request('/forms', {headers: {Cookie: context.cookie}})).text();
+    assert.doesNotMatch(rootAfterArchive, /rowing-2/);
+
     // the root create page carries the Browse escape
     const rootCreate = await (await server.request('/forms/new?kind=container', {headers: {Cookie: context.cookie}})).text();
     assert.match(rootCreate, /groups-link" href="\/forms">Groups</);


### PR DESCRIPTION
Closes #293. Four operator calls (one batch):

- **Archived lives with its group**: group pages get collapsed Show archived + in-place Restore (managers); the root's archived narrows to archived groups + ungrouped strays.
- **Bar grammar**: group bar = Groups | Trackers | **New tracker** | History | Configure — same up | main | do | history | admin grammar as the tracker bar; the action sits next to what it acts on, admin last.
- **Tinted NEW buttons**: accent-on-accent-tint with an inset ring — in-theme, distinct from both plain tabs and the solid current-tab marker.
- **No recent-entries on the group page** (operator: "we already have a history button there") — the /entries History keeps the aggregate; tracker pages keep their recent/baseline panels.

Also confirmed already-shipped: root has New group, group pages have New tracker (both since #280).

**Test gates:** archived-member flow (archive → appears on group page with Restore, absent from root), no-recents assert, order-insensitive nav asserts unchanged. Suite 201 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
