### PR TITLE
feat(forms): one-checkbox inheritance — uncheck overrides, recheck un-overrides

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -1005,9 +1005,9 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
           ${options.inherited && options.inherited.fields.length ? `<div class="inherited-fields" aria-label="Inherited fields">
-            <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong> — these serve on this tracker live. Uncheck one to leave it off THIS tracker; Override copies it below for editing. Applies with Save draft.</p>
+            <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong>. Checked = the parent's version serves here, live. <strong>Uncheck + Save</strong> = make an editable copy below (that's overriding). Re-check + Save = drop the copy and inherit again. Remove the copy = the field is off this tracker. Clone = an independent copy with its own id.</p>
             <input type="hidden" name="inheritCfg" value="1">
-            ${options.inherited.fields.map((field) => `<div class="inherited-field"><label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(field.id)}"${field.excluded ? '' : ' checked'}><span class="inherited-field-label">${escapeHtml(field.label)}</span></label><span class="inherited-field-meta">${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span><button type="submit" name="_action" value="inherit-override:${escapeHtml(field.id)}" class="inherited-override-btn">Override</button></div>`).join('')}
+            ${options.inherited.fields.map((field) => `<div class="inherited-field"><label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(field.id)}"${field.state === 'inherited' ? ' checked' : ''}><span class="inherited-field-label">${escapeHtml(field.label)}</span></label><span class="inherited-field-meta">${field.state === 'overridden' ? 'overridden below · ' : field.state === 'excluded' ? 'off · ' : ''}${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span><button type="submit" name="_action" value="inherit-clone:${escapeHtml(field.id)}" class="inherited-override-btn">Clone</button></div>`).join('')}
           </div>` : ''}
           ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length, Boolean(options.parentFieldIds && options.parentFieldIds.has(field.id)))).join('')}
         </section>
@@ -2434,8 +2434,11 @@ function createFormsRouter(options) {
         inherited = {
           parentTitle: parent.title,
           parentFieldIds: new Set((parent.fields || []).map((field) => field.id)),
-          fields: (parent.fields || []).filter((field) => field.isDestroyed !== true && !ownIds.has(field.id))
-            .map((field) => ({id: field.id, label: field.label, type: field.type, excluded: excluded.has(field.id)})),
+          fields: (parent.fields || []).filter((field) => field.isDestroyed !== true)
+            .map((field) => ({
+              id: field.id, label: field.label, type: field.type,
+              state: ownIds.has(field.id) ? 'overridden' : excluded.has(field.id) ? 'excluded' : 'inherited',
+            })),
         };
       }
     }
@@ -2746,19 +2749,47 @@ function createFormsRouter(options) {
         const parent = await registry.getTemplate(record.draft.parentId);
         if (parent) {
           const action = postedString(req.body, '_action', 'save');
-          const overrideMatch = /^inherit-override:([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
-          if (overrideMatch) {
-            const sourceField = (parent.fields || []).find((field) => field.id === overrideMatch[1]);
-            if (sourceField && !(patch.fields || []).some((field) => field.id === sourceField.id)) {
-              patch.fields = [...(patch.fields || []), structuredClone(sourceField)];
+          const cloneMatch = /^inherit-clone:([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
+          if (cloneMatch) {
+            // #319: Clone = an independent, tracker-specific copy with its own id.
+            const sourceField = (parent.fields || []).find((field) => field.id === cloneMatch[1]);
+            if (sourceField) {
+              let cloneId;
+              const taken = new Set([...(parent.fields || []), ...(patch.fields || [])].map((field) => field.id));
+              for (let suffix = 2; !cloneId || taken.has(cloneId); suffix += 1) {
+                cloneId = `${sourceField.id}-copy${suffix > 2 ? `-${suffix}` : ''}`.slice(0, 64);
+                if (!taken.has(cloneId)) break;
+              }
+              patch.fields = [...(patch.fields || []), {...structuredClone(sourceField), id: cloneId, label: `${sourceField.label} (copy)`}];
             }
           }
           if (Object.prototype.hasOwnProperty.call(req.body, 'inheritCfg')) {
+            // #319: the one-checkbox state machine. Checked = inherit (dropping any
+            // own copy — the checkbox wins over edits). Unchecked with no copy =
+            // create the editable copy (that IS overriding). Removing the copy
+            // (isDestroyed on an override) = the field goes off via inherit.exclude.
             const included = new Set([].concat(req.body.inheritInclude || []));
-            const ownIds = new Set((patch.fields || []).map((field) => field.id));
-            const exclude = (parent.fields || [])
-              .filter((field) => field.isDestroyed !== true && !ownIds.has(field.id) && !included.has(field.id))
-              .map((field) => field.id);
+            const currentlyExcluded = new Set((record.draft.inherit && record.draft.inherit.exclude) || []);
+            const parentById = new Map((parent.fields || []).filter((field) => field.isDestroyed !== true).map((field) => [field.id, field]));
+            let fields = patch.fields || [];
+            const exclude = [];
+            for (const [fieldId, parentField] of parentById) {
+              const own = fields.find((field) => field.id === fieldId);
+              if (included.has(fieldId)) {
+                if (own) fields = fields.filter((field) => field.id !== fieldId); // un-override
+                continue;
+              }
+              if (own) {
+                if (own.isDestroyed === true) {
+                  fields = fields.filter((field) => field.id !== fieldId); // off, cleanly
+                  exclude.push(fieldId);
+                }
+                continue; // keep the override
+              }
+              if (currentlyExcluded.has(fieldId)) { exclude.push(fieldId); continue; } // stays off
+              fields = [...fields, structuredClone(parentField)]; // uncheck = override copy
+            }
+            patch.fields = fields;
             patch.inherit = exclude.length ? {exclude} : null;
           }
         }

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2156,7 +2156,8 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     assert.match(childConfigure, /inherited-fields/);
     assert.match(childConfigure, /Inherited from <strong>Gym Session Entry<\/strong>/);
     assert.match(childConfigure, /Warmed up/);
-    assert.doesNotMatch(childConfigure, /inherited-field-label">Lift</);
+    // #319: overridden parent fields stay listed — unchecked, noted
+    assert.match(childConfigure, /inherited-field-label">Lift</);
     // #310: the own override field says so
     assert.match(childConfigure, /builder-override-marker">Overrides inherited</);
     assert.match(childConfigure, /Entry storage/);
@@ -2180,8 +2181,54 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     // configure shows it unchecked; GUI one-tap override copies a parent field down
     const exConfigure = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
     assert.match(exConfigure, /name="inheritInclude" value="notes"(?! checked)/);
+    assert.match(exConfigure, /off · long-text · notes/);
     assert.match(exConfigure, /name="inheritInclude" value="warmup-done" checked/);
-    assert.match(exConfigure, /inherit-override:warmup-done/);
+    assert.match(exConfigure, /inherit-clone:warmup-done/);
+    assert.doesNotMatch(exConfigure, /inherit-override:/);
+    // overridden rows show unchecked with the note (lift is bench-day's override)
+    assert.match(exConfigure, /name="inheritInclude" value="lift"(?! checked)/);
+    assert.match(exConfigure, /overridden below · select · lift/);
+
+    // #319: the one-checkbox flow via the GUI save endpoint —
+    // uncheck an inherited field -> an editable copy appears (override)
+    const {JSDOM: JSDOM319} = require('jsdom');
+    const guiSave = async (mutate) => {
+      const pageHtml = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
+      const dom = new JSDOM319(pageHtml);
+      const form = dom.window.document.querySelector('.builder-form');
+      const values = new URLSearchParams();
+      for (const control of form.querySelectorAll('input, select, textarea')) {
+        if (!control.name || control.disabled) continue;
+        if (control.type === 'checkbox' && !control.checked) continue;
+        values.append(control.name, control.value);
+      }
+      values.set('_action', 'save');
+      mutate(values);
+      return server.request('/forms/bench-day/configure', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+        body: values.toString(),
+      });
+    };
+    // uncheck warmup-done -> override copy materializes
+    let saveResp = await guiSave((values) => {
+      const keep = values.getAll('inheritInclude').filter((id) => id !== 'warmup-done');
+      values.delete('inheritInclude');
+      for (const id of keep) values.append('inheritInclude', id);
+    });
+    assert.equal(saveResp.status, 200);
+    let draftNow = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
+    assert.ok(draftNow.fields.some((field) => field.id === 'warmup-done'), 'uncheck must create the override copy');
+    // re-check warmup-done -> un-override (copy dropped, inheritance resumes)
+    saveResp = await guiSave((values) => values.append('inheritInclude', 'warmup-done'));
+    assert.equal(saveResp.status, 200);
+    draftNow = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
+    assert.ok(!draftNow.fields.some((field) => field.id === 'warmup-done'), 're-check must drop the override copy');
+    // Clone -> independent copy with its own id
+    saveResp = await guiSave((values) => values.set('_action', 'inherit-clone:warmup-done'));
+    assert.equal(saveResp.status, 200);
+    draftNow = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
+    assert.ok(draftNow.fields.some((field) => field.id === 'warmup-done-copy'), 'clone must add an independent field');
     // #313: theme inheritance — parent presentation flows to a themeless child page
     const pRev = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
     assert.equal((await patch('/api/forms/templates/gym-session-entry', {revision: pRev, presentation: {theme: 'nord', themeMode: 'dark'}})).status, 200);
@@ -2202,7 +2249,8 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     const solo = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
     assert.equal(solo.parentId, undefined);
     assert.ok(solo.fields.some((field) => field.id === 'warmup-done'), 'detach did not materialize inherited fields');
-    assert.equal(solo.fields.at(-1).id, 'spotter');
+    assert.ok(solo.fields.some((field) => field.id === 'spotter'));
+    assert.ok(solo.fields.some((field) => field.id === 'warmup-done-copy'), 'cloned field must survive detach');
   } finally {
     await cleanup(fixture, server);
   }


### PR DESCRIPTION
Closes #319. Operator: "overriding should really just be done by unchecking it... should be able to un-override... COULD clone a field too."

One checkbox, four verbs:
- **Checked** = inherit live · **Uncheck+Save** = editable copy materializes (override) · **Re-check+Save** = copy drops, inheritance resumes · **Remove the copy** = field off this tracker (converted to `inherit.exclude`, re-checkable — no destroyed-stub pollution).
- **Clone** per row = independent copy, fresh id, "(copy)" label.
- Panel lists ALL parent fields with state (inheriting / overridden below / off). Grammar unchanged; the save-time state machine lives in the configure POST. Supersedes #315's Override-button shape (to be narrated there).

**Test gates:** full GUI round-trips via the real save endpoint — uncheck→copy exists, recheck→copy gone, clone→`warmup-done-copy`, off-state rendering; detach keeps cloned fields. Suite 203/0; validate:editable 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
