### PR TITLE
feat(forms): drag/drop reordering; children nest in the Trackers view

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -1020,15 +1020,17 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           ${options.fieldsTable ? `<div class="fields-table" aria-label="Fields in serving order">
             <p class="builder-help">Everything this tracker serves, in order. Source says whose definition it is — <strong>${escapeHtml(options.inherited.parentTitle)}</strong> (live) or this tracker. Checked = on; Copy makes a local version; ↑↓ reorder. Applies with Save draft.</p>
             <input type="hidden" name="inheritCfg" value="1">
+            <input type="hidden" name="resolvedOrder" value="" id="resolved-order-input">
             <div class="fields-table-head"><span>Field</span><span>Source</span><span>On</span><span>Move</span></div>
             ${options.fieldsTable.map((row) => {
+              const handle = '<span class="drag-handle" aria-hidden="true" title="Drag to reorder">⋮⋮</span>';
               const move = `<span class="field-move"><button type="submit" name="_action" value="resolved-up:${escapeHtml(row.field.id)}" aria-label="Move up">↑</button><button type="submit" name="_action" value="resolved-down:${escapeHtml(row.field.id)}" aria-label="Move down">↓</button></span>`;
               if (row.kind === 'local') {
-                return builderField(row.field, row.ownIndex, (template.fields || []).length, row.isOverride, {sourceLabel: 'this tracker', moveButtons: move});
+                return `<div class="fields-table-local" data-field-id="${escapeHtml(row.field.id)}">${builderField(row.field, row.ownIndex, (template.fields || []).length, row.isOverride, {sourceLabel: 'this tracker', moveButtons: handle + move})}</div>`;
               }
-              return `<div class="inherited-field fields-table-row">${row.state === 'excluded'
+              return `<div class="inherited-field fields-table-row"${row.state === 'excluded' ? '' : ` data-field-id="${escapeHtml(row.field.id)}"`}>${row.state === 'excluded'
                 ? `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}"><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">off · ${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span>`
-                : `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}" checked><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span><button type="submit" name="_action" value="inherit-copy:${escapeHtml(row.field.id)}" class="inherited-override-btn">Copy</button>${move}`}</div>`;
+                : `${handle}<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}" checked><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span><button type="submit" name="_action" value="inherit-copy:${escapeHtml(row.field.id)}" class="inherited-override-btn">Copy</button>${move}`}</div>`;
             }).join('')}
             <div class="fields-table-row fields-table-theme"><span class="inherited-field-label">Theme</span>${options.themeRow.local || !options.themeRow.effective
               ? `<select name="theme">${childThemeOptions}</select>`
@@ -1072,7 +1074,51 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
       </section>
     </section>
   </main>
-  ${themeScript(options.cspNonce, themeDefaults(template))}`;
+  ${themeScript(options.cspNonce, themeDefaults(template))}
+  ${options.fieldsTable ? `<script${options.cspNonce ? ` nonce="${escapeHtml(options.cspNonce)}"` : ''}>
+  (function () {
+    // #327: drag to reorder — writes the built order to a hidden input; the
+    // arrows and Save draft remain the no-JS path.
+    var table = document.querySelector('.fields-table');
+    var orderInput = document.getElementById('resolved-order-input');
+    if (!table || !orderInput) return;
+    var dragging = null;
+    table.addEventListener('pointerdown', function (event) {
+      var handle = event.target.closest('.drag-handle');
+      if (!handle) return;
+      dragging = handle.closest('[data-field-id]');
+      if (!dragging) return;
+      event.preventDefault();
+      dragging.classList.add('dragging');
+    });
+    table.addEventListener('pointermove', function (event) {
+      if (!dragging) return;
+      event.preventDefault();
+      var rows = Array.prototype.slice.call(table.querySelectorAll('[data-field-id]'));
+      var target = null;
+      for (var i = 0; i < rows.length; i += 1) {
+        if (rows[i] === dragging) continue;
+        var box = rows[i].getBoundingClientRect();
+        if (event.clientY < box.top + box.height / 2) { target = rows[i]; break; }
+      }
+      if (target) table.insertBefore(dragging, target);
+      else {
+        var last = rows[rows.length - 1];
+        if (last !== dragging) table.insertBefore(dragging, last.nextSibling);
+      }
+    });
+    function finish() {
+      if (!dragging) return;
+      dragging.classList.remove('dragging');
+      orderInput.value = Array.prototype.map.call(table.querySelectorAll('[data-field-id]'), function (row) {
+        return row.getAttribute('data-field-id');
+      }).join(' ');
+      dragging = null;
+    }
+    table.addEventListener('pointerup', finish);
+    table.addEventListener('pointercancel', finish);
+  })();
+  </script>` : ''}`;
   return baseHtml({
     defaultScheme: themeDefaults(template).scheme || null,
     defaultMode: themeDefaults(template).mode || null,
@@ -1261,16 +1307,24 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   // #298: two root views. Groups (default) = tap-in group rows; Trackers = every
   // tracker under its group heading — the resurrected pre-#261 listing.
   let rows;
+  // #329: children nest under their parent in the listing.
+  const nestRows = (list) => {
+    const ids = new Set(list.map((template) => template.templateId));
+    const childrenOf = (parentId) => list.filter((template) => template.parentId === parentId);
+    const tops = list.filter((template) => !(template.parentId && ids.has(template.parentId)));
+    return tops.map((top) => trackerRow(top) + childrenOf(top.templateId).map((child) =>
+      `<div class="tracker-nested">${trackerRow(child)}</div>`).join('')).join('');
+  };
   if (view === 'trackers') {
     rows = [
       ...containers.map((container) => {
         const members = active.filter((template) => template.containerId === container.templateId);
         return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
           <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} tracker${members.length === 1 ? '' : 's'}</span></div>
-          <div class="container-members">${members.map(trackerRow).join('')}</div>
+          <div class="container-members">${nestRows(members)}</div>
         </section>`;
       }),
