### PR TITLE
fix(forms): Configure legibility — Entry storage, Overrides inherited badge

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -846,7 +846,7 @@ function builderOption(option, fieldIndex, optionIndex, optionCount) {
   </div>`;
 }
 
-function builderField(field, fieldIndex, fieldCount) {
+function builderField(field, fieldIndex, fieldCount, isOverride = false) {
   const prefix = `field.${fieldIndex}`;
   const constraints = field.constraints || {};
   const selection = field.type === 'select' || field.type === 'multi-select';
@@ -868,7 +868,7 @@ function builderField(field, fieldIndex, fieldCount) {
     }
     return inputs.join('');
   };
-  const summary = `<span class="builder-field-title"><strong>${escapeHtml(field.label)}</strong><span class="builder-type-badge">${escapeHtml(fieldTypeLabel(field.type))}</span></span>
+  const summary = `<span class="builder-field-title"><strong>${escapeHtml(field.label)}</strong><span class="builder-type-badge">${escapeHtml(fieldTypeLabel(field.type))}</span>${isOverride ? '<span class="builder-marker builder-override-marker">Overrides inherited</span>' : ''}</span>
       <span class="builder-field-markers">${field.required ? '<span class="builder-marker builder-required-marker">Required</span>' : ''}${field.showInList ? '<span class="builder-marker builder-list-marker">In list</span>' : ''}${field.isDestroyed ? '<span class="builder-marker builder-removed-marker">Removed</span>' : ''}</span>`;
   if (field.isDestroyed === true) {
     return `<div class="builder-field builder-field-removed">
@@ -979,8 +979,8 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
         <section class="builder-basics" aria-labelledby="builder-basics-heading">
           <h2 id="builder-basics-heading">Template</h2>
           <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
-          <label><span>Destination</span><select name="destinationId" required>${destinationOptions}</select></label>
-          <p class="builder-help">Destinations are deployment-approved aliases. Filesystem paths cannot be entered here.</p>
+          <label><span>Entry storage</span><select name="destinationId" required>${destinationOptions}</select></label>
+          <p class="builder-help">Where this tracker's entries are saved — a storage area named by the server operator. 'default' is fine unless your deployment says otherwise. (Only these approved names are accepted; paths cannot be entered.)</p>
           <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
           <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
           ${Array.isArray(options.parents) && options.parents.length ? `<label><span>Parent form</span><select name="parent"><option value=""${!template.parentId ? ' selected' : ''}>None</option>${options.parents.map((parent) => `<option value="${escapeHtml(parent.templateId)}"${template.parentId === parent.templateId ? ' selected' : ''}>${escapeHtml(parent.title)}</option>`).join('')}</select></label><p class="builder-help">A child form inherits every parent field live. Fields below override a parent field with the same id or extend the form; detaching copies the resolved fields back onto this form (#245).</p>` : ''}
@@ -994,7 +994,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
             <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong> — these serve on this tracker live. Add a field with the same id below to override one.</p>
             ${options.inherited.fields.map((field) => `<div class="inherited-field"><span class="inherited-field-label">${escapeHtml(field.label)}</span><span class="inherited-field-meta">${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span></div>`).join('')}
           </div>` : ''}
-          ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length)).join('')}
+          ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length, Boolean(options.parentFieldIds && options.parentFieldIds.has(field.id)))).join('')}
         </section>
         <details class="builder-related">
           <summary>Related trackers</summary>
@@ -1289,8 +1289,8 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
         <label><span>ID (optional)</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*"></label>
         <p class="builder-help">Leave the ID blank and it derives from the name (#279).</p>
         ${options.group ? `<input type="hidden" name="group" value="${escapeHtml(options.group.templateId)}"><p class="builder-help">Joining group: <strong>${escapeHtml(options.group.title || options.group.templateId)}</strong></p>` : `<label><span>Kind</span><select name="kind"><option value="">Form</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>`}
-        <label><span>Destination</span><select name="destinationId">${destinationOptions}</select></label>
-        <p class="builder-help">Destination applies to trackers only — groups hold trackers, not entries.</p>
+        <label><span>Entry storage</span><select name="destinationId">${destinationOptions}</select></label>
+        <p class="builder-help">Where entries are saved — a storage area named by the server operator; 'default' is fine. Applies to trackers only (groups hold trackers, not entries).</p>
         <p class="builder-help">Only deployment-approved destination aliases are available; a filesystem path is never accepted.</p>
         <button class="button-link button-link-primary form-primary-action" type="submit">Create template</button>
       </form>
@@ -2414,6 +2414,7 @@ function createFormsRouter(options) {
         const ownIds = new Set((record.draft.fields || []).map((field) => field.id));
         inherited = {
           parentTitle: parent.title,
+          parentFieldIds: new Set((parent.fields || []).map((field) => field.id)),
           fields: (parent.fields || []).filter((field) => field.isDestroyed !== true && !ownIds.has(field.id))
             .map((field) => ({id: field.id, label: field.label, type: field.type})),
         };
@@ -2444,6 +2445,7 @@ function createFormsRouter(options) {
       children,
       relatedChoices,
       inherited,
+      parentFieldIds: inherited ? inherited.parentFieldIds : null,
       relatedForms: {container: await containerCrumbFor(record.draft), related: []},
       ...responseOptions,
     }));

--- a/public/style.css
+++ b/public/style.css
@@ -2860,6 +2860,9 @@ tbody tr:last-child td {
 .form-layout .inherited-field { display: flex; justify-content: space-between; gap: 0.8rem; font-size: 0.9rem; }
 .form-layout .inherited-field-meta { color: var(--text-soft); font-size: 0.8rem; }
 
+/* #310: override badge on a child's own fields. */
+.form-layout .builder-override-marker { background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent); border-radius: 999px; padding: 0.1rem 0.5rem; font-size: 0.72rem; margin-left: 0.45rem; white-space: nowrap; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2157,6 +2157,9 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     assert.match(childConfigure, /Inherited from <strong>Gym Session Entry<\/strong>/);
     assert.match(childConfigure, /Warmed up/);
     assert.doesNotMatch(childConfigure, /inherited-field-label">Lift</);
+    // #310: the own override field says so
+    assert.match(childConfigure, /builder-override-marker">Overrides inherited</);
+    assert.match(childConfigure, /Entry storage/);
 
     // #307: cloning a child keeps its parent (and thus the full resolved schema)
     const cloneResp = await post('/api/forms/templates/bench-day/clone', {});


### PR DESCRIPTION
Closes #310. Playwright-confirmed operator confusion on a machine tracker's Configure: Destination help said only what it refuses, now says what it IS (Entry storage — where entries are saved, server-named; destinationId unchanged in the API); the child's own override field now wears an Overrides-inherited badge tying it to the inherited panel's mechanism. Suite 203/0.🤖 Generated with [Claude Code](https://claude.com/claude-code)