### PR TITLE
feat(forms): per-tracker related-strip config — all-in-group + cross-group picks

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -17,11 +17,11 @@ const EMBED_SANDBOX = `${ARTIFACT_SANDBOX} allow-top-navigation-by-user-activati
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const TEMPLATE_CREATE_KEYS = new Set([
   'templateId', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
-  'lineage', 'presentation', 'fields', 'kind', 'containerId', 'memberOrder', 'parentId',
+  'lineage', 'presentation', 'fields', 'kind', 'containerId', 'memberOrder', 'parentId', 'related',
 ]);
 const TEMPLATE_PATCH_KEYS = new Set([
   'revision', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
-  'lineage', 'presentation', 'fields', 'containerId', 'memberOrder', 'parentId',
+  'lineage', 'presentation', 'fields', 'containerId', 'memberOrder', 'parentId', 'related',
 ]);
 const TEMPLATE_PUBLISH_KEYS = new Set(['revision']);
 const TEMPLATE_CLONE_KEYS = new Set(['templateId', 'templateVersion', 'title']);
@@ -988,6 +988,22 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           ${Array.isArray(options.containers) && options.containers.length ? `<label><span>Group</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${options.containers.map((container) => `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label><p class="builder-help">Groups hold related trackers and give each member back-and-sibling navigation.</p>` : ''}
           <p class="builder-help">Themes are installed by the deployment and read from the server. Leave both alone and this form follows whatever theme the viewer has chosen.</p>
         </section>
+        <section class="builder-related" aria-labelledby="builder-related-heading">
+          <h2 id="builder-related-heading">Related trackers</h2>
+          <p class="builder-help">What shows in the strip at the bottom of this tracker (and its receipts).</p>
+          <input type="hidden" name="relatedCfg" value="1">
+          ${template.containerId ? `<label class="related-all"><input type="checkbox" name="relatedAll"${!template.related || template.related.group !== false ? ' checked' : ''}> All in this group</label>` : ''}
+          ${Array.isArray(options.relatedChoices) && options.relatedChoices.length ? `<details class="related-picker"${template.related && Array.isArray(template.related.include) && template.related.include.length ? ' open' : ''}><summary>Pick specific trackers</summary>${options.relatedChoices.map((choiceGroup) => {
+            const own = choiceGroup.templateId === template.containerId;
+            const allOn = !template.related || template.related.group !== false;
+            const includeSet = new Set((template.related && template.related.include) || []);
+            const members = choiceGroup.members.filter((member) => member.templateId !== template.templateId);
+            if (!members.length) return '';
+            return `<div class="related-picker-group"><span class="tracker-jump-head">${escapeHtml(choiceGroup.title)}</span>${members.map((member) =>
+              `<label class="container-member-choice"><input type="checkbox" name="related" value="${escapeHtml(member.templateId)}"${own && allOn ? ' checked disabled' : includeSet.has(member.templateId) ? ' checked' : ''}> ${escapeHtml(member.title)}</label>`
+            ).join('')}</div>`;
+          }).join('')}</details>` : ''}
+        </section>
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
           ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length)).join('')}
@@ -1453,6 +1469,13 @@ function builderPatch(current, body) {
     // materializes the resolved fields on detach (#245).
     patch.parentId = postedString(body, 'parent') || null;
   }
+  if (Object.prototype.hasOwnProperty.call(body, 'relatedCfg')) {
+    // #300: All-in-group + explicit picks. Default state stores nothing.
+    const include = [].concat(body.related || []).filter((id) => typeof id === 'string' && id);
+    const hasGroup = Boolean(current.containerId);
+    const group = hasGroup ? Object.prototype.hasOwnProperty.call(body, 'relatedAll') : true;
+    patch.related = (group && include.length === 0) ? null : {group, include};
+  }
   return patch;
 }
 
