### PR TITLE
feat(forms): root Groups|Trackers switcher; root archived is groups-only

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -1184,29 +1184,41 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   const managed = templates.some((template) => template.management === true);
   const active = templates.filter((template) => template.state !== 'archived');
   const archived = templates.filter((template) => template.state === 'archived');
-  // #260: the root IS a container page one level up — clean tap-to-enter rows
-  // (containers first, then ungrouped forms straight to a new entry). The
-  // management detail (#257 quick-configure, meta, archived) lives in one
-  // collapsed Manage section at the bottom, out of the main view.
   const containers = active.filter((template) => template.kind === 'container');
   const containerIds = new Set(containers.map((template) => template.templateId));
   const ungrouped = active.filter((template) => template.kind !== 'container' && !(template.containerId && containerIds.has(template.containerId)));
   const memberCount = (container) => active.filter((template) => template.containerId === container.templateId).length;
-  const rows = [
-    ...containers.map((container) => {
-      const count = memberCount(container);
-      return `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(container.templateId)}"><span class="container-member-title">${escapeHtml(container.title)}</span><span class="forms-root-count">${count} tracker${count === 1 ? '' : 's'}</span><span aria-hidden="true">›</span></a>`;
-    }),
-    ...ungrouped.map((template) => (
-      `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(template.templateId)}"><span class="container-member-title">${escapeHtml(template.title)}</span><span aria-hidden="true">›</span></a>`
-    )),
-  ].join('');
+  const trackerRow = (template) => (
+    `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(template.templateId)}"><span class="container-member-title">${escapeHtml(template.title)}</span><span aria-hidden="true">›</span></a>`
+  );
+  const view = options.view === 'trackers' ? 'trackers' : 'groups';
+  // #298: two root views. Groups (default) = tap-in group rows; Trackers = every
+  // tracker under its group heading — the resurrected pre-#261 listing.
+  let rows;
+  if (view === 'trackers') {
+    rows = [
+      ...containers.map((container) => {
+        const members = active.filter((template) => template.containerId === container.templateId);
+        return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
+          <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} tracker${members.length === 1 ? '' : 's'}</span></div>
+          <div class="container-members">${members.map(trackerRow).join('')}</div>
+        </section>`;
+      }),
+      ungrouped.length ? `<section class="forms-index-ungrouped" aria-label="Ungrouped trackers">${containers.length ? '<h2 class="forms-index-ungrouped-head">Ungrouped</h2>' : ''}<div class="container-members">${ungrouped.map(trackerRow).join('')}</div></section>` : '',
+    ].join('');
+  } else {
+    rows = [
+      ...containers.map((container) => {
+        const count = memberCount(container);
+        return `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(container.templateId)}"><span class="container-member-title">${escapeHtml(container.title)}</span><span class="forms-root-count">${count} tracker${count === 1 ? '' : 's'}</span><span aria-hidden="true">›</span></a>`;
+      }),
+      ...ungrouped.map(trackerRow),
+    ].join('');
+  }
   const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first group' : 'No trackers available'}</h2><p>${canCreate ? 'Groups hold your trackers — make one, then add trackers inside it.' : 'There are no active trackers you can log to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new?kind=container">New group</a>' : ''}</div>`;
-  // #291: the Manage section (and with it the #257 root quick-configure surface)
-  // is retired — lifecycle actions live on each Configure page now. Archived
-  // stays reachable here, collapsed.
-  const rootArchived = archived.filter((template) => template.kind === 'container'
-    || !(template.containerId && containerIds.has(template.containerId)));
+  // #298: the root's archived holds archived GROUPS only — a group's archived
+  // trackers live on that group's page (#293).
+  const rootArchived = archived.filter((template) => template.kind === 'container');
   const manageHtml = managed && rootArchived.length
     ? `<details class="forms-index-archived"><summary>Show archived <span>${rootArchived.length}</span></summary><div class="forms-index-list">${rootArchived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>`
     : '';
