### PR TITLE
feat(forms): child Configure shows inherited fields; clone keeps structure

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -990,6 +990,10 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
         </section>
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
+          ${options.inherited && options.inherited.fields.length ? `<div class="inherited-fields" aria-label="Inherited fields">
+            <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong> — these serve on this tracker live. Add a field with the same id below to override one.</p>
+            ${options.inherited.fields.map((field) => `<div class="inherited-field"><span class="inherited-field-label">${escapeHtml(field.label)}</span><span class="inherited-field-meta">${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span></div>`).join('')}
+          </div>` : ''}
           ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length)).join('')}
         </section>
         <details class="builder-related">
@@ -2025,7 +2029,14 @@ function createFormsRouter(options) {
         ...(body.templateVersion === undefined ? {} : {templateVersion: body.templateVersion}),
       },
       ...(source.presentation === undefined ? {} : {presentation: structuredClone(source.presentation)}),
-      fields: structuredClone(source.fields),
+      // #307: a clone keeps its structure — kind (containers were uncloneable),
+      // parent (a child's clone is a sibling variant, not an orphan missing the
+      // inherited fields), group, and related config.
+      ...(source.kind === 'container' ? {kind: 'container'} : {}),
+      ...(source.parentId ? {parentId: source.parentId} : {}),
+      ...(source.containerId ? {containerId: source.containerId} : {}),
+      ...(source.related === undefined ? {} : {related: structuredClone(source.related)}),
+      ...(source.kind === 'container' ? {} : {fields: structuredClone(source.fields)}),
     });
   }
 
@@ -2395,6 +2406,19 @@ function createFormsRouter(options) {
       .filter((candidate) => candidate.draft.parentId === record.draft.templateId && candidate.state !== 'archived')
       .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title}))
       .sort((left, right) => String(left.title).localeCompare(String(right.title)));
+    // #307: a child's Configure shows what it inherits (read-only)
+    let inherited = null;
+    if (record.draft.parentId) {
+      const parent = await registry.getTemplate(record.draft.parentId);
+      if (parent) {
+        const ownIds = new Set((record.draft.fields || []).map((field) => field.id));
+        inherited = {
+          parentTitle: parent.title,
+          fields: (parent.fields || []).filter((field) => field.isDestroyed !== true && !ownIds.has(field.id))
+            .map((field) => ({id: field.id, label: field.label, type: field.type})),
+        };
+      }
+    }
     // #300: every group with its active trackers (+ Ungrouped) for the related picker
     const activeForms = all.filter((candidate) => candidate.draft.kind !== 'container' && candidate.state !== 'archived');
     const groupIds = new Set(containers.map((group) => group.templateId));
@@ -2419,6 +2443,7 @@ function createFormsRouter(options) {
       parents,
       children,
       relatedChoices,
+      inherited,
       relatedForms: {container: await containerCrumbFor(record.draft), related: []},
       ...responseOptions,
     }));

--- a/public/style.css
+++ b/public/style.css
@@ -2855,6 +2855,11 @@ tbody tr:last-child td {
 .form-layout .related-own-note { color: var(--text-soft); font-size: 0.8rem; }
 .form-layout .related-picker-group .container-member-choice { display: flex; align-items: center; justify-content: flex-start; gap: 0.45rem; padding: 0.15rem 0 0.15rem 1.5rem; }
 
+/* #307: read-only inherited fields on a child's Configure. */
+.form-layout .inherited-fields { display: grid; gap: 0.35rem; margin: 0.4rem 0 0.9rem; padding: 0.7rem 0.9rem; border: 1px dashed var(--border); border-radius: 0.6rem; }
+.form-layout .inherited-field { display: flex; justify-content: space-between; gap: 0.8rem; font-size: 0.9rem; }
+.form-layout .inherited-field-meta { color: var(--text-soft); font-size: 0.8rem; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2151,6 +2151,27 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     const archived = await post('/api/forms/templates/gym-session-entry/archive', {revision: benchRevForArchive});
     assert.ok(archived.status === 422 || archived.status === 409, `parent archive not refused: ${archived.status}`);
 
+    // #307: a child's Configure shows the inherited schema read-only
+    const childConfigure = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
+    assert.match(childConfigure, /inherited-fields/);
+    assert.match(childConfigure, /Inherited from <strong>Gym Session Entry<\/strong>/);
+    assert.match(childConfigure, /Warmed up/);
+    assert.doesNotMatch(childConfigure, /inherited-field-label">Lift</);
+
+    // #307: cloning a child keeps its parent (and thus the full resolved schema)
+    const cloneResp = await post('/api/forms/templates/bench-day/clone', {});
+    assert.equal(cloneResp.status, 201, await cloneResp.text());
+    const cloneId = JSON.parse(await cloneResp.text()).template.templateId;
+    const clonedGet = JSON.parse(await (await server.request(`/api/forms/templates/${cloneId}`)).text());
+    assert.equal(clonedGet.template.parentId, 'gym-session-entry');
+    assert.ok(clonedGet.resolvedFields.some((field) => field.id === 'warmup-done'), 'clone lost the inherited fields');
+
+    // #307: cloning a container yields a container
+    assert.equal((await post('/api/forms/templates', {templateId: 'hub', title: 'Hub', kind: 'container', grammarVersion: 1})).status, 201);
+    const hubClone = await post('/api/forms/templates/hub/clone', {});
+    assert.equal(hubClone.status, 201);
+    assert.equal(JSON.parse(await hubClone.text()).template.kind, 'container');
+
     // detach materializes the resolved fields onto the child
     const childRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;
     const detached = await patch('/api/forms/templates/bench-day', {revision: childRev, parentId: null});


### PR DESCRIPTION
Closes #307. The two gaps from the #245 design plus the clone bug the audit surfaced:

- **Inherited fields visible**: a child's Configure lists "Inherited from <parent>" read-only (label · type · id per field, own overrides excluded), with the override-by-same-id mechanism stated in the help line.
- **Clone keeps structure**: `kind` (containers were uncloneable — validation failure), `parentId` (a child's clone was an orphan with only its override fields), `containerId` (clones stay in their group), `related`. Fields copy only for form-kind sources.
- **Pinned by tests**: child clone keeps parent + full resolvedFields; container clone yields a container; inherited view renders (and excludes overridden fields).

Suite 203 pass / 0 fail; validate:editable 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