@@ -1850,20 +1873,38 @@ function createFormsRouter(options) {
 
   async function relatedFormsFor(req, template) {
     // #234: container membership drives the strip; tags remain the fallback for
-    // uncontained forms.
+    // uncontained, unconfigured forms. #300: template.related overrides —
+    // {group: false} drops the siblings, include[] adds trackers from ANY group.
+    const cfg = template.related || null;
+    const useGroup = !cfg || cfg.group !== false;
+    let container = null;
+    const related = [];
+    const seen = new Set([template.templateId]);
     if (template.containerId) {
-      const container = await registry.getTemplate(template.containerId);
-      if (container && container.kind === 'container' && container.archived !== true) {
-        const members = await containerMembersFor(req, container);
-        return {
-          container: {templateId: container.templateId, title: container.title},
-          related: members.filter((member) => member.templateId !== template.templateId),
-        };
+      const candidate = await registry.getTemplate(template.containerId);
+      if (candidate && candidate.kind === 'container' && candidate.archived !== true) {
+        container = candidate;
+        if (useGroup) {
+          for (const member of await containerMembersFor(req, candidate)) {
+            if (seen.has(member.templateId)) continue;
+            seen.add(member.templateId);
+            related.push(member);
+          }
+        }
       }
     }
+    for (const includeId of (cfg && Array.isArray(cfg.include)) ? cfg.include : []) {
+      if (seen.has(includeId)) continue;
+      const candidate = await registry.getTemplate(includeId);
+      if (!candidate || candidate.kind === 'container' || candidate.archived === true) continue;
+      if (await allowed(req, 'forms.submit', candidate) || await allowed(req, 'forms.view', candidate)) {
+        seen.add(includeId);
+        related.push(candidate);
+      }
+    }
+    if (container || related.length || cfg) return {container, related};
     const tags = Array.isArray(template.tags) ? template.tags : [];
     if (!tags.length) return {container: null, related: []};
-    const related = [];
     for (const candidate of await registry.listTemplates()) {
       if (candidate.templateId === template.templateId || candidate.archived === true) continue;
       if (candidate.kind === 'container') continue;
@@ -2259,7 +2300,7 @@ function createFormsRouter(options) {
   function validBuilderBody(body, create = false) {
     const fixed = create
       ? new Set(['_csrf', 'templateId', 'title', 'destinationId', 'kind', 'group'])
-      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container', 'parent']);
+      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container', 'parent', 'relatedCfg', 'relatedAll', 'related']);
     // An author SELECTS an installed theme; they can never introduce one. Anything
     // outside the server's list is refused rather than quietly ignored.
     if (!create && body && typeof body === 'object') {
@@ -2271,8 +2312,10 @@ function createFormsRouter(options) {
     }
     const fieldKey = /^field\.\d+\.(?:id|type|label|required|help|component|showInList|isDestroyed|minimum|maximum|step|integer|providerSlot|option\.\d+\.(?:id|label))$/;
     return body && typeof body === 'object' && !Array.isArray(body)
-      && Object.entries(body).every(([key, value]) => typeof value === 'string'
-        && (fixed.has(key) || (!create && fieldKey.test(key))));
+      && Object.entries(body).every(([key, value]) => {
+        if (key === 'related') return [].concat(value).every((id) => typeof id === 'string' && isDefinitionId(id));
+        return typeof value === 'string' && (fixed.has(key) || (!create && fieldKey.test(key)));
+      });
   }
 
   async function canCreateTemplate(req) {
@@ -2338,12 +2381,30 @@ function createFormsRouter(options) {
       .filter((candidate) => candidate.draft.parentId === record.draft.templateId && candidate.state !== 'archived')
       .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title}))
       .sort((left, right) => String(left.title).localeCompare(String(right.title)));
+    // #300: every group with its active trackers (+ Ungrouped) for the related picker
+    const activeForms = all.filter((candidate) => candidate.draft.kind !== 'container' && candidate.state !== 'archived');
+    const groupIds = new Set(containers.map((group) => group.templateId));
+    const relatedChoices = [
+      ...containers.map((group) => ({
+        templateId: group.templateId,
+        title: group.title,
+        members: activeForms.filter((candidate) => candidate.draft.containerId === group.templateId)
+          .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title})),
+      })),
+      {
+        templateId: null,
+        title: 'Ungrouped',
+        members: activeForms.filter((candidate) => !(candidate.draft.containerId && groupIds.has(candidate.draft.containerId)))
+          .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title})),
+      },
+    ].filter((choiceGroup) => choiceGroup.members.length);
     res.status(status).type('html').send(renderConfigurePage(record, csrfToken, destinationIds, {
       customThemeCss,
       cspNonce,
       containers,
       parents,
       children,
+      relatedChoices,
       relatedForms: {container: await containerCrumbFor(record.draft), related: []},
       ...responseOptions,
     }));

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -21,13 +21,13 @@ const CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/u;
 const TEMPLATE_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision',
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields', 'archived', 'kind', 'containerId', 'memberOrder', 'parentId',
+  'presentation', 'fields', 'archived', 'kind', 'containerId', 'memberOrder', 'parentId', 'related',
 ]);
 const TEMPLATE_VERSION_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'templateVersion',
   'sourceRevision', 'grammarVersion', 'publishedAt', 'publishedBy', 'title',
   'description', 'tags', 'lineage', 'presentation', 'fields', 'schemaDigest',
