### PR TITLE
feat(forms): related picker v2 — group checkmarks, expandable, compact

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -988,26 +988,30 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           ${Array.isArray(options.containers) && options.containers.length ? `<label><span>Group</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${options.containers.map((container) => `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label><p class="builder-help">Groups hold related trackers and give each member back-and-sibling navigation.</p>` : ''}
           <p class="builder-help">Themes are installed by the deployment and read from the server. Leave both alone and this form follows whatever theme the viewer has chosen.</p>
         </section>
-        <section class="builder-related" aria-labelledby="builder-related-heading">
-          <h2 id="builder-related-heading">Related trackers</h2>
-          <p class="builder-help">What shows in the strip at the bottom of this tracker (and its receipts).</p>
-          <input type="hidden" name="relatedCfg" value="1">
-          ${template.containerId ? `<label class="related-all"><input type="checkbox" name="relatedAll"${!template.related || template.related.group !== false ? ' checked' : ''}> All in this group</label>` : ''}
-          ${Array.isArray(options.relatedChoices) && options.relatedChoices.length ? `<details class="related-picker"${template.related && Array.isArray(template.related.include) && template.related.include.length ? ' open' : ''}><summary>Pick specific trackers</summary>${options.relatedChoices.map((choiceGroup) => {
-            const own = choiceGroup.templateId === template.containerId;
-            const allOn = !template.related || template.related.group !== false;
-            const includeSet = new Set((template.related && template.related.include) || []);
-            const members = choiceGroup.members.filter((member) => member.templateId !== template.templateId);
-            if (!members.length) return '';
-            return `<div class="related-picker-group"><span class="tracker-jump-head">${escapeHtml(choiceGroup.title)}</span>${members.map((member) =>
-              `<label class="container-member-choice"><input type="checkbox" name="related" value="${escapeHtml(member.templateId)}"${own && allOn ? ' checked disabled' : includeSet.has(member.templateId) ? ' checked' : ''}> ${escapeHtml(member.title)}</label>`
-            ).join('')}</div>`;
-          }).join('')}</details>` : ''}
-        </section>
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
           ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length)).join('')}
         </section>
+        <details class="builder-related">
+          <summary>Related trackers</summary>
+          <p class="builder-help">What rides the strip at the bottom of this tracker. Check a group for all of it (live), or expand and pick. A checked group locks its trackers — uncheck the group to pick individually. Applies when you Save draft.</p>
+          <input type="hidden" name="relatedCfg" value="1">
+          ${Array.isArray(options.relatedChoices) ? options.relatedChoices.map((choiceGroup) => {
+            const own = choiceGroup.templateId === template.containerId;
+            const allOn = !template.related || template.related.group !== false;
+            const includeSet = new Set((template.related && template.related.include) || []);
+            const members = choiceGroup.members.filter((member) => member.templateId !== template.templateId);
+            if (!members.length && !choiceGroup.templateId) return '';
+            const groupBox = choiceGroup.templateId
+              ? (own
+                ? `<label class="related-group-box"><input type="checkbox" name="relatedAll"${allOn ? ' checked' : ''}> ${escapeHtml(choiceGroup.title)} <span class="related-own-note">(this group)</span></label>`
+                : `<label class="related-group-box"><input type="checkbox" name="related" value="${escapeHtml(choiceGroup.templateId)}"${includeSet.has(choiceGroup.templateId) ? ' checked' : ''}> ${escapeHtml(choiceGroup.title)}</label>`)
+              : `<span class="related-group-box">${escapeHtml(choiceGroup.title)}</span>`;
+            return `<details class="related-picker-group"><summary>${groupBox}</summary>${members.map((member) =>
+              `<label class="container-member-choice"><input type="checkbox" name="related" value="${escapeHtml(member.templateId)}"${(own && allOn) || includeSet.has(choiceGroup.templateId) ? ' checked disabled' : includeSet.has(member.templateId) ? ' checked' : ''}> ${escapeHtml(member.title)}</label>`
+            ).join('')}</details>`;
+          }).join('') : ''}
+        </details>
         <button class="button-link button-link-primary form-primary-action" type="submit" name="_action" value="save">Save draft</button>
       </form>
       <section class="builder-publish" aria-labelledby="builder-publish-heading">
@@ -1896,7 +1900,17 @@ function createFormsRouter(options) {
     for (const includeId of (cfg && Array.isArray(cfg.include)) ? cfg.include : []) {
       if (seen.has(includeId)) continue;
       const candidate = await registry.getTemplate(includeId);
-      if (!candidate || candidate.kind === 'container' || candidate.archived === true) continue;
+      if (!candidate || candidate.archived === true) continue;
+      if (candidate.kind === 'container') {
+        // #302: a group id includes the WHOLE group, live — new members follow.
+        seen.add(includeId);
+        for (const member of await containerMembersFor(req, candidate)) {
+          if (seen.has(member.templateId)) continue;
+          seen.add(member.templateId);
+          related.push(member);
+        }
+        continue;
+      }
       if (await allowed(req, 'forms.submit', candidate) || await allowed(req, 'forms.view', candidate)) {
         seen.add(includeId);
         related.push(candidate);

--- a/public/style.css
+++ b/public/style.css
@@ -2842,11 +2842,17 @@ tbody tr:last-child td {
 .form-layout .container-card .forms-index-archived { margin-top: 1.1rem; }
 .form-layout .container-card .forms-index-archived > summary { cursor: pointer; color: var(--text-soft); font-size: 0.9rem; }
 
-/* #300: related-trackers picker on Configure. */
-.form-layout .builder-related { display: grid; gap: 0.5rem; }
-.form-layout .related-all { display: flex; align-items: center; gap: 0.5rem; }
-.form-layout .related-picker > summary { cursor: pointer; color: var(--accent); font-size: 0.9rem; }
-.form-layout .related-picker-group { display: grid; gap: 0.3rem; padding: 0.4rem 0; }
+/* #300/#302: compact related-trackers disclosure above Save draft. */
+.form-layout .builder-related { margin: 0.4rem 0 0.9rem; font-size: 0.9rem; }
+.form-layout .builder-related > summary { cursor: pointer; color: var(--accent); }
+.form-layout .builder-related .builder-help { margin: 0.4rem 0; }
+.form-layout .related-picker-group { margin: 0.25rem 0 0.25rem 0.4rem; }
+.form-layout .related-picker-group > summary { cursor: pointer; list-style: none; display: flex; align-items: center; gap: 0.4rem; }
+.form-layout .related-picker-group > summary::before { content: '›'; color: var(--text-soft); transition: transform 0.12s; }
+.form-layout .related-picker-group[open] > summary::before { transform: rotate(90deg); }
+.form-layout .related-group-box { display: inline-flex; align-items: center; gap: 0.45rem; }
+.form-layout .related-own-note { color: var(--text-soft); font-size: 0.8rem; }
+.form-layout .related-picker-group .container-member-choice { display: flex; gap: 0.45rem; padding: 0.15rem 0 0.15rem 1.5rem; }
 
 /* ============================================================================
    Document components

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2261,11 +2261,34 @@ test('related-strip config: all-in-group default, cross-group picks, API roundtr
     assert.match(page, /related-form-link" href="\/forms\/weight"/);
     assert.match(page, /related-container-link/);
 
-    // configure carries the section; bad include ids are refused
+    // configure carries the compact disclosure; bad include ids are refused
     const configure = await (await server.request('/forms/gym-session-entry/configure', {headers: {Cookie: context.cookie}})).text();
     assert.match(configure, /builder-related/);
     assert.match(configure, /name="relatedAll"/);
     assert.match(configure, /name="related" value="weight" checked/);
+    // #302: group rows are checkable (another group's id includes it whole, live)
+    assert.match(configure, /related-group-box/);
+
+    // #302: the GUI save path — scrape the real builder form, tick a box, save
+    const {JSDOM} = require('jsdom');
+    const guiPage = await (await server.request('/forms/gym-session-entry/configure', {headers: {Cookie: context.cookie}})).text();
+    const dom = new JSDOM(guiPage);
+    const builderForm = dom.window.document.querySelector('.builder-form');
+    const guiValues = new URLSearchParams();
+    for (const control of builderForm.querySelectorAll('input, select, textarea')) {
+      if (!control.name || control.disabled) continue;
+      if (control.type === 'checkbox' && !control.checked) continue;
+      guiValues.append(control.name, control.value);
+    }
+    guiValues.set('_action', 'save');
+    const guiSave = await server.request('/forms/gym-session-entry/configure', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: guiValues.toString(),
+    });
+    assert.equal(guiSave.status, 200, (await guiSave.text()).slice(0, 300));
+    const afterGui = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template;
+    assert.deepEqual(afterGui.related, {group: false, include: ['weight']}, 'GUI save must preserve the related config');
     const rev3 = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
     assert.equal((await patch('/api/forms/templates/gym-session-entry', {revision: rev3, related: {include: ['NOT AN ID']}})).status, 422);
   } finally {


### PR DESCRIPTION
Closes #302. Operator feedback on #300's section, all four points:

- **Bottom + compact**: one collapsed disclosure directly above Save draft.
- **Groups with checkmarks, expandable**: each group is a checkbox row (own group = the all-in-group flag; another group = that whole group rides the strip LIVE — `related.include` may now carry group ids, expanded to members at render) with its trackers beneath.
- **"Checkmark not working"**: the GUI save path is now tested end-to-end (real form scrape → save → registry verifies `{group:false, include:['weight']}`) — it round-trips; the confusing part was the by-design locked own-group boxes, now labeled ("A checked group locks its trackers — uncheck the group to pick individually. Applies when you Save draft."). Firefox interaction verified live post-deploy.

Suite 204 pass / 0 fail; validate:editable 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