-      ungrouped.length ? `<section class="forms-index-ungrouped" aria-label="Ungrouped trackers">${containers.length ? '<h2 class="forms-index-ungrouped-head">Ungrouped</h2>' : ''}<div class="container-members">${ungrouped.map(trackerRow).join('')}</div></section>` : '',
+      ungrouped.length ? `<section class="forms-index-ungrouped" aria-label="Ungrouped trackers">${containers.length ? '<h2 class="forms-index-ungrouped-head">Ungrouped</h2>' : ''}<div class="container-members">${nestRows(ungrouped)}</div></section>` : '',
     ].join('');
   } else {
     rows = [
@@ -2370,7 +2424,7 @@ function createFormsRouter(options) {
   function validBuilderBody(body, create = false) {
     const fixed = create
       ? new Set(['_csrf', 'templateId', 'title', 'destinationId', 'kind', 'group'])
-      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container', 'parent', 'relatedCfg', 'relatedAll', 'related', 'inheritCfg', 'inheritInclude']);
+      : new Set(['_csrf', '_action', 'revision', 'title', 'destinationId', 'theme', 'themeMode', 'container', 'parent', 'relatedCfg', 'relatedAll', 'related', 'inheritCfg', 'inheritInclude', 'resolvedOrder']);
     // An author SELECTS an installed theme; they can never introduce one. Anything
     // outside the server's list is refused rather than quietly ignored.
     if (!create && body && typeof body === 'object') {
@@ -2859,6 +2913,15 @@ function createFormsRouter(options) {
               if (effective) presentationPatch.themeMode = effective;
             }
             patch.presentation = Object.keys(presentationPatch).length ? presentationPatch : patch.presentation;
+          }
+          // #327: the drag/drop enhancement posts the full order it built.
+          const draggedOrder = postedString(req.body, 'resolvedOrder');
+          if (draggedOrder) {
+            const ids = draggedOrder.split(/[\s,]+/).filter((id) => isDefinitionId(id));
+            if (ids.length) {
+              const base = patch.inherit !== undefined ? patch.inherit : (record.draft.inherit || null);
+              patch.inherit = {...(base && base.exclude && base.exclude.length ? {exclude: base.exclude} : {}), order: ids};
+            }
           }
           const moveMatch = /^resolved-(up|down):([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
           if (moveMatch) {

--- a/public/style.css
+++ b/public/style.css
@@ -2892,6 +2892,13 @@ tbody tr:last-child td {
 /* #326: theme rows in the inherit idiom. */
 .form-layout .theme-effective { color: var(--text-soft); }
 
+/* #327/#329: drag handles + nested children in the trackers listing. */
+.form-layout .drag-handle { cursor: grab; touch-action: none; color: var(--text-soft); padding: 0.1rem 0.35rem; user-select: none; letter-spacing: -0.12em; }
+.form-layout .dragging { opacity: 0.55; }
+.form-layout .fields-table-local { display: contents; }
+.form-layout .tracker-nested { margin-left: 1.4rem; position: relative; }
+.form-layout .tracker-nested::before { content: '↳'; position: absolute; left: -1.1rem; top: 50%; transform: translateY(-50%); color: var(--text-soft); }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -442,10 +442,13 @@ test('forms index separates archived templates and removes management detail for
     assert.match(archived.querySelector('summary').textContent, /Show archived\s*1/);
     assert.match(archived.textContent, /Retired group/);
     assert.doesNotMatch(archived.textContent, /Old log/);
-    // the Trackers view lists every active tracker under its group heading
+    // the Trackers view lists every active tracker under its group heading;
+    // #329: children nest under their parent
+    await server.registry.reviseDraft('daily-log', 1, {parentId: 'training-log'});
     const trackersView = await browserPage(await server.request('/forms?view=trackers'));
     assert.ok(trackersView.document.querySelector('.form-hub-nav a[aria-current="page"][href="/forms?view=trackers"]'));
-    assert.ok([...trackersView.document.querySelectorAll('.forms-root-row .container-member-title')].some((node) => /Daily log/.test(node.textContent)));
+    const nested = trackersView.document.querySelector('.tracker-nested .container-member-title');
+    assert.ok(nested && /Daily log/.test(nested.textContent), 'child must nest under its parent');
 
     const submitOnly = await browserPage(await server.request('/forms', {headers: {'X-No-Manage': 'yes'}}));
     assert.equal(submitOnly.document.querySelector('a[href="/forms/new"]'), null);

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2277,6 +2277,16 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     const localized = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template;
     assert.equal(localized.presentation && localized.presentation.theme, 'nord', 'Set locally must materialize the effective theme');
 
+    // #327: the DnD input exists; posting a full resolvedOrder applies it
+    const dndConfigure = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
+    assert.match(dndConfigure, /resolved-order-input/);
+    assert.match(dndConfigure, /drag-handle/);
+    const dndSave = await guiSave((values) => values.set('resolvedOrder', 'warmup-done spotter lift'));
+    assert.equal(dndSave.status, 200);
+    const dndOrdered = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
+    assert.deepEqual(dndOrdered.template.inherit.order.slice(0, 3), ['warmup-done', 'spotter', 'lift']);
+    assert.ok((dndOrdered.template.inherit.exclude || []).includes('notes'), 'drag order must preserve exclusions');
+
     // detach materializes the resolved fields onto the child
     const childRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;
     const detached = await patch('/api/forms/templates/bench-day', {revision: childRev, parentId: null});


### PR DESCRIPTION
Closes #327. Closes #329. Pointer-events drag over the fields table (nonce-CSP first-party script) writing resolvedOrder, applied with Save draft — arrows stay as the full no-JS path. Trackers view nests children under parents with indent + arrow. Tested: resolvedOrder round-trip preserving exclusions; nested child renders. Suite 203/0.🤖 Generated with [Claude Code](https://claude.com/claude-code)