### PR TITLE
feat(forms): inherit.exclude, one-tap override, parent theme inheritance

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -17,11 +17,11 @@ const EMBED_SANDBOX = `${ARTIFACT_SANDBOX} allow-top-navigation-by-user-activati
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const TEMPLATE_CREATE_KEYS = new Set([
   'templateId', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
-  'lineage', 'presentation', 'fields', 'kind', 'containerId', 'memberOrder', 'parentId', 'related',
+  'lineage', 'presentation', 'fields', 'kind', 'containerId', 'memberOrder', 'parentId', 'related', 'inherit',
 ]);
 const TEMPLATE_PATCH_KEYS = new Set([
   'revision', 'grammarVersion', 'destinationId', 'title', 'description', 'tags',
-  'lineage', 'presentation', 'fields', 'containerId', 'memberOrder', 'parentId', 'related',
+  'lineage', 'presentation', 'fields', 'containerId', 'memberOrder', 'parentId', 'related', 'inherit',
 ]);
 const TEMPLATE_PUBLISH_KEYS = new Set(['revision']);
 const TEMPLATE_CLONE_KEYS = new Set(['templateId', 'templateVersion', 'title']);
@@ -589,11 +589,23 @@ function themeDefaults(template) {
   return out;
 }
 
-function withGroupTheme(template, container) {
-  if (!template || !container) return template;
-  const group = themeDefaults(container);
-  if (!group.scheme && !group.mode) return template;
-  return {...template, __groupTheme: group};
+function withGroupTheme(template, container, parent) {
+  // #313: fallback chain own -> parent -> group; themeDefaults consumes the merge.
+  if (!template) return template;
+  const parentTheme = parent ? themeDefaults(parent) : {};
+  const groupTheme = container ? themeDefaults(container) : {};
+  const merged = {
+    scheme: parentTheme.scheme || groupTheme.scheme || null,
+    mode: parentTheme.mode || groupTheme.mode || null,
+  };
+  if (!merged.scheme && !merged.mode) return template;
+  return {...template, __groupTheme: merged};
+}
+
+async function parentThemeSourceFor(registry, template) {
+  if (!template || !template.parentId) return null;
+  const parent = await registry.getTemplate(template.parentId);
+  return parent && parent.archived !== true ? parent : null;
 }
 
 function displayValue(entry, timeZone) {
@@ -991,8 +1003,9 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
           ${options.inherited && options.inherited.fields.length ? `<div class="inherited-fields" aria-label="Inherited fields">
