### PR TITLE
feat(forms): unified hierarchy, theme fixes, delete, version restore

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -377,19 +377,21 @@ function renderArchivedMembers(archived, csrfToken) {
   // #293: a group's archived trackers live WITH the group, restorable in place.
   if (!archived.length) return '';
   const rows = archived.map((member) => `<div class="archived-member-row"><span>${escapeHtml(member.title)}</span>
-    <form method="post" action="/forms/${encodeURIComponent(member.templateId)}/restore">
+    <span class="archived-member-actions"><form method="post" action="/forms/${encodeURIComponent(member.templateId)}/restore">
       <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
       <input type="hidden" name="revision" value="${escapeHtml(member.revision)}">
       <button type="submit">Restore</button>
-    </form></div>`).join('');
+    </form>
+    <form method="post" action="/forms/${encodeURIComponent(member.templateId)}/delete">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <input type="hidden" name="revision" value="${escapeHtml(member.revision)}">
+      <button type="submit" class="delete-button">Delete</button>
+    </form></span></div>`).join('');
   return `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="archived-member-list">${rows}</div></details>`;
 }
 
-function renderContainerPage(template, members, options = {}) {
-  // #234: a container's page IS its form view — member navigation instead of fields.
-  const cards = members.length
-    ? members.map((member) => (
-      `<details class="container-member-row">
+function renderLeafRow(member, options = {}) {
+  return `<details class="container-member-row">
         <summary class="container-member"><a class="container-member-title" href="/forms/${encodeURIComponent(member.templateId)}">${escapeHtml(member.title)}</a><span aria-hidden="true">›</span></summary>
         <div class="container-member-preview">
           ${renderFormPreview(member)}
@@ -398,8 +400,29 @@ function renderContainerPage(template, members, options = {}) {
             ${options.canManage ? `<a class="container-member-configure" href="/forms/${encodeURIComponent(member.templateId)}/configure">Configure</a>` : ''}
           </div>
         </div>
-      </details>`
-    )).join('')
+      </details>`;
+}
+
+function renderNestedMembers(members, options = {}) {
+  // #335: ONE listing everywhere — parents expand to their nested children,
+  // leaves expand to their live preview. The group page and the root share this.
+  const ids = new Set(members.map((member) => member.templateId));
+  const childrenOf = (parentId) => members.filter((member) => member.parentId === parentId);
+  const tops = members.filter((member) => !(member.parentId && ids.has(member.parentId)));
+  return tops.map((top) => {
+    const children = childrenOf(top.templateId);
+    if (!children.length) return renderLeafRow(top, options);
+    return `<details class="container-member-row parent-tracker-row">
+        <summary class="container-member"><a class="container-member-title" href="/forms/${encodeURIComponent(top.templateId)}">${escapeHtml(top.title)}</a><span class="forms-root-count">${children.length} tracker${children.length === 1 ? '' : 's'}</span><span aria-hidden="true">›</span></summary>
+        <div class="nested-children">${children.map((child) => `<div class="tracker-nested">${renderLeafRow(child, options)}</div>`).join('')}</div>
+      </details>`;
+  }).join('');
+}
+
+function renderContainerPage(template, members, options = {}) {
+  // #234: a container's page IS its form view — member navigation instead of fields.
+  const cards = members.length
+    ? renderNestedMembers(members, options)
     : '<p class="container-empty">No trackers in this group yet. Add some from its Configure page.</p>';
   const body = `${toolbarHtml(formProperties(template, {memberCount: members.length}))}
   <main class="layout form-layout container-layout">
