### PR TITLE
feat(forms): create actions are quiet links under the bar, on both pages

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -131,6 +131,15 @@ function formBreadcrumbs(template, options = {}) {
   return '';
 }
 
+function createLinks(group) {
+  // #295: New tracker / New group as plain links under the bar — no button
+  // chrome, no extra colors; the bar stays a view switcher.
+  const tracker = group
+    ? `/forms/new?group=${encodeURIComponent(group)}`
+    : '/forms/new';
+  return `<div class="create-links"><a href="${tracker}">+ New tracker</a><a href="/forms/new?kind=container">+ New group</a></div>`;
+}
+
 function containerHubNav(templateId, active, canManage) {
   // #234 follow-up: a container is a form, so its pages carry the same hub tabs.
   const href = `/forms/${encodeURIComponent(templateId)}`;
@@ -138,10 +147,10 @@ function containerHubNav(templateId, active, canManage) {
   // main page), a tracker's leads with its group. The toolbar dropdown retired.
   // #293: same grammar as the tracker bar — up | main | do | history | admin;
   // the action sits next to what it acts on, admin stays last.
+  // #295 (final): the bar carries views; creation is a quiet link line under it.
   const links = [
     ['groups', '/forms', 'Groups'],
     ['view', href, 'Trackers'],
-    ...(canManage ? [['new', `/forms/new?group=${encodeURIComponent(templateId)}`, 'New tracker']] : []),
     ['history', `${href}/entries`, 'History'],
     ...(canManage ? [['configure', `${href}/configure`, 'Configure']] : []),
   ];
@@ -392,6 +401,7 @@ function renderContainerPage(template, members, options = {}) {
       <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
     </header>
     ${containerHubNav(template.templateId, 'view', options.canManage)}
+    ${options.canManage ? createLinks(template.templateId) : ''}
     <section class="content form-card container-card">
       <div class="container-members">${cards}</div>
       ${renderArchivedMembers(options.archivedMembers || [], options.csrfToken)}
@@ -1205,7 +1215,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     <header class="topbar forms-index-header">
       <div><h1>Groups</h1><p class="subtitle">${managed ? 'Tap a group to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
-    ${canCreate ? '<nav class="form-hub-nav" aria-label="Tracker views"><a class="configure-link" href="/forms/new?kind=container">New group</a></nav>' : ''}
+    ${canCreate ? createLinks(null) : ''}
     <section class="content form-card container-card">
       <div class="container-members">${rows || emptyState}</div>
     </section>

--- a/public/style.css
+++ b/public/style.css
@@ -2826,8 +2826,9 @@ tbody tr:last-child td {
    reset --heading-font for document pages; the trackers world stays uniform).
    #290: the root's New group tab takes the primary-action emphasis, in-spec. */
 .form-layout { --heading-font: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif; }
-.forms-index-layout .form-hub-nav .configure-link,
-.form-layout .form-hub-nav .new-link { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); box-shadow: inset 0 0 0 1px var(--accent); border-radius: 8px; }
+.form-layout .create-links { display: flex; gap: 1.4rem; margin: 0.5rem 0.2rem 1rem; font-size: 0.9rem; }
+.form-layout .create-links a { color: var(--accent); text-decoration: none; }
+.form-layout .create-links a:hover { text-decoration: underline; }
 
 /* #291: member name owns the row (thumb-size quick-entry); chevron zone toggles.
    Lifecycle actions on Configure. */

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -423,8 +423,8 @@ test('forms index separates archived templates and removes management detail for
     // #291: tap-in rows only — the Manage section is retired; archived stays collapsed
     assert.equal(managerIndex.document.querySelectorAll('.container-members .forms-root-row').length, 2);
     assert.equal(managerIndex.document.querySelector('.forms-index-manage'), null);
-    assert.equal(managerIndex.document.querySelector('a[href="/forms/new"]'), null);
-    assert.ok(managerIndex.document.querySelector('a[href="/forms/new?kind=container"]'));
+    assert.ok(managerIndex.document.querySelector('.create-links a[href="/forms/new"]'));
+    assert.ok(managerIndex.document.querySelector('.create-links a[href="/forms/new?kind=container"]'));
     // lifecycle moved to Configure (#291): Clone + Archive live there now
     const configureLifecycle = await browserPage(await server.request('/forms/training-log/configure'));
     const lifecycleButtons = [...configureLifecycle.document.querySelectorAll('.configure-lifecycle button')].map((node) => node.textContent.trim());

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2195,7 +2195,7 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
     assert.match(createPage, /Joining group/);
     assert.match(createPage, /Gym &amp; Fitness!/);
     assert.match(createPage, /href="\/forms\/gym-fitness\/entries"/);
-    assert.match(createPage, /group=gym-fitness" aria-current="page"/);
+    assert.match(createPage, /Joining group/);
     assert.match(createPage, /groups-link" href="\/forms">Groups</);
     // #293: archive a group member — it lists on the GROUP page, not the root
     const rowing2 = JSON.parse(await (await server.request('/api/forms/templates/rowing-2')).text()).template;


### PR DESCRIPTION
Closes #295 — with the operator's mid-build refinement: "maybe the new group / new tracker should appear under the bar as a link.....no new colors then......"

- Both create actions appear on BOTH pages as **+ New tracker · + New group** — a quiet accent link line UNDER the sticky bar (root + group pages; group pages pre-join the tracker).
- The bars go back to views only: root has no bar; group bar = Groups | Trackers | History | Configure.
- The tinted-button color treatment (this issue's original ask) is dropped per the refinement — plain links, no new colors.

**Test gates:** create-links asserted on root; group create-link still pre-joins; create-page asserts unchanged semantics. Suite 201 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