-  'kind', 'containerId', 'memberOrder', 'parentId',
+  'kind', 'containerId', 'memberOrder', 'parentId', 'related',
 ]);
 const FIELD_KEYS = new Set([
   'id', 'type', 'label', 'help', 'required', 'default', 'component',
@@ -428,6 +428,7 @@ function validateTemplate(doc) {
     if (own(doc, 'destinationId')) addError(errors, 'destinationId', 'must be absent for a container');
     if (own(doc, 'containerId')) addError(errors, 'containerId', 'containers cannot be nested');
     if (own(doc, 'parentId')) addError(errors, 'parentId', 'is only valid on a form');
+    if (own(doc, 'related')) addError(errors, 'related', 'is only valid on a form');
     if (own(doc, 'memberOrder')) {
       if (!Array.isArray(doc.memberOrder) || doc.memberOrder.length > 200) {
         addError(errors, 'memberOrder', 'must be an array of at most 200 definition IDs');
@@ -446,6 +447,29 @@ function validateTemplate(doc) {
     if (own(doc, 'parentId')) {
       validateId(doc.parentId, 'parentId', errors);
       if (doc.parentId === doc.templateId) addError(errors, 'parentId', 'must not reference the template itself');
+    }
+    if (own(doc, 'related')) {
+      // #300: related-strip config — {group, include}; soft references (the strip
+      // filters at render), so include ids are shape-checked only.
+      if (!isRecord(doc.related)) addError(errors, 'related', 'must be an object');
+      else {
+        rejectUnknownKeys(doc.related, new Set(['group', 'include']), 'related', errors);
+        if (own(doc.related, 'group') && typeof doc.related.group !== 'boolean') {
+          addError(errors, 'related.group', 'must be a boolean');
+        }
+        if (own(doc.related, 'include')) {
+          if (!Array.isArray(doc.related.include) || doc.related.include.length > 200) {
+            addError(errors, 'related.include', 'must be an array of at most 200 definition IDs');
+          } else {
+            const seen = new Set();
+            doc.related.include.forEach((id, index) => {
+              validateId(id, `related.include[${index}]`, errors);
+              if (seen.has(id)) addError(errors, `related.include[${index}]`, 'must not repeat');
+              seen.add(id);
+            });
+          }
+        }
+      }
     }
   }
   if (own(doc, 'contractVersion') && doc.contractVersion !== 1) addError(errors, 'contractVersion', 'must equal 1');

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -31,7 +31,7 @@ function resolveInheritedFields(parentFields, childFields) {
 
 const MUTABLE_TEMPLATE_KEYS = [
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields', 'containerId', 'memberOrder', 'parentId',
+  'presentation', 'fields', 'containerId', 'memberOrder', 'parentId', 'related',
 ];
 
 function isDefinitionId(value) {
@@ -499,7 +499,7 @@ class TemplateRegistry {
       const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
       for (const key of MUTABLE_TEMPLATE_KEYS) {
         if (!Object.prototype.hasOwnProperty.call(changes, key)) continue;
-        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation', 'containerId', 'memberOrder', 'parentId'].includes(key)) {
+        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation', 'containerId', 'memberOrder', 'parentId', 'related'].includes(key)) {
           delete revised[key];
         } else if (key === 'presentation' && isPlainObject(changes.presentation) && isPlainObject(revised.presentation)) {
           // #225: merge presentation patches instead of replacing wholesale — a patch
@@ -612,6 +612,7 @@ class TemplateRegistry {
         ...(Object.prototype.hasOwnProperty.call(draft, 'containerId') ? {containerId: draft.containerId} : {}),
         ...(Object.prototype.hasOwnProperty.call(draft, 'memberOrder') ? {memberOrder: clone(draft.memberOrder)} : {}),
         ...(Object.prototype.hasOwnProperty.call(draft, 'parentId') ? {parentId: draft.parentId} : {}),
+        ...(Object.prototype.hasOwnProperty.call(draft, 'related') ? {related: clone(draft.related)} : {}),
         ...(draft.kind === 'container' ? {} : {fields: Array.isArray(draft.fields) ? clone(draft.fields) : []}),
         schemaDigest: `sha256:${schemaDigest(draft)}`,
       };

--- a/public/style.css
+++ b/public/style.css
@@ -2842,6 +2842,12 @@ tbody tr:last-child td {
 .form-layout .container-card .forms-index-archived { margin-top: 1.1rem; }
 .form-layout .container-card .forms-index-archived > summary { cursor: pointer; color: var(--text-soft); font-size: 0.9rem; }
 
+/* #300: related-trackers picker on Configure. */
+.form-layout .builder-related { display: grid; gap: 0.5rem; }
+.form-layout .related-all { display: flex; align-items: center; gap: 0.5rem; }
+.form-layout .related-picker > summary { cursor: pointer; color: var(--accent); font-size: 0.9rem; }
+.form-layout .related-picker-group { display: grid; gap: 0.3rem; padding: 0.4rem 0; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2219,3 +2219,56 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
     await cleanup(fixture, server);
   }
 });
+
+test('related-strip config: all-in-group default, cross-group picks, API roundtrip (#300)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {formsTimezone: 'America/New_York'});
+  try {
+    const context = await getBrowserContext(server);
+    const jsonHeaders = { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token };
+    const post = (route, body) => server.request(route, {method: 'POST', headers: jsonHeaders, body: JSON.stringify(body)});
+    const patch = (route, body) => server.request(route, {method: 'PATCH', headers: jsonHeaders, body: JSON.stringify(body)});
+
+    // a group with two members, plus an ungrouped weight tracker
+    assert.equal((await post('/api/forms/templates', {templateId: 'gym', title: 'Gym', kind: 'container', grammarVersion: 1})).status, 201);
+    assert.equal((await post('/api/forms/templates', {templateId: 'cardio', title: 'Cardio', grammarVersion: 1, destinationId: 'default', containerId: 'gym',
+      fields: [{id: 'minutes', type: 'number', label: 'Minutes', required: true}]})).status, 201);
+    assert.equal((await patch('/api/forms/templates/gym-session-entry', {revision: 1, containerId: 'gym'})).status, 200);
+    assert.equal((await post('/api/forms/templates', {templateId: 'weight', title: 'Weight', grammarVersion: 1, destinationId: 'default',
+      fields: [{id: 'lbs', type: 'number', label: 'Pounds', required: true}]})).status, 201);
+
+    // default: the whole group rides the strip
+    let page = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    assert.match(page, /related-form-link" href="\/forms\/cardio"/);
+    assert.doesNotMatch(page, /related-form-link" href="\/forms\/weight"/);
+
+    // API: add a cross-group pick — survives PATCH and publish
+    const rev = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
+    const patched = await patch('/api/forms/templates/gym-session-entry', {revision: rev, related: {group: true, include: ['weight']}});
+    assert.equal(patched.status, 200);
+    const pub = await post('/api/forms/templates/gym-session-entry/publish', {revision: patched.status === 200 ? JSON.parse(await patched.text()).template.revision : 0});
+    assert.equal(pub.status, 201);
+    assert.deepEqual(JSON.parse(await pub.text()).version.related, {group: true, include: ['weight']});
+    page = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    assert.match(page, /related-form-link" href="\/forms\/cardio"/);
+    assert.match(page, /related-form-link" href="\/forms\/weight"/);
+
+    // group:false narrows the strip to the picks (back-to-group link survives)
+    const rev2 = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
+    assert.equal((await patch('/api/forms/templates/gym-session-entry', {revision: rev2, related: {group: false, include: ['weight']}})).status, 200);
+    page = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    assert.doesNotMatch(page, /related-form-link" href="\/forms\/cardio"/);
+    assert.match(page, /related-form-link" href="\/forms\/weight"/);
+    assert.match(page, /related-container-link/);
+
+    // configure carries the section; bad include ids are refused
+    const configure = await (await server.request('/forms/gym-session-entry/configure', {headers: {Cookie: context.cookie}})).text();
+    assert.match(configure, /builder-related/);
+    assert.match(configure, /name="relatedAll"/);
+    assert.match(configure, /name="related" value="weight" checked/);
+    const rev3 = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
+    assert.equal((await patch('/api/forms/templates/gym-session-entry', {revision: rev3, related: {include: ['NOT AN ID']}})).status, 422);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});


### PR DESCRIPTION
Closes #300. Operator: related-forms config per tracker — "ALL IN GROUP kinda thing but then the opportunity to expand and see specific ones... but also see other groups and add some in there too... Like might wanna be able to see weight inside of any of the machine ones." Plus: "OF COURSE all this stuff needs to survive API commands to match."

- **Grammar**: `related: {group: boolean, include: [ids]}` on form templates — absent = today's whole-group strip. Soft references; the strip filters to existing/active/visible at render.
- **Configure**: Related trackers section — All-in-this-group checkbox + collapsed per-group picker (own group checked+disabled while all-on; other groups individually checkable).
- **API parity**: create/PATCH key sets, publish version docs carry `related`, invalid ids 422 — proven by the end-to-end test's API roundtrip.
- **Latent #292 fix**: relatedFormsFor now returns the full container template, so the group-theme fallback actually receives `presentation`.

**Test gates:** end-to-end (default group strip → API include adds Weight cross-group → publish version carries config → group:false narrows strip, back-link survives → Configure section renders → bad ids 422). Suite **203 pass / 0 fail** (the long-standing #240 failure is gone from main — parallel session's canary rewrite landed); validate:editable 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
