### PR TITLE
feat(forms): unified fields table — order, source, theme rows

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -864,7 +864,7 @@ function builderOption(option, fieldIndex, optionIndex, optionCount) {
   </div>`;
 }
 
-function builderField(field, fieldIndex, fieldCount, isOverride = false) {
+function builderField(field, fieldIndex, fieldCount, isOverride = false, extras = null) {
   const prefix = `field.${fieldIndex}`;
   const constraints = field.constraints || {};
   const selection = field.type === 'select' || field.type === 'multi-select';
@@ -886,7 +886,7 @@ function builderField(field, fieldIndex, fieldCount, isOverride = false) {
     }
     return inputs.join('');
   };
-  const summary = `<span class="builder-field-title"><strong>${escapeHtml(field.label)}</strong><span class="builder-type-badge">${escapeHtml(fieldTypeLabel(field.type))}</span>${isOverride ? '<span class="builder-marker builder-override-marker">Overrides inherited</span>' : ''}</span>
+  const summary = `<span class="builder-field-title"><strong>${escapeHtml(field.label)}</strong><span class="builder-type-badge">${escapeHtml(fieldTypeLabel(field.type))}</span>${isOverride ? '<span class="builder-marker builder-override-marker">Overrides inherited</span>' : ''}${extras ? `<span class="field-source">${escapeHtml(extras.sourceLabel)}</span>${extras.moveButtons}` : ''}</span>
       <span class="builder-field-markers">${field.required ? '<span class="builder-marker builder-required-marker">Required</span>' : ''}${field.showInList ? '<span class="builder-marker builder-list-marker">In list</span>' : ''}${field.isDestroyed ? '<span class="builder-marker builder-removed-marker">Removed</span>' : ''}</span>`;
   if (field.isDestroyed === true) {
     return `<div class="builder-field builder-field-removed">
@@ -975,6 +975,13 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   const themeModeOptions = [['', 'Follow the viewer'], ['dark', 'Always dark'], ['light', 'Always light']].map(
     ([value, label]) => `<option value="${value}"${currentThemeMode === value ? ' selected' : ''}>${label}</option>`
   ).join('');
+  // #324: on children the empty value means "inherit" (own -> parent -> group -> viewer)
+  const childThemeOptions = [{slug: '', label: 'Inherited'}, ...getThemeList()].map((theme) =>
+    `<option value="${escapeHtml(theme.slug)}"${currentTheme === theme.slug ? ' selected' : ''}>${escapeHtml(theme.label)}</option>`
+  ).join('');
+  const childThemeModeOptions = [['', 'Inherited'], ['dark', 'Always dark'], ['light', 'Always light']].map(
+    ([value, label]) => `<option value="${value}"${currentThemeMode === value ? ' selected' : ''}>${label}</option>`
+  ).join('');
   const publishedText = published
     ? `Version ${published.templateVersion}, from draft revision ${published.sourceRevision}`
     : 'Not published yet';
@@ -1001,8 +1008,8 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           <label><span>Entry storage</span><select name="destinationId" required>${destinationOptions}</select></label>
           <p class="builder-help">Where this tracker's entries are saved — a storage area named by the server operator. 'default' is fine unless your deployment says otherwise. (Only these approved names are accepted; paths cannot be entered.) Changing it re-points FUTURE entries only.</p>
           </details>
-          <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
-          <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
+          ${options.fieldsTable ? '' : `<label><span>Theme</span><select name="theme">${themeOptions}</select></label>
+          <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>`}
           ${Array.isArray(options.parents) && options.parents.length ? `<label><span>Parent form</span><select name="parent"><option value=""${!template.parentId ? ' selected' : ''}>None</option>${options.parents.map((parent) => `<option value="${escapeHtml(parent.templateId)}"${template.parentId === parent.templateId ? ' selected' : ''}>${escapeHtml(parent.title)}</option>`).join('')}</select></label><p class="builder-help">A child form inherits every parent field live. Fields below override a parent field with the same id or extend the form; detaching copies the resolved fields back onto this form (#245).</p>` : ''}
           ${Array.isArray(options.children) && options.children.length ? `<p class="builder-help builder-parent-note">Parent of ${options.children.length} form${options.children.length === 1 ? '' : 's'}: ${options.children.map((child) => escapeHtml(child.title)).join(', ')}. Edits here flow to them live.</p>` : ''}
           ${Array.isArray(options.containers) && options.containers.length ? `<label><span>Group</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${options.containers.map((container) => `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label><p class="builder-help">Groups hold related trackers and give each member back-and-sibling navigation.</p>` : ''}
@@ -1010,14 +1017,22 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
         </section>
         <section class="builder-fields" aria-labelledby="builder-fields-heading">
           <div class="builder-section-heading"><div><h2 id="builder-fields-heading">Fields</h2><p class="builder-help">Tap a field to edit its settings.</p></div><button type="submit" name="_action" value="field-add">Add field</button></div>
-          ${options.inherited && options.inherited.fields.length ? `<div class="inherited-fields" aria-label="Inherited fields">
-            <p class="builder-help">Inherited from <strong>${escapeHtml(options.inherited.parentTitle)}</strong>. Checked = on (the parent's version serves here, live); unchecked = off for this tracker. <strong>Copy to this tracker</strong> makes a local editable version below; remove the copy to go back to inheriting. Applies with Save draft.</p>
+          ${options.fieldsTable ? `<div class="fields-table" aria-label="Fields in serving order">
+            <p class="builder-help">Everything this tracker serves, in order. Source says whose definition it is — <strong>${escapeHtml(options.inherited.parentTitle)}</strong> (live) or this tracker. Checked = on; Copy makes a local version; ↑↓ reorder. Applies with Save draft.</p>
             <input type="hidden" name="inheritCfg" value="1">
-            ${options.inherited.fields.map((field) => `<div class="inherited-field">${field.state === 'overridden'
-              ? `<span class="inherited-field-pick inherited-field-local"><span class="inherited-field-label">${escapeHtml(field.label)}</span></span><span class="inherited-field-meta">local copy below · ${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span>`
-              : `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(field.id)}"${field.state === 'inherited' ? ' checked' : ''}><span class="inherited-field-label">${escapeHtml(field.label)}</span></label><span class="inherited-field-meta">${field.state === 'excluded' ? 'off · ' : ''}${escapeHtml(field.type)} · ${escapeHtml(field.id)}</span><button type="submit" name="_action" value="inherit-copy:${escapeHtml(field.id)}" class="inherited-override-btn">Copy to this tracker</button>`}</div>`).join('')}
-          </div>` : ''}
-          ${(template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length, Boolean(options.parentFieldIds && options.parentFieldIds.has(field.id)))).join('')}
+            <div class="fields-table-head"><span>Field</span><span>Source</span><span>On</span><span>Move</span></div>
+            ${options.fieldsTable.map((row) => {
+              const move = `<span class="field-move"><button type="submit" name="_action" value="resolved-up:${escapeHtml(row.field.id)}" aria-label="Move up">↑</button><button type="submit" name="_action" value="resolved-down:${escapeHtml(row.field.id)}" aria-label="Move down">↓</button></span>`;
+              if (row.kind === 'local') {
+                return builderField(row.field, row.ownIndex, (template.fields || []).length, row.isOverride, {sourceLabel: 'this tracker', moveButtons: move});
+              }
+              return `<div class="inherited-field fields-table-row">${row.state === 'excluded'
+                ? `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}"><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">off · ${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span>`
+                : `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}" checked><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span><button type="submit" name="_action" value="inherit-copy:${escapeHtml(row.field.id)}" class="inherited-override-btn">Copy</button>${move}`}</div>`;
+            }).join('')}
+            <div class="fields-table-row fields-table-theme"><span class="inherited-field-label">Theme</span><select name="theme">${childThemeOptions}</select><span class="field-source">${escapeHtml(options.themeSource)}</span></div>
+            <div class="fields-table-row fields-table-theme"><span class="inherited-field-label">Theme mode</span><select name="themeMode">${childThemeModeOptions}</select><span class="field-source">${escapeHtml(options.themeModeSource)}</span></div>
+          </div>` : (template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length, false)).join('')}
         </section>
         <details class="builder-related">
           <summary>Related trackers</summary>
@@ -2432,8 +2447,11 @@ function createFormsRouter(options) {
       .filter((candidate) => candidate.draft.parentId === record.draft.templateId && candidate.state !== 'archived')
       .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title}))
       .sort((left, right) => String(left.title).localeCompare(String(right.title)));
-    // #307: a child's Configure shows what it inherits (read-only)
+    // #307/#324: a child's Configure gets the unified fields table
     let inherited = null;
+    let fieldsTable = null;
+    let themeSource = '';
+    let themeModeSource = '';
     if (record.draft.parentId) {
       const parent = await registry.getTemplate(record.draft.parentId);
       if (parent) {
@@ -2442,12 +2460,30 @@ function createFormsRouter(options) {
         inherited = {
           parentTitle: parent.title,
           parentFieldIds: new Set((parent.fields || []).map((field) => field.id)),
-          fields: (parent.fields || []).filter((field) => field.isDestroyed !== true)
-            .map((field) => ({
-              id: field.id, label: field.label, type: field.type,
-              state: ownIds.has(field.id) ? 'overridden' : excluded.has(field.id) ? 'excluded' : 'inherited',
-            })),
         };
+        // #324: the unified table — resolved serving order, then excluded rows.
+        const resolved = await registry.getTemplate(record.draft.templateId);
+        const ownIndexById = new Map((record.draft.fields || []).map((field, index) => [field.id, index]));
+        fieldsTable = [
+          ...(resolved.fields || []).filter((field) => field.isDestroyed !== true).map((field) => (
+            ownIndexById.has(field.id)
+              ? {kind: 'local', field: (record.draft.fields || [])[ownIndexById.get(field.id)], ownIndex: ownIndexById.get(field.id), isOverride: inherited.parentFieldIds.has(field.id)}
+              : {kind: 'inherited', field, state: 'inherited'}
+          )),
+          ...(parent.fields || []).filter((field) => field.isDestroyed !== true && excluded.has(field.id))
+            .map((field) => ({kind: 'inherited', field, state: 'excluded'})),
+        ];
+        const ownTheme = (record.draft.presentation && record.draft.presentation.theme) || '';
+        const ownMode = (record.draft.presentation && record.draft.presentation.themeMode) || '';
+        const parentTheme = themeDefaults(parent);
+        const groupForTheme = await containerCrumbFor(record.draft);
+        const groupTheme = groupForTheme ? themeDefaults(groupForTheme) : {};
+        themeSource = ownTheme ? 'this tracker'
+          : parentTheme.scheme ? `inherited from ${parent.title}`
+          : groupTheme.scheme ? `inherited from ${groupForTheme.title}` : 'viewer choice';
+        themeModeSource = ownMode ? 'this tracker'
+          : parentTheme.mode ? `inherited from ${parent.title}`
+          : groupTheme.mode ? `inherited from ${groupForTheme.title}` : 'viewer choice';
       }
     }
     // #300: every group with its active trackers (+ Ungrouped) for the related picker
@@ -2475,6 +2511,9 @@ function createFormsRouter(options) {
       children,
       relatedChoices,
       inherited,
+      fieldsTable,
+      themeSource,
+      themeModeSource,
       parentFieldIds: inherited ? inherited.parentFieldIds : null,
       relatedForms: {container: await containerCrumbFor(record.draft), related: []},
       ...responseOptions,
@@ -2786,7 +2825,23 @@ function createFormsRouter(options) {
               if (!included.has(fieldId)) exclude.push(fieldId); // unchecked = off
             }
             patch.fields = fields;
-            patch.inherit = exclude.length ? {exclude} : null;
+            const storedOrder = (record.draft.inherit && record.draft.inherit.order) || null;
+            patch.inherit = (exclude.length || storedOrder)
+              ? {...(exclude.length ? {exclude} : {}), ...(storedOrder ? {order: storedOrder} : {})}
+              : null;
+          }
+          const moveMatch = /^resolved-(up|down):([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
+          if (moveMatch) {
+            // #324: swap within the current serving order; store the full list.
+            const resolvedNow = await registry.getTemplate(record.draft.templateId);
+            const ids = (resolvedNow.fields || []).filter((field) => field.isDestroyed !== true).map((field) => field.id);
+            const at = ids.indexOf(moveMatch[2]);
+            const to = moveMatch[1] === 'up' ? at - 1 : at + 1;
+            if (at !== -1 && to >= 0 && to < ids.length) {
+              [ids[at], ids[to]] = [ids[to], ids[at]];
+              const base = patch.inherit !== undefined ? patch.inherit : (record.draft.inherit || null);
+              patch.inherit = {...(base && base.exclude && base.exclude.length ? {exclude: base.exclude} : {}), order: ids};
+            }
           }
         }
       }

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -454,7 +454,21 @@ function validateTemplate(doc) {
       if (!own(doc, 'parentId')) addError(errors, 'inherit', 'requires parentId');
       if (!isRecord(doc.inherit)) addError(errors, 'inherit', 'must be an object');
       else {
-        rejectUnknownKeys(doc.inherit, new Set(['exclude']), 'inherit', errors);
+        rejectUnknownKeys(doc.inherit, new Set(['exclude', 'order']), 'inherit', errors);
+        if (own(doc.inherit, 'order')) {
+          // #324: serve-time order over the RESOLVED list — listed ids first,
+          // unlisted follow naturally. Soft: unknown ids are ignored at render.
+          if (!Array.isArray(doc.inherit.order) || doc.inherit.order.length > 200) {
+            addError(errors, 'inherit.order', 'must be an array of at most 200 field IDs');
+          } else {
+            const seenOrder = new Set();
+            doc.inherit.order.forEach((id, index) => {
+              validateId(id, `inherit.order[${index}]`, errors);
+              if (seenOrder.has(id)) addError(errors, `inherit.order[${index}]`, 'must not repeat');
+              seenOrder.add(id);
+            });
+          }
+        }
         if (own(doc.inherit, 'exclude')) {
           if (!Array.isArray(doc.inherit.exclude) || doc.inherit.exclude.length > 200) {
             addError(errors, 'inherit.exclude', 'must be an array of at most 200 field IDs');

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -29,6 +29,20 @@ function resolveInheritedFields(parentFields, childFields, inherit) {
     return field;
   });
   for (const field of own) if (!used.has(field.id)) merged.push(field);
+  // #324: inherit.order reorders the RESOLVED list — listed ids first in the
+  // given order, everything else follows in natural order.
+  const order = (inherit && Array.isArray(inherit.order)) ? inherit.order : null;
+  if (order && order.length) {
+    const rank = new Map(order.map((id, index) => [id, index]));
+    return merged
+      .map((field, index) => ({field, index}))
+      .sort((a, b) => {
+        const ra = rank.has(a.field.id) ? rank.get(a.field.id) : order.length + a.index;
+        const rb = rank.has(b.field.id) ? rank.get(b.field.id) : order.length + b.index;
+        return ra - rb;
+      })
+      .map((entry) => entry.field);
+  }
   return merged;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -2879,6 +2879,16 @@ tbody tr:last-child td {
 /* #322: rows with a local copy show a label, not a checkbox. */
 .form-layout .inherited-field-local { opacity: 0.75; }
 
+/* #324: unified fields table — serving order, source column, move controls. */
+.form-layout .fields-table { display: grid; gap: 0.45rem; }
+.form-layout .fields-table-head { display: flex; gap: 0.8rem; justify-content: space-between; font-size: 0.72rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-soft); padding: 0 0.2rem; }
+.form-layout .fields-table-row { flex-wrap: wrap; row-gap: 0.3rem; }
+.form-layout .field-source { font-size: 0.75rem; color: var(--text-soft); border: 1px solid var(--border); border-radius: 999px; padding: 0.08rem 0.5rem; white-space: nowrap; }
+.form-layout .field-move { display: inline-flex; gap: 0.25rem; }
+.form-layout .field-move button { padding: 0.15rem 0.5rem; font-size: 0.8rem; }
+.form-layout .fields-table-theme { display: flex; align-items: center; gap: 0.8rem; border-top: 1px dashed var(--border); padding-top: 0.55rem; }
+.form-layout .fields-table-theme select { flex: 1; min-width: 8rem; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2156,11 +2156,15 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
 
     // #307: a child's Configure shows the inherited schema read-only
     const childConfigure = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
-    assert.match(childConfigure, /inherited-fields/);
-    assert.match(childConfigure, /Inherited from <strong>Gym Session Entry<\/strong>/);
+    // #324: the unified fields table — serving order, source column, theme rows
+    assert.match(childConfigure, /fields-table/);
+    assert.match(childConfigure, /fields-table-head/);
     assert.match(childConfigure, /Warmed up/);
-    // #319: overridden parent fields stay listed — unchecked, noted
-    assert.match(childConfigure, /inherited-field-label">Lift</);
+    assert.match(childConfigure, /field-source">Gym Session Entry</);
+    assert.match(childConfigure, /field-source">this tracker</);
+    assert.match(childConfigure, /resolved-up:warmup-done/);
+    assert.match(childConfigure, /fields-table-theme/);
+    assert.match(childConfigure, /field-source">inherited from Gym Session Entry<|field-source">viewer choice</);
     // #310: the own override field says so
     assert.match(childConfigure, /builder-override-marker">Overrides inherited</);
     assert.match(childConfigure, /Entry storage/);
@@ -2184,13 +2188,12 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     // configure shows it unchecked; GUI one-tap override copies a parent field down
     const exConfigure = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
     assert.match(exConfigure, /name="inheritInclude" value="notes"(?! checked)/);
-    assert.match(exConfigure, /off · long-text · notes/);
+    assert.match(exConfigure, /off · long-text/);
     assert.match(exConfigure, /name="inheritInclude" value="warmup-done" checked/);
     assert.match(exConfigure, /inherit-copy:warmup-done/);
     assert.doesNotMatch(exConfigure, /inherit-override:|inherit-clone:/);
-    // rows with a local copy show no checkbox — the copy governs (lift is bench-day's)
+    // rows with a local copy render as the editable field (source: this tracker)
     assert.doesNotMatch(exConfigure, /name="inheritInclude" value="lift"/);
-    assert.match(exConfigure, /local copy below · select · lift/);
 
     // #319: the one-checkbox flow via the GUI save endpoint —
     // uncheck an inherited field -> an editable copy appears (override)
@@ -2249,6 +2252,19 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     const hubClone = await post('/api/forms/templates/hub/clone', {});
     assert.equal(hubClone.status, 201);
     assert.equal(JSON.parse(await hubClone.text()).template.kind, 'container');
+
+    // #324: reorder — API order patch, then a GUI move, both reflected in serving order
+    const ordRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;
+    assert.equal((await patch('/api/forms/templates/bench-day', {revision: ordRev, inherit: {exclude: ['notes'], order: ['spotter', 'lift']}})).status, 200);
+    let ordered = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
+    assert.equal(ordered.resolvedFields.filter((f) => !f.isDestroyed)[0].id, 'spotter');
+    assert.equal(ordered.resolvedFields.filter((f) => !f.isDestroyed)[1].id, 'lift');
+    const moveSave = await guiSave((values) => values.set('_action', 'resolved-up:warmup-done'));
+    assert.equal(moveSave.status, 200);
+    ordered = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
+    const orderIds = ordered.template.inherit.order;
+    assert.ok(orderIds.indexOf('warmup-done') >= 0, 'move must write inherit.order');
+    assert.ok((ordered.template.inherit.exclude || []).includes('notes'), 'move must preserve exclusions');
 
     // detach materializes the resolved fields onto the child
     const childRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;


### PR DESCRIPTION
Closes #324. Closes #314 (the deferred reorder, delivered).

- **Unified fields table** on children: everything the tracker serves in resolved order — inherited rows (checkbox + Copy) and local rows (full editor) interleaved, Source column (parent title vs "this tracker"), ↑↓ on every row.
- **`inherit.order`**: ids over the resolved list; serve-time; preserved across saves; bakes in on detach; API parity.
- **Theme + Theme mode as table rows**: selects move from basics, live source labels ("inherited from <parent>" / "<group>" / "viewer choice"), empty option = **Inherited** (the #313/#315 chain made visible).

**Test gates:** API order patch → resolvedFields order; GUI move writes inherit.order and preserves exclusions; table head/source/theme-row assertions. Suite 203/0; validate:editable 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