@@ -410,7 +433,6 @@ function renderContainerPage(template, members, options = {}) {
     ${options.canManage ? createLinks(template.templateId) : ''}
     <section class="content form-card container-card">
       <div class="container-members">${cards}</div>
-      ${renderArchivedMembers(options.archivedMembers || [], options.csrfToken)}
     </section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;
@@ -937,18 +959,25 @@ function builderField(field, fieldIndex, fieldCount, isOverride = false, extras 
 
 function configureLifecycle(template, csrfToken) {
   // #291: lifecycle lives with Configure — Clone and Archive moved here when
-  // the root Manage section retired.
+  // the root Manage section retired. #333: archived templates offer Restore
+  // and Delete (two-step destruction).
   const templateId = encodeURIComponent(template.templateId);
+  const archived = template.archived === true;
   return `<div class="configure-lifecycle" aria-label="Lifecycle">
     <form method="post" action="/forms/${templateId}/clone">
       <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
       <button type="submit">Clone</button>
     </form>
-    <form method="post" action="/forms/${templateId}/archive">
+    <form method="post" action="/forms/${templateId}/${archived ? 'restore' : 'archive'}">
       <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
       <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
-      <button type="submit">Archive</button>
+      <button type="submit">${archived ? 'Restore' : 'Archive'}</button>
     </form>
+    ${archived ? `<form method="post" action="/forms/${templateId}/delete">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+      <button type="submit" class="delete-button">Delete</button>
+    </form>` : ''}
   </div>`;
 }
 
@@ -996,6 +1025,12 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
         <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
         <div><dt>Published</dt><dd>${escapeHtml(publishedText)}</dd></div>
       </dl>
+      ${Array.isArray(record.publishedVersions) && record.publishedVersions.length ? `<form method="post" action="${configureHref}/restore-version" class="version-restore-form">
+        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+        <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+        <label><span>Versions</span><select name="templateVersion">${record.publishedVersions.map((version) => `<option value="${escapeHtml(version.templateVersion)}">v${escapeHtml(version.templateVersion)} — from draft r${escapeHtml(version.sourceRevision)}</option>`).join('')}</select></label>
+        <button type="submit">Restore to draft</button>
+      </form>` : ''}
       ${status}${conflict}${builderErrors(options.errors)}
       <p class="builder-warning"><strong>Past entries stay intact.</strong> Removed fields are retained as restorable schema identities and hidden from new entries; earlier receipts keep their captured values and labels.</p>
       <form method="post" action="${configureHref}" class="builder-form">
@@ -1021,16 +1056,15 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
             <p class="builder-help">Everything this tracker serves, in order. Source says whose definition it is — <strong>${escapeHtml(options.inherited.parentTitle)}</strong> (live) or this tracker. Checked = on; Copy makes a local version; ↑↓ reorder. Applies with Save draft.</p>
             <input type="hidden" name="inheritCfg" value="1">
             <input type="hidden" name="resolvedOrder" value="" id="resolved-order-input">
-            <div class="fields-table-head"><span>Field</span><span>Source</span><span>On</span><span>Move</span></div>
+            <div class="fields-table-head"><span>Field</span><span>Source</span><span>On</span></div>
             ${options.fieldsTable.map((row) => {
               const handle = '<span class="drag-handle" aria-hidden="true" title="Drag to reorder">⋮⋮</span>';
-              const move = `<span class="field-move"><button type="submit" name="_action" value="resolved-up:${escapeHtml(row.field.id)}" aria-label="Move up">↑</button><button type="submit" name="_action" value="resolved-down:${escapeHtml(row.field.id)}" aria-label="Move down">↓</button></span>`;
               if (row.kind === 'local') {
-                return `<div class="fields-table-local" data-field-id="${escapeHtml(row.field.id)}">${builderField(row.field, row.ownIndex, (template.fields || []).length, row.isOverride, {sourceLabel: 'this tracker', moveButtons: handle + move})}</div>`;
+                return `<div class="fields-table-local" data-field-id="${escapeHtml(row.field.id)}">${builderField(row.field, row.ownIndex, (template.fields || []).length, row.isOverride, {sourceLabel: 'this tracker', moveButtons: handle})}</div>`;
               }
               return `<div class="inherited-field fields-table-row"${row.state === 'excluded' ? '' : ` data-field-id="${escapeHtml(row.field.id)}"`}>${row.state === 'excluded'
                 ? `<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}"><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">off · ${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span>`
-                : `${handle}<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}" checked><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span><button type="submit" name="_action" value="inherit-copy:${escapeHtml(row.field.id)}" class="inherited-override-btn">Copy</button>${move}`}</div>`;
+                : `${handle}<label class="inherited-field-pick"><input type="checkbox" name="inheritInclude" value="${escapeHtml(row.field.id)}" checked><span class="inherited-field-label">${escapeHtml(row.field.label)}</span></label><span class="inherited-field-meta">${escapeHtml(row.field.type)}</span><span class="field-source">${escapeHtml(options.inherited.parentTitle)}</span><button type="submit" name="_action" value="inherit-copy:${escapeHtml(row.field.id)}" class="inherited-override-btn">Copy</button>`}</div>`;
             }).join('')}
             <div class="fields-table-row fields-table-theme"><span class="inherited-field-label">Theme</span>${options.themeRow.local || !options.themeRow.effective
               ? `<select name="theme">${childThemeOptions}</select>`
@@ -1074,7 +1108,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
       </section>
     </section>
   </main>
-  ${themeScript(options.cspNonce, themeDefaults(template))}
+  ${themeScript(options.cspNonce, options.effectiveTheme || themeDefaults(template))}
   ${options.fieldsTable ? `<script${options.cspNonce ? ` nonce="${escapeHtml(options.cspNonce)}"` : ''}>
   (function () {
     // #327: drag to reorder — writes the built order to a hidden input; the
@@ -1120,8 +1154,8 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
   })();
   </script>` : ''}`;
   return baseHtml({
-    defaultScheme: themeDefaults(template).scheme || null,
-    defaultMode: themeDefaults(template).mode || null,
+    defaultScheme: (options.effectiveTheme || themeDefaults(template)).scheme || null,
+    defaultMode: (options.effectiveTheme || themeDefaults(template)).mode || null,
     title: `Configure ${template.title}`,
     body,
     customThemeCss: options.customThemeCss,
@@ -1146,6 +1180,11 @@ function renderTemplateActions(template, csrfToken) {
       <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
       <button type="submit">${lifecycleLabel}</button>
     </form>
+    ${template.state === 'archived' ? `<form method="post" action="/forms/${templateId}/delete">
+      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+      <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+      <button type="submit" class="delete-button">Delete</button>
+    </form>` : ''}
   </div>`;
 }
 
@@ -1240,7 +1279,7 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
     ? memberChoices.map((choice) => (
       `<label class="builder-check container-member-choice"><input type="checkbox" name="member" value="${escapeHtml(choice.templateId)}"${choice.checked ? ' checked' : ''}><span>${escapeHtml(choice.title)}</span></label>`
     )).join('')
-    : '<p class="builder-help">No forms exist yet to add.</p>';
+    : '<p class="builder-help">No trackers exist yet to add.</p>';
   const lifecycle = template.archived === true ? 'restore' : 'archive';
   const body = `${toolbarHtml(formProperties(record, {memberCount: (options.memberChoices || []).filter((choice) => choice.checked).length}))}
   <main class="layout form-layout builder-layout">
@@ -1258,29 +1297,29 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
         <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
         <section class="builder-basics" aria-labelledby="container-basics-heading">
-          <h2 id="container-basics-heading">Container</h2>
+          <h2 id="container-basics-heading">Group</h2>
           <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
           <label class="builder-wide"><span>Description</span><textarea name="description" rows="2" maxlength="2000">${escapeHtml(template.description || '')}</textarea></label>
           <label><span>Theme</span><select name="theme">${themeOptions}</select></label>
           <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>
         </section>
         <section class="builder-members" aria-labelledby="container-members-heading">
-          <h2 id="container-members-heading">Forms in this container</h2>
+          <h2 id="container-members-heading">Trackers in this group</h2>
           <p class="builder-help">Checked trackers join this group; unchecking releases them. Members gain back-and-sibling navigation automatically.</p>
           <div class="container-member-choices">${membersHtml}</div>
         </section>
         <button class="button-link button-link-primary" type="submit">Save draft</button>
       </form>
-      <form method="post" action="${configureHref}/publish" class="builder-publish-form">
-        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-        <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
-        <button class="button-link" type="submit">Publish revision ${escapeHtml(template.revision)}</button>
-      </form>
-      <form method="post" action="/forms/${encodeURIComponent(template.templateId)}/${lifecycle}" class="builder-lifecycle-form">
-        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-        <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
-        <button class="button-link" type="submit">${lifecycle === 'archive' ? 'Archive container' : 'Restore container'}</button>
-      </form>
+      <section class="builder-publish" aria-labelledby="group-publish-heading">
+        <h2 id="group-publish-heading">Publish</h2>
+        <p>Publishing creates a new immutable version from the saved draft. Past published versions and submissions remain unchanged.</p>
+        <form method="post" action="${configureHref}/publish">
+          <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+          <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+          <button class="button-link builder-publish-action" type="submit">Publish saved draft</button>
+        </form>
+        ${configureLifecycle(template, csrfToken)}
+      </section>
     </section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;
@@ -1293,64 +1332,38 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
 }
 
 function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
+  // #335: the root IS the hierarchy — group sections rendering the SAME nested
+  // listing the group pages use. The Groups|Trackers switcher retired with it;
+  // New tracker / New group take the freed bar; ONE archive holds everything.
   const managed = templates.some((template) => template.management === true);
   const active = templates.filter((template) => template.state !== 'archived');
   const archived = templates.filter((template) => template.state === 'archived');
   const containers = active.filter((template) => template.kind === 'container');
   const containerIds = new Set(containers.map((template) => template.templateId));
   const ungrouped = active.filter((template) => template.kind !== 'container' && !(template.containerId && containerIds.has(template.containerId)));
-  const memberCount = (container) => active.filter((template) => template.containerId === container.templateId).length;
-  const trackerRow = (template) => (
-    `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(template.templateId)}"><span class="container-member-title">${escapeHtml(template.title)}</span><span aria-hidden="true">›</span></a>`
-  );
-  const view = options.view === 'trackers' ? 'trackers' : 'groups';
-  // #298: two root views. Groups (default) = tap-in group rows; Trackers = every
-  // tracker under its group heading — the resurrected pre-#261 listing.
-  let rows;
-  // #329: children nest under their parent in the listing.
-  const nestRows = (list) => {
-    const ids = new Set(list.map((template) => template.templateId));
-    const childrenOf = (parentId) => list.filter((template) => template.parentId === parentId);
-    const tops = list.filter((template) => !(template.parentId && ids.has(template.parentId)));
-    return tops.map((top) => trackerRow(top) + childrenOf(top.templateId).map((child) =>
-      `<div class="tracker-nested">${trackerRow(child)}</div>`).join('')).join('');
-  };
-  if (view === 'trackers') {
-    rows = [
-      ...containers.map((container) => {
-        const members = active.filter((template) => template.containerId === container.templateId);
-        return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
-          <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} tracker${members.length === 1 ? '' : 's'}</span></div>
-          <div class="container-members">${nestRows(members)}</div>
-        </section>`;
-      }),
-      ungrouped.length ? `<section class="forms-index-ungrouped" aria-label="Ungrouped trackers">${containers.length ? '<h2 class="forms-index-ungrouped-head">Ungrouped</h2>' : ''}<div class="container-members">${nestRows(ungrouped)}</div></section>` : '',
-    ].join('');
-  } else {
-    rows = [
-      ...containers.map((container) => {
-        const count = memberCount(container);
-        return `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(container.templateId)}"><span class="container-member-title">${escapeHtml(container.title)}</span><span class="forms-root-count">${count} tracker${count === 1 ? '' : 's'}</span><span aria-hidden="true">›</span></a>`;
-      }),
-      ...ungrouped.map(trackerRow),
-    ].join('');
-  }
+  const rowOptions = {canManage: managed};
+  const sections = [
+    ...containers.map((container) => {
+      const members = active.filter((template) => template.containerId === container.templateId);
+      return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
+        <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} tracker${members.length === 1 ? '' : 's'}</span>${container.management ? `<a class="forms-index-container-configure" href="/forms/${encodeURIComponent(container.templateId)}/configure">Configure</a>` : ''}</div>
+        <div class="container-members">${renderNestedMembers(members, rowOptions)}</div>
+      </section>`;
+    }),
+    ungrouped.length ? `<section class="forms-index-ungrouped" aria-label="Ungrouped trackers">${containers.length ? '<h2 class="forms-index-ungrouped-head">Ungrouped</h2>' : ''}<div class="container-members">${renderNestedMembers(ungrouped, rowOptions)}</div></section>` : '',
+  ].join('');
   const emptyState = `<div class="forms-index-empty"><h2>${canCreate ? 'Create your first group' : 'No trackers available'}</h2><p>${canCreate ? 'Groups hold your trackers — make one, then add trackers inside it.' : 'There are no active trackers you can log to.'}</p>${canCreate ? '<a class="button-link button-link-primary" href="/forms/new?kind=container">New group</a>' : ''}</div>`;
-  // #298: the root's archived holds archived GROUPS only — a group's archived
-  // trackers live on that group's page (#293).
-  const rootArchived = archived.filter((template) => template.kind === 'container');
-  const manageHtml = managed && rootArchived.length
-    ? `<details class="forms-index-archived"><summary>Show archived <span>${rootArchived.length}</span></summary><div class="forms-index-list">${rootArchived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>`
+  const manageHtml = managed && archived.length
+    ? `<details class="forms-index-archived"><summary>Show archived <span>${archived.length}</span></summary><div class="forms-index-list">${archived.map((template) => renderManagedTemplate(template, csrfToken, templates)).join('')}</div></details>`
     : '';
   const body = `${toolbarHtml()}
   <main class="layout form-layout container-layout forms-index-layout">
     <header class="topbar forms-index-header">
-      <div><h1>Groups</h1><p class="subtitle">${managed ? 'Tap a group to see and configure what lives inside it.' : 'Choose a tracker to log an entry.'}</p></div>
+      <div><h1>Groups</h1><p class="subtitle">${managed ? 'Everything, nested — tap a group heading for its page, a name to log, a chevron to peek.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
-    <nav class="form-hub-nav" aria-label="Root views"><a class="groups-link" href="/forms"${view === 'groups' ? ' aria-current="page"' : ''}>Groups</a><a class="view-link" href="/forms?view=trackers"${view === 'trackers' ? ' aria-current="page"' : ''}>Trackers</a></nav>
-    ${canCreate ? createLinks(null) : ''}
+    ${canCreate ? '<nav class="form-hub-nav" aria-label="Create"><a class="new-link" href="/forms/new">New tracker</a><a class="newgroup-link" href="/forms/new?kind=container">New group</a></nav>' : ''}
     <section class="content form-card container-card">
-      <div class="container-members">${rows || emptyState}</div>
+      ${sections || emptyState}
     </section>
     ${manageHtml}
   </main>
@@ -1555,8 +1568,12 @@ function builderPatch(current, body) {
   if (typeof existing.component === 'string') presentation.component = existing.component;
   const theme = postedString(body, 'theme');
   const themeMode = postedString(body, 'themeMode');
-  if (theme) presentation.theme = theme;
-  if (themeMode === 'dark' || themeMode === 'light') presentation.themeMode = themeMode;
+  // #331: the registry MERGES presentation patches — an absent key keeps the old
+  // value. A posted-but-empty select means "give it back": send an explicit null.
+  if (Object.prototype.hasOwnProperty.call(body, 'theme')) presentation.theme = theme || null;
+  if (Object.prototype.hasOwnProperty.call(body, 'themeMode')) {
+    presentation.themeMode = (themeMode === 'dark' || themeMode === 'light') ? themeMode : null;
+  }
 
   const patch = {
     revision: Number(postedString(body, 'revision')),
@@ -2346,6 +2363,24 @@ function createFormsRouter(options) {
     }
   });
 
+  router.delete('/api/forms/templates/:templateId', async (req, res, next) => {
+    const type = 'form.template.delete';
+    try {
+      if (!managementEnvelope(req, res, true, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return apiNotFound(req, res, type);
+      const current = await registry.getManagementTemplate(req.params.templateId);
+      if (!current || !await allowed(req, 'forms.manage', current.draft)) return apiNotFound(req, res, type);
+      if (!managementContentType(req, res, type)) return;
+      const body = managementBody(req, res, TEMPLATE_LIFECYCLE_KEYS, type);
+      if (!body) return;
+      await registry.deleteTemplate(req.params.templateId, body.revision);
+      emitAudit(req, type, 'accepted', current.draft);
+      res.status(200).json({ok: true, deleted: req.params.templateId});
+    } catch (error) {
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
   router.post('/api/forms/templates/:templateId/clone', async (req, res, next) => {
     const type = 'form.template.clone';
     try {
@@ -2512,6 +2547,7 @@ function createFormsRouter(options) {
     let themeModeSource = '';
     let themeRow = {local: false, effective: ''};
     let modeRow = {local: false, effective: ''};
+    let effectiveTheme = null;
     if (record.draft.parentId) {
       const parent = await registry.getTemplate(record.draft.parentId);
       if (parent) {
@@ -2550,6 +2586,9 @@ function createFormsRouter(options) {
         const installed = getThemeList().find((entry) => entry.slug === effectiveScheme);
         themeRow = {local: Boolean(ownTheme), effective: effectiveScheme, effectiveLabel: installed ? installed.label : effectiveScheme};
         modeRow = {local: Boolean(ownMode), effective: effectiveModeValue, effectiveLabel: effectiveModeValue === 'dark' ? 'Always dark' : effectiveModeValue === 'light' ? 'Always light' : ''};
+        // #331: the page chrome wears the effective theme; the rows keep
+        // reporting only what is saved.
+        effectiveTheme = {scheme: ownTheme || effectiveScheme || null, mode: ownMode || effectiveModeValue || null};
       }
     }
     // #300: every group with its active trackers (+ Ungrouped) for the related picker
@@ -2582,6 +2621,7 @@ function createFormsRouter(options) {
       themeModeSource,
       themeRow,
       modeRow,
+      effectiveTheme,
       parentFieldIds: inherited ? inherited.parentFieldIds : null,
       relatedForms: {container: await containerCrumbFor(record.draft), related: []},
       ...responseOptions,
@@ -2593,15 +2633,19 @@ function createFormsRouter(options) {
     try {
       if (!browserAuthenticated(req, res, type)) return;
       const templates = await listTemplatesThroughApi(req);
+      // #335: previews need fields — join the authz projections with the full
+      // public (resolved) templates.
+      const fullById = new Map((await registry.listTemplates()).map((template) => [template.templateId, template]));
+      const enriched = templates.map((template) => ({...(fullById.get(template.templateId) || {}), ...template}));
       const canCreate = await canCreateTemplate(req);
       const cspNonce = crypto.randomBytes(18).toString('base64url');
       formHeaders(res, cspNonce);
       emitAudit(req, type, 'accepted');
       res.status(200).type('html').send(renderFormsIndexPage(
-        templates,
+        enriched,
         canCreate,
         issueContext(req, res),
-        {customThemeCss, cspNonce, view: req.query.view === 'trackers' ? 'trackers' : 'groups'},
+        {customThemeCss, cspNonce},
       ));
     } catch (error) {
       next(error);
@@ -2697,6 +2741,69 @@ function createFormsRouter(options) {
           kind: postedString(req.body, 'kind') === 'container' ? 'container' : '',
           ...(errorGroup && isDefinitionId(errorGroup) ? {group: {templateId: errorGroup, title: errorGroup}} : {}),
         }, error.code === 'ECONFLICT' ? 409 : 422);
+        return;
+      }
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  router.post('/forms/:templateId/delete', parseBuilder, async (req, res, next) => {
+    const type = 'form.template.delete';
+    try {
+      if (!browserEnvelope(req, res, req.body && req.body._csrf, type)) return;
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+      const current = await registry.getManagementTemplate(req.params.templateId);
+      if (!current || !await allowed(req, 'forms.manage', current.draft)) return formNotFound(req, res, type);
+      if (!req.body || Object.keys(req.body).some((key) => !['_csrf', 'revision'].includes(key))
+          || !Number.isSafeInteger(Number(req.body.revision)) || Number(req.body.revision) < 1) {
+        emitAudit(req, type, 'rejected_validation', current.draft);
+        res.status(400).type('text/plain').send('Invalid form body.');
+        return;
+      }
+      await registry.deleteTemplate(req.params.templateId, Number(req.body.revision));
+      emitAudit(req, type, 'accepted', current.draft);
+      res.redirect(303, '/forms');
+    } catch (error) {
+      if (!sendTemplateMutationError(req, res, error, type)) next(error);
+    }
+  });
+
+  router.post('/forms/:templateId/configure/restore-version', parseBuilder, async (req, res, next) => {
+    const type = 'form.template.revise';
+    try {
+      if (!browserEnvelope(req, res, req.body && req.body._csrf, type)) return;
+      if (!browserAuthenticated(req, res, type)) return;
+      if (!isDefinitionId(req.params.templateId)) return formNotFound(req, res, type);
+      const record = await registry.getManagementTemplate(req.params.templateId);
+      if (!record || !await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
+      const versionNumber = Number(postedString(req.body, 'templateVersion'));
+      const version = await registry.getTemplateVersion(req.params.templateId, versionNumber);
+      if (!version) return formNotFound(req, res, type);
+      // #334: the version's schema and look load into the working draft — a new
+      // revision; nothing historical changes. Fields the version lacks are
+      // retained as destroyed (the platform's removal rule).
+      const versionFieldIds = new Set((version.fields || []).map((field) => field.id));
+      const retained = (record.draft.fields || [])
+        .filter((field) => !versionFieldIds.has(field.id))
+        .map((field) => ({...structuredClone(field), isDestroyed: true}));
+      const patch = {
+        revision: Number(postedString(req.body, 'revision')),
+        title: version.title,
+        presentation: version.presentation === undefined ? null : structuredClone(version.presentation),
+      };
+      if (version.kind !== 'container') patch.fields = [...structuredClone(version.fields || []), ...retained];
+      for (const key of ['related', 'inherit', 'parentId', 'containerId']) {
+        patch[key] = version[key] === undefined ? null : structuredClone(version[key]);
+      }
+      const revised = await reviseTemplateThroughApi(req.params.templateId, patch);
+      emitAudit(req, type, 'accepted', revised.draft);
+      await sendConfigure(res, revised, issueContext(req, res), {status: `Version ${versionNumber} restored to draft. Publish to make it live.`});
+    } catch (error) {
+      if (error && error.code === 'ESTALE') {
+        emitAudit(req, type, 'rejected_validation');
+        const latest = await registry.getManagementTemplate(req.params.templateId);
+        await sendConfigure(res, latest, issueContext(req, res), {conflict: true}, 409);
         return;
       }
       if (!sendTemplateMutationError(req, res, error, type)) next(error);
@@ -2923,19 +3030,6 @@ function createFormsRouter(options) {
               patch.inherit = {...(base && base.exclude && base.exclude.length ? {exclude: base.exclude} : {}), order: ids};
             }
           }
-          const moveMatch = /^resolved-(up|down):([a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/.exec(action);
-          if (moveMatch) {
-            // #324: swap within the current serving order; store the full list.
-            const resolvedNow = await registry.getTemplate(record.draft.templateId);
-            const ids = (resolvedNow.fields || []).filter((field) => field.isDestroyed !== true).map((field) => field.id);
-            const at = ids.indexOf(moveMatch[2]);
-            const to = moveMatch[1] === 'up' ? at - 1 : at + 1;
-            if (at !== -1 && to >= 0 && to < ids.length) {
-              [ids[at], ids[to]] = [ids[to], ids[at]];
-              const base = patch.inherit !== undefined ? patch.inherit : (record.draft.inherit || null);
-              patch.inherit = {...(base && base.exclude && base.exclude.length ? {exclude: base.exclude} : {}), order: ids};
-            }
-          }
         }
       }
       const revised = await reviseTemplateThroughApi(req.params.templateId, patch);
@@ -3010,19 +3104,12 @@ function createFormsRouter(options) {
       }
       if (template.kind === 'container') {
         const members = await containerMembersFor(req, template);
-        // #293: no recent-entries aside here — the History tab owns it. Managers
-        // see the group's archived trackers, restorable in place.
-        const archivedMembers = canManage
-          ? (await registry.listManagementTemplates())
-            .filter((record) => record.draft.containerId === template.templateId && record.state === 'archived')
-            .map((record) => ({templateId: record.draft.templateId, title: record.draft.title, revision: record.draft.revision}))
-          : [];
         const csrfToken = issueContext(req, res);
         const cspNonce = crypto.randomBytes(18).toString('base64url');
         formHeaders(res, cspNonce);
         emitAudit(req, 'form.render', 'accepted', template);
         res.status(200).type('html').send(renderContainerPage(template, members, {
-          customThemeCss, cspNonce, canManage, archivedMembers, csrfToken,
+          customThemeCss, cspNonce, canManage, csrfToken,
           timezone: serverTimezone, now: currentDate(),
         }));
         return;

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -522,11 +522,12 @@ class TemplateRegistry {
         if (!Object.prototype.hasOwnProperty.call(changes, key)) continue;
         if (changes[key] === null && ['description', 'destinationId', 'tags', 'lineage', 'presentation', 'containerId', 'memberOrder', 'parentId', 'related', 'inherit'].includes(key)) {
           delete revised[key];
-        } else if (key === 'presentation' && isPlainObject(changes.presentation) && isPlainObject(revised.presentation)) {
+        } else if (key === 'presentation' && isPlainObject(changes.presentation)) {
           // #225: merge presentation patches instead of replacing wholesale — a patch
           // stating only `theme` must not silently drop `submitLabel`. A null value
           // inside the patch unsets that single key; top-level null still clears all.
-          const merged = { ...revised.presentation };
+          // #331: merge against {} when none exists yet, so inner nulls never store.
+          const merged = isPlainObject(revised.presentation) ? { ...revised.presentation } : {};
           for (const [presentationKey, presentationValue] of Object.entries(changes.presentation)) {
             if (presentationValue === null) delete merged[presentationKey];
             else merged[presentationKey] = clone(presentationValue);
@@ -600,6 +601,31 @@ class TemplateRegistry {
       entry.schemaDigest = schemaDigest(revised);
       this.files.set(entry.key, entry);
       return this.managementEntry(entry);
+    });
+  }
+
+  async deleteTemplate(templateId, expectedRevision) {
+    // #333: two-step destruction — archive first, then delete. Fail-closed on
+    // references. The template directory (draft + versions) goes; entries in
+    // the storage cabinets are untouched (submissions stay immutable).
+    return this.withMutationLock(templateId, async () => {
+      const entry = await this.entryFor(templateId);
+      if (!entry) throw codedError('ENOTFOUND', 'Template not found.');
+      if (entry.template.revision !== expectedRevision) {
+        throw codedError('ESTALE', 'Template revision is stale.');
+      }
+      if (entry.template.archived !== true) {
+        throw validationError([{path: 'archived', message: 'archive the template before deleting it'}]);
+      }
+      const refs = [...this.files.values()]
+        .filter((candidate) => candidate.template.parentId === templateId || candidate.template.containerId === templateId)
+        .map((candidate) => candidate.template.templateId);
+      if (refs.length) {
+        throw validationError([{path: 'templateId', message: `still referenced by ${refs.join(', ')} — detach or delete them first`}]);
+      }
+      await fs.rm(path.join(this.templatesPath, templateId), {recursive: true, force: true});
+      this.files.delete(entry.key);
+      return true;
     });
   }
 

--- a/public/style.css
+++ b/public/style.css
@@ -2899,6 +2899,15 @@ tbody tr:last-child td {
 .form-layout .tracker-nested { margin-left: 1.4rem; position: relative; }
 .form-layout .tracker-nested::before { content: '↳'; position: absolute; left: -1.1rem; top: 50%; transform: translateY(-50%); color: var(--text-soft); }
 
+/* #333/#334: delete affordance + version restore. */
+.form-layout .delete-button { color: #ff6b6b; border-color: color-mix(in srgb, #ff6b6b 45%, transparent); }
+.form-layout .archived-member-actions { display: inline-flex; gap: 0.5rem; }
+.form-layout .version-restore-form { display: flex; align-items: center; gap: 0.7rem; margin: 0.6rem 0 0.2rem; font-size: 0.9rem; }
+
+/* #335: nested children inside parent rows. */
+.form-layout .parent-tracker-row .nested-children { padding: 0.5rem 0 0.6rem 1.1rem; display: grid; gap: 0.5rem; }
+.form-layout .forms-index-container .container-members { display: grid; gap: 0.55rem; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -425,29 +425,29 @@ test('forms index separates archived templates and removes management detail for
     assert.equal(submitted.status, 303);
 
     const managerIndex = await browserPage(await server.request('/forms'));
-    // #291: tap-in rows only — the Manage section is retired; archived stays collapsed
-    assert.equal(managerIndex.document.querySelectorAll('.container-members .forms-root-row').length, 2);
+    // #335: the root is the nested hierarchy — sections + leaf rows, no switcher
+    assert.ok(managerIndex.document.querySelectorAll('.container-members .container-member-row').length >= 2);
     assert.equal(managerIndex.document.querySelector('.forms-index-manage'), null);
-    assert.ok(managerIndex.document.querySelector('.create-links a[href="/forms/new"]'));
-    assert.ok(managerIndex.document.querySelector('.create-links a[href="/forms/new?kind=container"]'));
+    assert.equal(managerIndex.document.querySelector('a[href="/forms?view=trackers"]'), null);
+    assert.ok(managerIndex.document.querySelector('.form-hub-nav a.new-link[href="/forms/new"]'));
+    assert.ok(managerIndex.document.querySelector('.form-hub-nav a.newgroup-link[href="/forms/new?kind=container"]'));
     // lifecycle moved to Configure (#291): Clone + Archive live there now
     const configureLifecycle = await browserPage(await server.request('/forms/training-log/configure'));
     const lifecycleButtons = [...configureLifecycle.document.querySelectorAll('.configure-lifecycle button')].map((node) => node.textContent.trim());
     assert.deepEqual(lifecycleButtons, ['Clone', 'Archive']);
-    // #298: root archived holds archived GROUPS only; archived trackers live
-    // with their group (or, ungrouped like old-log, stay off the root entirely)
+    // #335: ONE archive — everything archived lives here (groups AND trackers)
     const archived = managerIndex.document.querySelector('.forms-index-archived');
     assert.ok(archived);
     assert.equal(archived.open, false);
-    assert.match(archived.querySelector('summary').textContent, /Show archived\s*1/);
+    assert.match(archived.querySelector('summary').textContent, /Show archived\s*2/);
     assert.match(archived.textContent, /Retired group/);
-    assert.doesNotMatch(archived.textContent, /Old log/);
-    // the Trackers view lists every active tracker under its group heading;
-    // #329: children nest under their parent
+    assert.match(archived.textContent, /Old log/);
+    // archived cards carry Delete (#333) alongside Restore
+    assert.ok(archived.querySelector('form[action$="/delete"] .delete-button, form[action$="/delete"] button'));
+    // #329/#335: children nest under their parent on the SAME page
     await server.registry.reviseDraft('daily-log', 1, {parentId: 'training-log'});
-    const trackersView = await browserPage(await server.request('/forms?view=trackers'));
-    assert.ok(trackersView.document.querySelector('.form-hub-nav a[aria-current="page"][href="/forms?view=trackers"]'));
-    const nested = trackersView.document.querySelector('.tracker-nested .container-member-title');
+    const nestedIndex = await browserPage(await server.request('/forms'));
+    const nested = nestedIndex.document.querySelector('.parent-tracker-row .tracker-nested .container-member-title');
     assert.ok(nested && /Daily log/.test(nested.textContent), 'child must nest under its parent');
 
     const submitOnly = await browserPage(await server.request('/forms', {headers: {'X-No-Manage': 'yes'}}));
@@ -456,7 +456,7 @@ test('forms index separates archived templates and removes management detail for
     assert.equal(submitOnly.document.querySelector('.forms-index-meta'), null);
     assert.equal(submitOnly.document.querySelector('.forms-index-archived'), null);
     assert.deepEqual(
-      [...submitOnly.document.querySelectorAll('.forms-root-row .container-member-title')].map((node) => node.textContent.trim()),
+      [...submitOnly.document.querySelectorAll('.container-member-row > summary .container-member-title')].map((node) => node.textContent.trim()).sort(),
       ['Daily log', 'Training <log>'],
     );
     assert.doesNotMatch(submitOnly.document.body.textContent, /Old log|Entries|Destination|Configure|Archive/);

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2045,10 +2045,11 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     assert.match(member, /related-container-link/);
     assert.match(member, /← Gym/);
 
-    // #260: the root is a container page — the container is a tap-in row with its count
+    // #335: the root renders group sections through the shared nested listing
     const root = await (await server.request('/forms', {headers: {Cookie: context.cookie}})).text();
-    assert.match(root, /forms-root-row/);
+    assert.match(root, /forms-index-container-head/);
     assert.match(root, /1 tracker</);
+    assert.match(root, /container-member-row/);
     // member titles are direct entry links inside the container page
     const containerPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
@@ -2162,7 +2163,7 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     assert.match(childConfigure, /Warmed up/);
     assert.match(childConfigure, /field-source">Gym Session Entry</);
     assert.match(childConfigure, /field-source">this tracker</);
-    assert.match(childConfigure, /resolved-up:warmup-done/);
+    assert.match(childConfigure, /drag-handle/);
     assert.match(childConfigure, /fields-table-theme/);
     assert.match(childConfigure, /field-source">inherited from Gym Session Entry<|field-source">viewer choice</);
     // #310: the own override field says so
@@ -2259,12 +2260,12 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     let ordered = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
     assert.equal(ordered.resolvedFields.filter((f) => !f.isDestroyed)[0].id, 'spotter');
     assert.equal(ordered.resolvedFields.filter((f) => !f.isDestroyed)[1].id, 'lift');
-    const moveSave = await guiSave((values) => values.set('_action', 'resolved-up:warmup-done'));
+    // #332: arrows retired — order changes arrive as a dragged resolvedOrder
+    const moveSave = await guiSave((values) => values.set('resolvedOrder', 'warmup-done spotter lift'));
     assert.equal(moveSave.status, 200);
     ordered = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
-    const orderIds = ordered.template.inherit.order;
-    assert.ok(orderIds.indexOf('warmup-done') >= 0, 'move must write inherit.order');
-    assert.ok((ordered.template.inherit.exclude || []).includes('notes'), 'move must preserve exclusions');
+    assert.equal(ordered.template.inherit.order[0], 'warmup-done');
+    assert.ok((ordered.template.inherit.exclude || []).includes('notes'), 'drag must preserve exclusions');
 
     // #326: theme rows in the inherit idiom — parent nord/dark shows as effective
     // text with Set locally; the action materializes it as a local value
@@ -2281,6 +2282,7 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     const dndConfigure = await (await server.request('/forms/bench-day/configure', {headers: {Cookie: context.cookie}})).text();
     assert.match(dndConfigure, /resolved-order-input/);
     assert.match(dndConfigure, /drag-handle/);
+    assert.doesNotMatch(dndConfigure, /resolved-up:/);
     const dndSave = await guiSave((values) => values.set('resolvedOrder', 'warmup-done spotter lift'));
     assert.equal(dndSave.status, 200);
     const dndOrdered = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text());
@@ -2345,11 +2347,12 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
       body: JSON.stringify({revision: rowing2.revision}),
     });
     assert.equal(archivedResp.status, 200);
+    // #335: ONE archive — the root holds it (restore + delete); group pages don't
     const groupWithArchived = await (await server.request('/forms/gym-fitness', {headers: {Cookie: context.cookie}})).text();
-    assert.match(groupWithArchived, /archived-member-row/);
-    assert.match(groupWithArchived, /rowing-2\/restore/);
+    assert.doesNotMatch(groupWithArchived, /archived-member-row/);
     const rootAfterArchive = await (await server.request('/forms', {headers: {Cookie: context.cookie}})).text();
-    assert.doesNotMatch(rootAfterArchive, /rowing-2/);
+    assert.match(rootAfterArchive, /rowing-2\/restore/);
+    assert.match(rootAfterArchive, /rowing-2\/delete/);
 
     // the root create page carries the Browse escape
     const rootCreate = await (await server.request('/forms/new?kind=container', {headers: {Cookie: context.cookie}})).text();

--- a/test/forms-template-api.test.js
+++ b/test/forms-template-api.test.js
@@ -505,7 +505,7 @@ test('clone and archive APIs preserve source history, receipts, CAS, and authori
     assert.equal((await server.request('/api/forms/templates/training-log', {
       method: 'DELETE',
       headers: AGENT_HEADERS,
-    })).status, 404);
+    })).status, 415);
   } finally {
     await server.close();
   }


### PR DESCRIPTION
Closes #331. Closes #332. Closes #333. Closes #334. Closes #335.

Operator-driven batch (five asks in one afternoon):

- **#331** Theme give-back fixed at the root: the registry's presentation merge now applies against `{}` when none exists (inner nulls never store), and posted-empty selects send explicit nulls. The Configure page chrome wears the **effective** theme (Firefox had tracker/history inheriting while Configure sat in slate).
- **#332** Reorder arrows retired — drag/drop + Save draft is the path (API `inherit.order` remains for scripts).
- **#333** Delete after archive: `registry.deleteTemplate` (CAS, archived-only, fail-closed while any child/member references it; cabinet entries untouched — submissions stay immutable), GUI + `DELETE /api/forms/templates/:id`, Delete buttons on archived cards and on Configure (whose lifecycle now toggles Archive/Restore and offers Delete when archived).
- **#334** Version picker on Configure: restore any published version to draft (missing fields retained as destroyed per the removal rule); publish makes it live.
- **#335** ONE nested hierarchy: root group-sections render the SAME listing partial as group pages — parents expand to children, leaves to live previews; the Groups|Trackers switcher retired; New tracker / New group are bar buttons again; ONE archive on the root (restore + delete); per-group archived retired. Group Configure gains tracker-parity Publish/lifecycle and Group/trackers language.

Suite 203/0; validate:editable 0. Supersessions to narrate: #298/#299 (switcher), #293/#294 (per-group archived), #324 (arrows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxKcpbpZtJ2JgB58FUJoZL
