### PR TITLE
feat(forms): orthogonal inheritance controls; pinned fields stamp

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -276,6 +276,12 @@ function renderControl(field, values, describedBy = [], invalid = false, options
   const controlId = options.controlId || `field-${field.id}`;
   const common = `id="${escapeHtml(controlId)}" name="${escapeHtml(field.id)}"${field.required ? ' required' : ''}${invalid ? ' aria-invalid="true"' : ''}${description}`;
   if (field.type === 'select') {
+    const liveOptions = (field.options || []).filter((option) => option.isDestroyed !== true);
+    if (liveOptions.length === 1) {
+      // #321: a pinned field is identity, not a question — stamp it, don't ask it.
+      const only = liveOptions[0];
+      return `<div class="field-pinned" id="${escapeHtml(controlId)}">${escapeHtml(only.label)}</div><input type="hidden" name="${escapeHtml(field.id)}" value="${escapeHtml(only.id)}">`;
+    }
     return `<select ${common}><option value="">Select…</option>${renderOptions(field, value, false)}</select>`;
   }
   if (field.type === 'multi-select') {
@@ -1005,9 +1011,11 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
           ${options.inherited && options.inherited.fields.length ? `<div class="inherited-fields" aria-label="Inherited fields">
-            <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong>. Checked = the parent's version serves here, live. <strong>Uncheck + Save</strong> = make an editable copy below (that's overriding). Re-check + Save = drop the copy and inherit again. Remove the copy = the field is off this tracker. Clone = an independent copy with its own id.</p>
+            <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong>. Checked = on (the parent's version serves here, live); unchecked = off for this tracker. <strong>Copy to this tracker</strong> makes a local editable version below; remove the copy to go back to inheriting. Applies with Save draft.</p>
             <input type="hidden" name="inheritCfg" value="1">
-            ${options.inherited.fields.map((field) => `<div class="inherited-field"><label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(field.id)}"${field.state === 'inherited' ? ' checked' : ''}><span class="inherited-field-label">${escapeHtml(field.label)}</span></label><span class="inherited-field-meta">${field.state === 'overridden' ? 'overridden below · ' : field.state === 'excluded' ? 'off · ' : ''}${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span><button type="submit" name="_action" value="inherit-clone:${escapeHtml(field.id)}" class="inherited-override-btn">Clone</button></div>`).join('')}
+            ${options.inherited.fields.map((field) => `<div class="inherited-field">${field.state === 'overridden'
+              ? `<span class="inherited-field-pick inherited-field-local"><span class="inherited-field-label">${escapeHtml(field.label)}</span></span><span class="inherited-field-meta">local copy below · ${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span>`
+              : `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(field.id)}"${field.state === 'inherited' ? ' checked' : ''}><span class="inherited-field-label">${escapeHtml(field.label)}</span></label><span class="inherited-field-meta">${field.state === 'excluded' ? 'off · ' : ''}${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span><button type="submit" name="_action" value="inherit-copy:${escapeHtml(field.id)}" class="inherited-override-btn">Copy to this tracker</button>`}</div>`).join('')}
           </div>` : ''}
           ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length, Boolean(options.parentFieldIds && options.parentFieldIds.has(field.id)))).join('')}
         </section>
@@ -2749,45 +2757,33 @@ function createFormsRouter(options) {
         const parent = await registry.getTemplate(record.draft.parentId);
         if (parent) {
           const action = postedString(req.body, '_action', 'save');
-          const cloneMatch = /^inherit-clone:([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
-          if (cloneMatch) {
-            // #319: Clone = an independent, tracker-specific copy with its own id.
-            const sourceField = (parent.fields || []).find((field) => field.id === cloneMatch[1]);
-            if (sourceField) {
-              let cloneId;
-              const taken = new Set([...(parent.fields || []), ...(patch.fields || [])].map((field) => field.id));
-              for (let suffix = 2; !cloneId || taken.has(cloneId); suffix += 1) {
-                cloneId = `${sourceField.id}-copy${suffix > 2 ? `-${suffix}` : ''}`.slice(0, 64);
-                if (!taken.has(cloneId)) break;
-              }
-              patch.fields = [...(patch.fields || []), {...structuredClone(sourceField), id: cloneId, label: `${sourceField.label} (copy)`}];
+          const copyMatch = /^inherit-copy:([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
+          if (copyMatch) {
+            // #322: Copy to this tracker — a same-id local copy; the copy governs
+            // until removed (entry data keeps the same field id).
+            const sourceField = (parent.fields || []).find((field) => field.id === copyMatch[1]);
+            if (sourceField && !(patch.fields || []).some((field) => field.id === sourceField.id)) {
+              patch.fields = [...(patch.fields || []), structuredClone(sourceField)];
             }
           }
           if (Object.prototype.hasOwnProperty.call(req.body, 'inheritCfg')) {
-            // #319: the one-checkbox state machine. Checked = inherit (dropping any
-            // own copy — the checkbox wins over edits). Unchecked with no copy =
-            // create the editable copy (that IS overriding). Removing the copy
-            // (isDestroyed on an override) = the field goes off via inherit.exclude.
+            // #322: orthogonal model — the checkbox is ON/OFF only; a local copy
+            // governs its field (no checkbox rendered); removing the copy
+            // (isDestroyed) deletes it and resumes inheritance.
             const included = new Set([].concat(req.body.inheritInclude || []));
-            const currentlyExcluded = new Set((record.draft.inherit && record.draft.inherit.exclude) || []);
             const parentById = new Map((parent.fields || []).filter((field) => field.isDestroyed !== true).map((field) => [field.id, field]));
             let fields = patch.fields || [];
             const exclude = [];
-            for (const [fieldId, parentField] of parentById) {
+            const justCopied = copyMatch ? copyMatch[1] : null;
+            for (const [fieldId] of parentById) {
               const own = fields.find((field) => field.id === fieldId);
-              if (included.has(fieldId)) {
-                if (own) fields = fields.filter((field) => field.id !== fieldId); // un-override
-                continue;
-              }
               if (own) {
-                if (own.isDestroyed === true) {
-                  fields = fields.filter((field) => field.id !== fieldId); // off, cleanly
-                  exclude.push(fieldId);
+                if (own.isDestroyed === true && fieldId !== justCopied) {
+                  fields = fields.filter((field) => field.id !== fieldId); // back to inheriting
                 }
-                continue; // keep the override
+                continue; // the local copy governs
               }
-              if (currentlyExcluded.has(fieldId)) { exclude.push(fieldId); continue; } // stays off
-              fields = [...fields, structuredClone(parentField)]; // uncheck = override copy
+              if (!included.has(fieldId)) exclude.push(fieldId); // unchecked = off
             }
             patch.fields = fields;
             patch.inherit = exclude.length ? {exclude} : null;

--- a/public/style.css
+++ b/public/style.css
@@ -2874,6 +2874,11 @@ tbody tr:last-child td {
 .form-layout .builder-advanced > summary { cursor: pointer; color: var(--text-soft); }
 .form-layout .builder-advanced[open] > summary { margin-bottom: 0.5rem; }
 
+/* #321: pinned fields stamp their value instead of asking. */
+.form-layout .field-pinned { padding: 0.65rem 0.9rem; border: 1px solid var(--border); border-radius: 0.55rem; background: var(--bg-elev); color: var(--text-soft); }
+/* #322: rows with a local copy show a label, not a checkbox. */
+.form-layout .inherited-field-local { opacity: 0.75; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2125,6 +2125,9 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     const page = await (await server.request('/forms/bench-day', {headers: {Cookie: context.cookie}})).text();
     assert.match(page, /Session date|session-date/);
     assert.match(page, /Spotter/);
+    // #321: the pinned single-option select stamps instead of asking
+    assert.match(page, /field-pinned/);
+    assert.match(page, /type="hidden" name="lift" value="bench"/);
     const submitted = await server.request('/forms/bench-day', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
@@ -2183,11 +2186,11 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     assert.match(exConfigure, /name="inheritInclude" value="notes"(?! checked)/);
     assert.match(exConfigure, /off · long-text · notes/);
     assert.match(exConfigure, /name="inheritInclude" value="warmup-done" checked/);
-    assert.match(exConfigure, /inherit-clone:warmup-done/);
-    assert.doesNotMatch(exConfigure, /inherit-override:/);
-    // overridden rows show unchecked with the note (lift is bench-day's override)
-    assert.match(exConfigure, /name="inheritInclude" value="lift"(?! checked)/);
-    assert.match(exConfigure, /overridden below · select · lift/);
+    assert.match(exConfigure, /inherit-copy:warmup-done/);
+    assert.doesNotMatch(exConfigure, /inherit-override:|inherit-clone:/);
+    // rows with a local copy show no checkbox — the copy governs (lift is bench-day's)
+    assert.doesNotMatch(exConfigure, /name="inheritInclude" value="lift"/);
+    assert.match(exConfigure, /local copy below · select · lift/);
 
     // #319: the one-checkbox flow via the GUI save endpoint —
     // uncheck an inherited field -> an editable copy appears (override)
@@ -2210,7 +2213,7 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
         body: values.toString(),
       });
     };
-    // uncheck warmup-done -> override copy materializes
+    // #322: uncheck = OFF (no copy materializes)
     let saveResp = await guiSave((values) => {
       const keep = values.getAll('inheritInclude').filter((id) => id !== 'warmup-done');
       values.delete('inheritInclude');
@@ -2218,17 +2221,23 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     });
     assert.equal(saveResp.status, 200);
     let draftNow = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
-    assert.ok(draftNow.fields.some((field) => field.id === 'warmup-done'), 'uncheck must create the override copy');
-    // re-check warmup-done -> un-override (copy dropped, inheritance resumes)
+    assert.ok(!draftNow.fields.some((field) => field.id === 'warmup-done'), 'uncheck must NOT create a copy');
+    assert.ok((draftNow.inherit.exclude || []).includes('warmup-done'), 'uncheck must exclude');
+    // re-check = back on
     saveResp = await guiSave((values) => values.append('inheritInclude', 'warmup-done'));
     assert.equal(saveResp.status, 200);
     draftNow = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
-    assert.ok(!draftNow.fields.some((field) => field.id === 'warmup-done'), 're-check must drop the override copy');
-    // Clone -> independent copy with its own id
-    saveResp = await guiSave((values) => values.set('_action', 'inherit-clone:warmup-done'));
+    assert.ok(!((draftNow.inherit && draftNow.inherit.exclude) || []).includes('warmup-done'), 're-check must clear the exclusion');
+    // Copy to this tracker = same-id local copy
+    saveResp = await guiSave((values) => values.set('_action', 'inherit-copy:warmup-done'));
     assert.equal(saveResp.status, 200);
     draftNow = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
-    assert.ok(draftNow.fields.some((field) => field.id === 'warmup-done-copy'), 'clone must add an independent field');
+    assert.ok(draftNow.fields.some((field) => field.id === 'warmup-done'), 'copy must create the same-id local field');
+    // removing the copy resumes inheritance (isDestroyed converts to deletion)
+    saveResp = await guiSave((values) => values.set('field.' + draftNow.fields.findIndex((field) => field.id === 'warmup-done') + '.isDestroyed', 'true'));
+    assert.equal(saveResp.status, 200);
+    draftNow = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
+    assert.ok(!draftNow.fields.some((field) => field.id === 'warmup-done'), 'removing the copy must resume inheritance');
     // #313: theme inheritance — parent presentation flows to a themeless child page
     const pRev = JSON.parse(await (await server.request('/api/forms/templates/gym-session-entry')).text()).template.revision;
     assert.equal((await patch('/api/forms/templates/gym-session-entry', {revision: pRev, presentation: {theme: 'nord', themeMode: 'dark'}})).status, 200);
@@ -2250,7 +2259,6 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     assert.equal(solo.parentId, undefined);
     assert.ok(solo.fields.some((field) => field.id === 'warmup-done'), 'detach did not materialize inherited fields');
     assert.ok(solo.fields.some((field) => field.id === 'spotter'));
-    assert.ok(solo.fields.some((field) => field.id === 'warmup-done-copy'), 'cloned field must survive detach');
   } finally {
     await cleanup(fixture, server);
   }


### PR DESCRIPTION
Closes #321. Closes #322.

**#322 — orthogonal inheritance controls** (operator refinement of #319 within the hour): the checkbox is ON/OFF only (unchecked = `inherit.exclude`, nothing materializes); **Copy to this tracker** makes the same-id local copy (entry-data continuity); a row with a copy shows "local copy below" instead of a checkbox; removing the copy resumes inheritance. The #320 uncheck-materializes shape and new-id Clone retire — narrated on #319.

**#321 — pinned fields stamp**: a select with exactly one live option renders as static text + hidden input. On machine trackers the Machine dropdown-of-one disappears from the logging flow; the entry still carries the value (shared cabinet stays self-describing; the master's real select unchanged).

**Test gates:** GUI round-trips for all four verbs (uncheck→excluded, recheck→on, copy→same-id local, remove-copy→inherits again); pinned stamp + hidden input on the child form. Suite 203/0; validate:editable 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