@@ -1215,6 +1227,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     <header class="topbar forms-index-header">
       <div><h1>Groups</h1><p class="subtitle">${managed ? 'Tap a group to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
+    <nav class="form-hub-nav" aria-label="Root views"><a class="groups-link" href="/forms"${view === 'groups' ? ' aria-current="page"' : ''}>Groups</a><a class="view-link" href="/forms?view=trackers"${view === 'trackers' ? ' aria-current="page"' : ''}>Trackers</a></nav>
     ${canCreate ? createLinks(null) : ''}
     <section class="content form-card container-card">
       <div class="container-members">${rows || emptyState}</div>
@@ -2349,7 +2362,7 @@ function createFormsRouter(options) {
         templates,
         canCreate,
         issueContext(req, res),
-        {customThemeCss, cspNonce},
+        {customThemeCss, cspNonce, view: req.query.view === 'trackers' ? 'trackers' : 'groups'},
       ));
     } catch (error) {
       next(error);

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -410,6 +410,11 @@ test('forms index separates archived templates and removes management detail for
     await server.registry.createDraft({...base, templateId: 'daily-log', title: 'Daily log'});
     await server.registry.createDraft({...base, templateId: 'old-log', title: 'Old log'});
     await server.registry.setArchived('old-log', 1, true);
+    await server.registry.createDraft({
+      contractVersion: 1, resourceKind: 'form-template', templateId: 'retired-group',
+      ownerId: 'operator', revision: 1, grammarVersion: 1, title: 'Retired group', kind: 'container',
+    });
+    await server.registry.setArchived('retired-group', 1, true);
 
     const formPage = await browserPage(await server.request('/forms/training-log'));
     const submitted = await browserPost(server, '/forms/training-log', new URLSearchParams({
@@ -429,11 +434,18 @@ test('forms index separates archived templates and removes management detail for
     const configureLifecycle = await browserPage(await server.request('/forms/training-log/configure'));
     const lifecycleButtons = [...configureLifecycle.document.querySelectorAll('.configure-lifecycle button')].map((node) => node.textContent.trim());
     assert.deepEqual(lifecycleButtons, ['Clone', 'Archive']);
+    // #298: root archived holds archived GROUPS only; archived trackers live
+    // with their group (or, ungrouped like old-log, stay off the root entirely)
     const archived = managerIndex.document.querySelector('.forms-index-archived');
     assert.ok(archived);
     assert.equal(archived.open, false);
     assert.match(archived.querySelector('summary').textContent, /Show archived\s*1/);
-    assert.match(archived.textContent, /Old log/);
+    assert.match(archived.textContent, /Retired group/);
+    assert.doesNotMatch(archived.textContent, /Old log/);
+    // the Trackers view lists every active tracker under its group heading
+    const trackersView = await browserPage(await server.request('/forms?view=trackers'));
+    assert.ok(trackersView.document.querySelector('.form-hub-nav a[aria-current="page"][href="/forms?view=trackers"]'));
+    assert.ok([...trackersView.document.querySelectorAll('.forms-root-row .container-member-title')].some((node) => /Daily log/.test(node.textContent)));
 
     const submitOnly = await browserPage(await server.request('/forms', {headers: {'X-No-Manage': 'yes'}}));
     assert.equal(submitOnly.document.querySelector('a[href="/forms/new"]'), null);


### PR DESCRIPTION
Closes #298. Operator: root archived "should only show archived groups"; group-page archived confirmed as shipped (#294); "bring the bar back in groups too and let it show whether we're on groups or trackers... show all the trackers under all the groups there like we used to do."

- **Root bar = Groups | Trackers switcher** (current lit): Groups = tap-in rows (default); Trackers = `/forms?view=trackers`, every active tracker under its group heading + Ungrouped — the pre-#261 listing resurrected.
- **Root archived = archived groups only**; grouped archived live with their group (#293/#294); ungrouped archived stay off the root.
- Create links remain under the bar on both views.

**Test gates:** archived-group-only assertions (Retired group shown, Old log hidden), Trackers-view listing + lit tab. Suite 201 pass / 1 pre-existing (#240); validate:editable 0; raw-html pre-existing red (#249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