-            <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong> — these serve on this tracker live. Add a field with the same id below to override one.</p>
-            ${options.inherited.fields.map((field) => `<div class="inherited-field"><span class="inherited-field-label">${escapeHtml(field.label)}</span><span class="inherited-field-meta">${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span></div>`).join('')}
+            <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong> — these serve on this tracker live. Uncheck one to leave it off THIS tracker; Override copies it below for editing. Applies with Save draft.</p>
+            <input type="hidden" name="inheritCfg" value="1">
+            ${options.inherited.fields.map((field) => `<div class="inherited-field"><label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(field.id)}"${field.excluded ? '' : ' checked'}><span class="inherited-field-label">${escapeHtml(field.label)}</span></label><span class="inherited-field-meta">${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span><button type="submit" name="_action" value="inherit-override:${escapeHtml(field.id)}" class="inherited-override-btn">Override</button></div>`).join('')}
           </div>` : ''}
           ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length, Boolean(options.parentFieldIds && options.parentFieldIds.has(field.id)))).join('')}
         </section>
@@ -2036,6 +2049,7 @@ function createFormsRouter(options) {
       ...(source.parentId ? {parentId: source.parentId} : {}),
       ...(source.containerId ? {containerId: source.containerId} : {}),
       ...(source.related === undefined ? {} : {related: structuredClone(source.related)}),
+      ...(source.inherit === undefined ? {} : {inherit: structuredClone(source.inherit)}),
       ...(source.kind === 'container' ? {} : {fields: structuredClone(source.fields)}),
     });
   }
@@ -2325,7 +2339,7 @@ function createFormsRouter(options) {
   function validBuilderBody(body, create = false) {
     const fixed = create
       ? new Set(['_csrf', 'templateId', 'title', 'destinationId', 'kind', 'group'])
-      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container', 'parent', 'relatedCfg', 'relatedAll', 'related']);
+      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container', 'parent', 'relatedCfg', 'relatedAll', 'related', 'inheritCfg', 'inheritInclude']);
     // An author SELECTS an installed theme; they can never introduce one. Anything
     // outside the server's list is refused rather than quietly ignored.
     if (!create && body && typeof body === 'object') {
@@ -2338,7 +2352,7 @@ function createFormsRouter(options) {
     const fieldKey = /^field\.\d+\.(?:id|type|label|required|help|component|showInList|isDestroyed|minimum|maximum|step|integer|providerSlot|option\.\d+\.(?:id|label))$/;
     return body && typeof body === 'object' && !Array.isArray(body)
       && Object.entries(body).every(([key, value]) => {
-        if (key === 'related') return [].concat(value).every((id) => typeof id === 'string' && isDefinitionId(id));
+        if (key === 'related' || key === 'inheritInclude') return [].concat(value).every((id) => typeof id === 'string' && isDefinitionId(id));
         return typeof value === 'string' && (fixed.has(key) || (!create && fieldKey.test(key)));
       });
   }
@@ -2412,11 +2426,12 @@ function createFormsRouter(options) {
       const parent = await registry.getTemplate(record.draft.parentId);
       if (parent) {
         const ownIds = new Set((record.draft.fields || []).map((field) => field.id));
+        const excluded = new Set((record.draft.inherit && record.draft.inherit.exclude) || []);
         inherited = {
           parentTitle: parent.title,
           parentFieldIds: new Set((parent.fields || []).map((field) => field.id)),
           fields: (parent.fields || []).filter((field) => field.isDestroyed !== true && !ownIds.has(field.id))
-            .map((field) => ({id: field.id, label: field.label, type: field.type})),
+            .map((field) => ({id: field.id, label: field.label, type: field.type, excluded: excluded.has(field.id)})),
         };
       }
     }
@@ -2709,6 +2724,29 @@ function createFormsRouter(options) {
         return;
       }
       const patch = builderPatch(record.draft, req.body);
+      // #313: inherited-panel state — exclusion set and one-tap override both
+      // need the parent's schema, so they assemble here rather than in builderPatch.
+      if (record.draft.parentId) {
+        const parent = await registry.getTemplate(record.draft.parentId);
+        if (parent) {
+          const action = postedString(req.body, '_action', 'save');
+          const overrideMatch = /^inherit-override:([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
+          if (overrideMatch) {
+            const sourceField = (parent.fields || []).find((field) => field.id === overrideMatch[1]);
+            if (sourceField && !(patch.fields || []).some((field) => field.id === sourceField.id)) {
+              patch.fields = [...(patch.fields || []), structuredClone(sourceField)];
+            }
+          }
+          if (Object.prototype.hasOwnProperty.call(req.body, 'inheritCfg')) {
+            const included = new Set([].concat(req.body.inheritInclude || []));
+            const ownIds = new Set((patch.fields || []).map((field) => field.id));
+            const exclude = (parent.fields || [])
+              .filter((field) => field.isDestroyed !== true && !ownIds.has(field.id) && !included.has(field.id))
+              .map((field) => field.id);
+            patch.inherit = exclude.length ? {exclude} : null;
+          }
+        }
+      }
       const revised = await reviseTemplateThroughApi(req.params.templateId, patch);
       emitAudit(req, type, 'accepted', revised.draft);
       await sendConfigure(res, revised, issueContext(req, res), {status: 'Draft saved.'});
@@ -2804,7 +2842,7 @@ function createFormsRouter(options) {
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.render', 'accepted', template);
       const relatedForms = await relatedFormsFor(req, template);
-      res.status(200).type('html').send(renderFormPage(withGroupTheme(template, relatedForms.container), csrfToken, {}, [], {
+      res.status(200).type('html').send(renderFormPage(withGroupTheme(template, relatedForms.container, await parentThemeSourceFor(registry, template)), csrfToken, {}, [], {
         customThemeCss,
         cspNonce,
         recentRecords,
@@ -2846,7 +2884,7 @@ function createFormsRouter(options) {
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.submissions.list', 'accepted', template);
       const relatedForms = {container: await containerCrumbFor(template), related: []};
-      res.status(200).type('html').send(renderEntriesPage(withGroupTheme(template, relatedForms.container), submissions, {
+      res.status(200).type('html').send(renderEntriesPage(withGroupTheme(template, relatedForms.container, await parentThemeSourceFor(registry, template)), submissions, {
         customThemeCss,
         cspNonce,
         timezone: serverTimezone,
@@ -3224,7 +3262,7 @@ function createFormsRouter(options) {
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.receipt.read', 'accepted', record);
       const receiptRelated = await relatedFormsFor(req, template);
-      res.status(200).type('html').send(renderReceiptPage(withGroupTheme(template, receiptRelated.container), record, {
+      res.status(200).type('html').send(renderReceiptPage(withGroupTheme(template, receiptRelated.container, await parentThemeSourceFor(registry, template)), record, {
         customThemeCss,
         cspNonce,
         canEdit,

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -21,13 +21,13 @@ const CONTROL_CHARACTER = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/u;
 const TEMPLATE_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'revision',
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields', 'archived', 'kind', 'containerId', 'memberOrder', 'parentId', 'related',
+  'presentation', 'fields', 'archived', 'kind', 'containerId', 'memberOrder', 'parentId', 'related', 'inherit',
 ]);
 const TEMPLATE_VERSION_KEYS = new Set([
   'contractVersion', 'resourceKind', 'templateId', 'ownerId', 'templateVersion',
   'sourceRevision', 'grammarVersion', 'publishedAt', 'publishedBy', 'title',
   'description', 'tags', 'lineage', 'presentation', 'fields', 'schemaDigest',
-  'kind', 'containerId', 'memberOrder', 'parentId', 'related',
+  'kind', 'containerId', 'memberOrder', 'parentId', 'related', 'inherit',
 ]);
 const FIELD_KEYS = new Set([
   'id', 'type', 'label', 'help', 'required', 'default', 'component',
@@ -429,6 +429,7 @@ function validateTemplate(doc) {
     if (own(doc, 'containerId')) addError(errors, 'containerId', 'containers cannot be nested');
     if (own(doc, 'parentId')) addError(errors, 'parentId', 'is only valid on a form');
     if (own(doc, 'related')) addError(errors, 'related', 'is only valid on a form');
+    if (own(doc, 'inherit')) addError(errors, 'inherit', 'is only valid on a form');
     if (own(doc, 'memberOrder')) {
       if (!Array.isArray(doc.memberOrder) || doc.memberOrder.length > 200) {
         addError(errors, 'memberOrder', 'must be an array of at most 200 definition IDs');
@@ -447,6 +448,26 @@ function validateTemplate(doc) {
     if (own(doc, 'parentId')) {
       validateId(doc.parentId, 'parentId', errors);
       if (doc.parentId === doc.templateId) addError(errors, 'parentId', 'must not reference the template itself');
+    }
+    if (own(doc, 'inherit')) {
+      // #313: per-child selection of the parent's fields — requires a parent.
+      if (!own(doc, 'parentId')) addError(errors, 'inherit', 'requires parentId');
+      if (!isRecord(doc.inherit)) addError(errors, 'inherit', 'must be an object');
+      else {
+        rejectUnknownKeys(doc.inherit, new Set(['exclude']), 'inherit', errors);
+        if (own(doc.inherit, 'exclude')) {
+          if (!Array.isArray(doc.inherit.exclude) || doc.inherit.exclude.length > 200) {
+            addError(errors, 'inherit.exclude', 'must be an array of at most 200 field IDs');
+          } else {
+            const seen = new Set();
+            doc.inherit.exclude.forEach((id, index) => {
+              validateId(id, `inherit.exclude[${index}]`, errors);
+              if (seen.has(id)) addError(errors, `inherit.exclude[${index}]`, 'must not repeat');
+              seen.add(id);
+            });
+          }
+        }
+      }
     }
     if (own(doc, 'related')) {
       // #300: related-strip config — {group, include}; soft references (the strip

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -13,8 +13,11 @@ const DEFINITION_ID = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 // #245: child fields resolve against the parent at serve time — a child field
 // whose id matches a parent field overrides it in place; other child fields
 // append after. Live inheritance: edit the parent once, every child updates.
-function resolveInheritedFields(parentFields, childFields) {
-  const parent = Array.isArray(parentFields) ? parentFields : [];
+function resolveInheritedFields(parentFields, childFields, inherit) {
+  // #313: inherit.exclude drops parent fields for THIS child only — selection,
+  // not deletion; receipts stay safe via capture-time snapshots.
+  const excluded = new Set((inherit && Array.isArray(inherit.exclude)) ? inherit.exclude : []);
+  const parent = (Array.isArray(parentFields) ? parentFields : []).filter((field) => !excluded.has(field.id));
   const own = Array.isArray(childFields) ? childFields : [];
   const overrides = new Map(own.map((field) => [field.id, field]));
   const used = new Set();
@@ -31,7 +34,7 @@ function resolveInheritedFields(parentFields, childFields) {
 
 const MUTABLE_TEMPLATE_KEYS = [
   'grammarVersion', 'destinationId', 'title', 'description', 'tags', 'lineage',
-  'presentation', 'fields', 'containerId', 'memberOrder', 'parentId', 'related',
+  'presentation', 'fields', 'containerId', 'memberOrder', 'parentId', 'related', 'inherit',
 ];
 
 function isDefinitionId(value) {
@@ -290,7 +293,7 @@ class TemplateRegistry {
       // at write time (assertParentReference); if it drifted, own fields serve.
       const parent = this.entrySync(template.parentId);
       if (parent) {
-        template.fields = clone(resolveInheritedFields(parent.template.fields, template.fields));
+        template.fields = clone(resolveInheritedFields(parent.template.fields, template.fields, template.inherit));
         digest = schemaDigest(template);
       }
     }
@@ -489,17 +492,21 @@ class TemplateRegistry {
       const revised = clone(entry.template);
       // #245: detaching (parentId: null) materializes the resolved fields onto the
       // child so nothing it served disappears — unless the patch supplies fields.
-      if (changes.parentId === null && entry.template.parentId
-          && !Object.prototype.hasOwnProperty.call(changes, 'fields')) {
-        const parent = await this.entryFor(entry.template.parentId);
-        if (parent) {
-          revised.fields = clone(resolveInheritedFields(parent.template.fields, entry.template.fields));
+      if (changes.parentId === null && entry.template.parentId) {
+        if (!Object.prototype.hasOwnProperty.call(changes, 'fields')) {
+          const parent = await this.entryFor(entry.template.parentId);
+          if (parent) {
+            revised.fields = clone(resolveInheritedFields(parent.template.fields, entry.template.fields, entry.template.inherit));
+          }
         }
+        // #313: inherit config is meaningless without a parent — exclusions are
+        // already honored in the materialized fields above.
+        delete revised.inherit;
       }
       const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
       for (const key of MUTABLE_TEMPLATE_KEYS) {
         if (!Object.prototype.hasOwnProperty.call(changes, key)) continue;
-        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation', 'containerId', 'memberOrder', 'parentId', 'related'].includes(key)) {
+        if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation', 'containerId', 'memberOrder', 'parentId', 'related', 'inherit'].includes(key)) {
           delete revised[key];
         } else if (key === 'presentation' && isPlainObject(changes.presentation) && isPlainObject(revised.presentation)) {
           // #225: merge presentation patches instead of replacing wholesale — a patch
@@ -613,6 +620,7 @@ class TemplateRegistry {
         ...(Object.prototype.hasOwnProperty.call(draft, 'memberOrder') ? {memberOrder: clone(draft.memberOrder)} : {}),
         ...(Object.prototype.hasOwnProperty.call(draft, 'parentId') ? {parentId: draft.parentId} : {}),
         ...(Object.prototype.hasOwnProperty.call(draft, 'related') ? {related: clone(draft.related)} : {}),
+        ...(Object.prototype.hasOwnProperty.call(draft, 'inherit') ? {inherit: clone(draft.inherit)} : {}),
         ...(draft.kind === 'container' ? {} : {fields: Array.isArray(draft.fields) ? clone(draft.fields) : []}),
         schemaDigest: `sha256:${schemaDigest(draft)}`,
       };

--- a/public/style.css
+++ b/public/style.css
@@ -2857,7 +2857,10 @@ tbody tr:last-child td {
 
 /* #307: read-only inherited fields on a child's Configure. */
 .form-layout .inherited-fields { display: grid; gap: 0.35rem; margin: 0.4rem 0 0.9rem; padding: 0.7rem 0.9rem; border: 1px dashed var(--border); border-radius: 0.6rem; }
-.form-layout .inherited-field { display: flex; justify-content: space-between; gap: 0.8rem; font-size: 0.9rem; }
+.form-layout .inherited-field { display: flex; align-items: center; justify-content: space-between; gap: 0.8rem; font-size: 0.9rem; }
+.form-layout .inherited-field-pick { display: flex; align-items: center; gap: 0.5rem; flex: 1; }
+.form-layout .inherited-field-pick input[type="checkbox"] { width: 1.05rem; height: 1.05rem; margin: 0; flex: none; accent-color: var(--accent); }
+.form-layout .inherited-override-btn { flex: none; font-size: 0.78rem; padding: 0.2rem 0.6rem; }
 .form-layout .inherited-field-meta { color: var(--text-soft); font-size: 0.8rem; }
 
 /* #310: override badge on a child's own fields — the row wraps rather than

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2169,6 +2169,25 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     assert.equal(clonedGet.template.parentId, 'gym-session-entry');
     assert.ok(clonedGet.resolvedFields.some((field) => field.id === 'warmup-done'), 'clone lost the inherited fields');
 
+    // #313: exclude an inherited field on THIS child only (API), serving honors it
+    const exRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;
+    assert.equal((await patch('/api/forms/templates/bench-day', {revision: exRev, inherit: {exclude: ['notes']}})).status, 200);
+    const excluded = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
+    assert.ok(!excluded.resolvedFields.some((field) => field.id === 'notes'), 'excluded field still serving');
+    assert.ok(excluded.resolvedFields.some((field) => field.id === 'warmup-done'), 'other inherited fields must survive');
+    const exPage = await (await server.request('/forms/bench-day', {headers: {Cookie: context.cookie}})).text();
+    assert.doesNotMatch(exPage, /name="notes"/);
+    // configure shows it unchecked; GUI one-tap override copies a parent field down
+    const exConfigure = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
+    assert.match(exConfigure, /name="inheritInclude" value="notes"(?! checked)/);
+    assert.match(exConfigure, /name="inheritInclude" value="warmup-done" checked/);
+    assert.match(exConfigure, /inherit-override:warmup-done/);
+    // #313: theme inheritance — parent presentation flows to a themeless child page
+    const pRev = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
+    assert.equal((await patch('/api/forms/templates/gym-session-entry', {revision: pRev, presentation: {theme: 'nord', themeMode: 'dark'}})).status, 200);
+    const themedChild = await (await server.request('/forms/bench-day', {headers: {Cookie: context.cookie}})).text();
+    assert.match(themedChild, /nord/);
+
     // #307: cloning a container yields a container
     assert.equal((await post('/api/forms/templates', {templateId: 'hub', title: 'Hub', kind: 'container', grammarVersion: 1})).status, 201);
     const hubClone = await post('/api/forms/templates/hub/clone', {});


### PR DESCRIPTION
Closes #313. Operator: "fields from the parent should be able to be unselected as well (kinda like we do the related trackers). And even overridden, rearranged, etc... AND the theme and dark/light could be something that could get inherited too."

- **`inherit: {exclude: [...]}`** on children — per-child field selection (not deletion); serving, previews, digests honor it; detach honors it in the materialized fields then clears the config.
- **Interactive inherited panel**: checkbox per inherited row (uncheck = off on this child), **Override** button per row (one tap copies the parent field down for editing — the #245 design's deferred affordance, delivered).
- **Theme inheritance**: own → parent → group → viewer, scheme and dark/light.
- **API parity**: create/PATCH keys, publish version docs, clone carries `inherit`; invalid ids 422.
- **Reordering** deferred to #314 (designed).

**Test gates:** API exclude → resolvedFields + child page honor it, other fields survive; configure shows the unchecked row + override actions; parent presentation flows to a themeless child; detach-after-exclude regression fixed in the same pass. Suite 203/0; validate:editable 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
