### PR TITLE
feat(forms): theme rows adopt the inherit idiom — Set locally

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -1030,8 +1030,12 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
                 ? `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}"><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">off · ${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span>`
                 : `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}" checked><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span><button type="submit" name="_action" value="inherit-copy:${escapeHtml(row.field.id)}" class="inherited-override-btn">Copy</button>${move}`}</div>`;
             }).join('')}
-            <div class="fields-table-row fields-table-theme"><span class="inherited-field-label">Theme</span><select name="theme">${childThemeOptions}</select><span class="field-source">${escapeHtml(options.themeSource)}</span></div>
-            <div class="fields-table-row fields-table-theme"><span class="inherited-field-label">Theme mode</span><select name="themeMode">${childThemeModeOptions}</select><span class="field-source">${escapeHtml(options.themeModeSource)}</span></div>
+            <div class="fields-table-row fields-table-theme"><span class="inherited-field-label">Theme</span>${options.themeRow.local || !options.themeRow.effective
+              ? `<select name="theme">${childThemeOptions}</select>`
+              : `<span class="theme-effective">${escapeHtml(options.themeRow.effectiveLabel)}</span><button type="submit" name="_action" value="theme-local" class="inherited-override-btn">Set locally</button>`}<span class="field-source">${escapeHtml(options.themeSource)}</span></div>
+            <div class="fields-table-row fields-table-theme"><span class="inherited-field-label">Theme mode</span>${options.modeRow.local || !options.modeRow.effective
+              ? `<select name="themeMode">${childThemeModeOptions}</select>`
+              : `<span class="theme-effective">${escapeHtml(options.modeRow.effectiveLabel)}</span><button type="submit" name="_action" value="mode-local" class="inherited-override-btn">Set locally</button>`}<span class="field-source">${escapeHtml(options.themeModeSource)}</span></div>
           </div>` : (template.fields || []).map((field, index) => builderField(field, index, (template.fields || []).length, false)).join('')}
         </section>
         <details class="builder-related">
@@ -2452,6 +2456,8 @@ function createFormsRouter(options) {
     let fieldsTable = null;
     let themeSource = '';
     let themeModeSource = '';
+    let themeRow = {local: false, effective: ''};
+    let modeRow = {local: false, effective: ''};
     if (record.draft.parentId) {
       const parent = await registry.getTemplate(record.draft.parentId);
       if (parent) {
@@ -2484,6 +2490,12 @@ function createFormsRouter(options) {
         themeModeSource = ownMode ? 'this tracker'
           : parentTheme.mode ? `inherited from ${parent.title}`
           : groupTheme.mode ? `inherited from ${groupForTheme.title}` : 'viewer choice';
+        // #326: idiom rows — inherited state shows the effective value + Set locally.
+        const effectiveScheme = parentTheme.scheme || groupTheme.scheme || '';
+        const effectiveModeValue = parentTheme.mode || groupTheme.mode || '';
+        const installed = getThemeList().find((entry) => entry.slug === effectiveScheme);
+        themeRow = {local: Boolean(ownTheme), effective: effectiveScheme, effectiveLabel: installed ? installed.label : effectiveScheme};
+        modeRow = {local: Boolean(ownMode), effective: effectiveModeValue, effectiveLabel: effectiveModeValue === 'dark' ? 'Always dark' : effectiveModeValue === 'light' ? 'Always light' : ''};
       }
     }
     // #300: every group with its active trackers (+ Ungrouped) for the related picker
@@ -2514,6 +2526,8 @@ function createFormsRouter(options) {
       fieldsTable,
       themeSource,
       themeModeSource,
+      themeRow,
+      modeRow,
       parentFieldIds: inherited ? inherited.parentFieldIds : null,
       relatedForms: {container: await containerCrumbFor(record.draft), related: []},
       ...responseOptions,
@@ -2829,6 +2843,22 @@ function createFormsRouter(options) {
             patch.inherit = (exclude.length || storedOrder)
               ? {...(exclude.length ? {exclude} : {}), ...(storedOrder ? {order: storedOrder} : {})}
               : null;
+          }
+          if (action === 'theme-local' || action === 'mode-local') {
+            // #326: materialize the inherited value as a local one; the select's
+            // Inherited option is the give-back.
+            const parentThemeNow = themeDefaults(parent);
+            const groupNow = await containerCrumbFor(record.draft);
+            const groupThemeNow = groupNow ? themeDefaults(groupNow) : {};
+            const presentationPatch = {...(patch.presentation || {})};
+            if (action === 'theme-local') {
+              const effective = parentThemeNow.scheme || groupThemeNow.scheme;
+              if (effective) presentationPatch.theme = effective;
+            } else {
+              const effective = parentThemeNow.mode || groupThemeNow.mode;
+              if (effective) presentationPatch.themeMode = effective;
+            }
+            patch.presentation = Object.keys(presentationPatch).length ? presentationPatch : patch.presentation;
           }
           const moveMatch = /^resolved-(up|down):([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
           if (moveMatch) {

--- a/public/style.css
+++ b/public/style.css
@@ -2889,6 +2889,9 @@ tbody tr:last-child td {
 .form-layout .fields-table-theme { display: flex; align-items: center; gap: 0.8rem; border-top: 1px dashed var(--border); padding-top: 0.55rem; }
 .form-layout .fields-table-theme select { flex: 1; min-width: 8rem; }
 
+/* #326: theme rows in the inherit idiom. */
+.form-layout .theme-effective { color: var(--text-soft); }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2266,6 +2266,17 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     assert.ok(orderIds.indexOf('warmup-done') >= 0, 'move must write inherit.order');
     assert.ok((ordered.template.inherit.exclude || []).includes('notes'), 'move must preserve exclusions');
 
+    // #326: theme rows in the inherit idiom — parent nord/dark shows as effective
+    // text with Set locally; the action materializes it as a local value
+    const themedConfigure = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
+    assert.match(themedConfigure, /theme-effective">Nord<|theme-effective">nord</);
+    assert.match(themedConfigure, /value="theme-local"/);
+    assert.match(themedConfigure, /inherited from Gym Session Entry/);
+    const localizeResp = await guiSave((values) => { values.set('_action', 'theme-local'); values.delete('theme'); });
+    assert.equal(localizeResp.status, 200);
+    const localized = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
+    assert.equal(localized.presentation && localized.presentation.theme, 'nord', 'Set locally must materialize the effective theme');
+
     // detach materializes the resolved fields onto the child
     const childRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;
     const detached = await patch('/api/forms/templates/bench-day', {revision: childRev, parentId: null});


### PR DESCRIPTION
Closes #326. Inherited state = effective value as text + source pill + Set locally (materializes); local state = select, whose Inherited option gives it back. Theme stays a presentation property, not a data field (fields stamp into entries; themes must not). Tested: effective Nord shows with Set locally; the action materializes presentation.theme=nord. Suite 203/0.🤖 Generated with [Claude Code](https://claude.com/claude-code)