### PR TITLE
feat(forms): Entry storage goes Advanced; creation presets the group cabinet

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -991,8 +991,10 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
         <section class="builder-basics" aria-labelledby="builder-basics-heading">
           <h2 id="builder-basics-heading">Template</h2>
           <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
+          <details class="builder-advanced"><summary>Advanced</summary>
           <label><span>Entry storage</span><select name="destinationId" required>${destinationOptions}</select></label>
-          <p class="builder-help">Where this tracker's entries are saved — a storage area named by the server operator. 'default' is fine unless your deployment says otherwise. (Only these approved names are accepted; paths cannot be entered.)</p>
+          <p class="builder-help">Where this tracker's entries are saved — a storage area named by the server operator. 'default' is fine unless your deployment says otherwise. (Only these approved names are accepted; paths cannot be entered.) Changing it re-points FUTURE entries only.</p>
+          </details>
           <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
           <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
           ${Array.isArray(options.parents) && options.parents.length ? `<label><span>Parent form</span><select name="parent"><option value=""${!template.parentId ? ' selected' : ''}>None</option>${options.parents.map((parent) => `<option value="${escapeHtml(parent.templateId)}"${template.parentId === parent.templateId ? ' selected' : ''}>${escapeHtml(parent.title)}</option>`).join('')}</select></label><p class="builder-help">A child form inherits every parent field live. Fields below override a parent field with the same id or extend the form; detaching copies the resolved fields back onto this form (#245).</p>` : ''}
@@ -1302,8 +1304,10 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
         <label><span>ID (optional)</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*"></label>
         <p class="builder-help">Leave the ID blank and it derives from the name (#279).</p>
         ${options.group ? `<input type="hidden" name="group" value="${escapeHtml(options.group.templateId)}"><p class="builder-help">Joining group: <strong>${escapeHtml(options.group.title || options.group.templateId)}</strong></p>` : `<label><span>Kind</span><select name="kind"><option value="">Form</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>`}
+        <details class="builder-advanced"><summary>Advanced</summary>
         <label><span>Entry storage</span><select name="destinationId">${destinationOptions}</select></label>
-        <p class="builder-help">Where entries are saved — a storage area named by the server operator; 'default' is fine. Applies to trackers only (groups hold trackers, not entries).</p>
+        <p class="builder-help">Where entries are saved — a storage area named by the server operator; ${options.group ? 'preset to what this group already uses' : "'default' is fine"}. Applies to trackers only (groups hold trackers, not entries).</p>
+        </details>
         <p class="builder-help">Only deployment-approved destination aliases are available; a filesystem path is never accepted.</p>
         <button class="button-link button-link-primary form-primary-action" type="submit">Create template</button>
       </form>
@@ -2501,7 +2505,19 @@ function createFormsRouter(options) {
           group = {templateId: target.templateId, title: target.title, theme: themeDefaults(target)};
         }
       }
-      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : '', group});
+      // #317: new trackers file where their group already files (majority cabinet,
+      // stamped at creation — deliberately not live-inherited).
+      let destinationId;
+      if (group) {
+        const counts = new Map();
+        for (const candidate of await registry.listTemplates()) {
+          if (candidate.containerId !== group.templateId || candidate.archived === true) continue;
+          const cabinet = candidate.destinationId || 'default';
+          counts.set(cabinet, (counts.get(cabinet) || 0) + 1);
+        }
+        destinationId = [...counts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0];
+      }
+      sendCreateTemplate(res, issueContext(req, res), {kind: req.query.kind === 'container' ? 'container' : '', group, destinationId});
     } catch (error) {
       next(error);
     }

--- a/public/style.css
+++ b/public/style.css
@@ -2869,6 +2869,11 @@ tbody tr:last-child td {
 .builder-layout .builder-field-title { flex-wrap: wrap; row-gap: 0.2rem; }
 .builder-layout .builder-field-title > strong { flex: 0 0 auto; min-width: 3ch; }
 
+/* #317: Advanced disclosure on Configure/create — storage out of the main flow. */
+.form-layout .builder-advanced { margin: 0.4rem 0 0.9rem; font-size: 0.92rem; }
+.form-layout .builder-advanced > summary { cursor: pointer; color: var(--text-soft); }
+.form-layout .builder-advanced[open] > summary { margin-bottom: 0.5rem; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2233,6 +2233,10 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
     // group page carries the New tracker action, preset to the group
     const groupPage = await (await server.request('/forms/gym-fitness', {headers: {Cookie: context.cookie}})).text();
     assert.match(groupPage, /href="\/forms\/new\?group=gym-fitness"/);
+    // #317: create-from-group presets the group's majority cabinet, behind Advanced
+    const advCreate = await (await server.request('/forms/new?group=gym-fitness', {headers: {Cookie: context.cookie}})).text();
+    assert.match(advCreate, /builder-advanced/);
+    assert.match(advCreate, /<option value="default" selected>/);
     // the create page shows the joining note AND the group's bar persists (#281)
     const createPage = await (await server.request('/forms/new?group=gym-fitness', {headers: {Cookie: context.cookie}})).text();
     assert.match(createPage, /Joining group/);


### PR DESCRIPTION
Closes #317. Entry storage behind Advanced on Configure + create; create-from-group presets the members' majority cabinet (stamped at creation — live inheritance deliberately rejected: re-pointing would hide children's history; decision recorded in the planning repo). Suite 203/0.🤖 Generated with [Claude Code](https://claude.com/claude-code)