### PR TITLE
docs: point CLAUDE.md at the AGENTS.md public boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ Lookie-Link is a private-network web viewer for configured local directories. It
 
 The authoritative route, authorization, configuration, CLI, discovery, and library inventory is [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md). Do not create another endpoint list or document forms, templates, or submissions as implemented.
 
+This repository is public. [`AGENTS.md`](AGENTS.md) defines the public boundary: what belongs here and what must never be added (product strategy, roadmaps, draft decisions, build prompts, private paths). Read it before adding documentation.
+
 ## Commands
 
 - `npm test` — Node test suite, including the discovery-to-documentation matrix check


### PR DESCRIPTION
One-line addition: CLAUDE.md now references AGENTS.md so Claude Code sessions (which auto-load CLAUDE.md, not AGENTS.md) discover the public boundary introduced by the planning split (#296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)