### PR TITLE
feat(forms): version viewer via the Published dropdown; field delete; bar parity

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -152,7 +152,11 @@ function containerHubNav(templateId, active, canManage) {
     ['groups', '/forms', 'Groups'],
     ['view', href, 'Trackers'],
     ['history', `${href}/entries`, 'History'],
-    ...(canManage ? [['configure', `${href}/configure`, 'Configure']] : []),
+    ...(canManage ? [
+      ['configure', `${href}/configure`, 'Configure'],
+      ['new', `/forms/new?group=${encodeURIComponent(templateId)}`, 'New tracker'],
+      ['newgroup', '/forms/new?kind=container', 'New group'],
+    ] : []),
   ];
   return `<nav class="form-hub-nav" aria-label="Group views">${links.map(([key, linkHref, label]) =>
     `<a class="${key}-link" href="${linkHref}"${key === active ? ' aria-current="page"' : ''}>${label}</a>`
@@ -430,7 +434,6 @@ function renderContainerPage(template, members, options = {}) {
       <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
     </header>
     ${containerHubNav(template.templateId, 'view', options.canManage)}
-    ${options.canManage ? createLinks(template.templateId) : ''}
     <section class="content form-card container-card">
       <div class="container-members">${cards}</div>
     </section>
@@ -915,6 +918,7 @@ function builderField(field, fieldIndex, fieldCount, isOverride = false, extras 
       <div class="builder-field-summary">${summary}</div>
       ${preservedInputs()}
       <button class="builder-restore" type="submit" name="_action" value="field-restore:${fieldIndex}">Restore field</button>
+      <button class="delete-button" type="submit" name="_action" value="field-delete:${fieldIndex}">Delete field</button>
     </div>`;
   }
   const bounds = ['number', 'date', 'datetime'].includes(field.type)
@@ -1023,19 +1027,22 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
     <section class="content form-card builder-card">
       <dl class="builder-revisions">
         <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
-        <div><dt>Published</dt><dd>${escapeHtml(publishedText)}</dd></div>
+        <div><dt>Published</dt><dd>${Array.isArray(record.publishedVersions) && record.publishedVersions.length ? `<form method="get" action="${configureHref}" class="version-select-form"><select name="version">${[...record.publishedVersions].reverse().map((version, index) => `<option value="${escapeHtml(version.templateVersion)}"${options.viewingVersion === version.templateVersion || (!options.viewingVersion && index === 0) ? ' selected' : ''}>v${escapeHtml(version.templateVersion)} — from r${escapeHtml(version.sourceRevision)}</option>`).join('')}</select><button type="submit">View</button></form>` : escapeHtml(publishedText)}</dd></div>
       </dl>
-      ${Array.isArray(record.publishedVersions) && record.publishedVersions.length ? `<form method="post" action="${configureHref}/restore-version" class="version-restore-form">
-        <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-        <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
-        <label><span>Versions</span><select name="templateVersion">${record.publishedVersions.map((version) => `<option value="${escapeHtml(version.templateVersion)}">v${escapeHtml(version.templateVersion)} — from draft r${escapeHtml(version.sourceRevision)}</option>`).join('')}</select></label>
-        <button type="submit">Restore to draft</button>
-      </form>` : ''}
+      ${options.viewingVersion ? `<div class="builder-warning version-banner"><strong>Viewing published v${escapeHtml(options.viewingVersion)} — read-only.</strong> The working draft is r${escapeHtml(options.realRevision)}.
+        <span class="version-banner-actions"><form method="post" action="${configureHref}/restore-version">
+          <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+          <input type="hidden" name="revision" value="${escapeHtml(options.realRevision)}">
+          <input type="hidden" name="templateVersion" value="${escapeHtml(options.viewingVersion)}">
+          <button type="submit">Restore this version to draft</button>
+        </form>
+        <a href="${configureHref}">Back to draft</a></span></div>` : ''}
       ${status}${conflict}${builderErrors(options.errors)}
       <p class="builder-warning"><strong>Past entries stay intact.</strong> Removed fields are retained as restorable schema identities and hidden from new entries; earlier receipts keep their captured values and labels.</p>
       <form method="post" action="${configureHref}" class="builder-form">
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
         <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+        ${options.viewingVersion ? '<fieldset disabled class="version-view">' : ''}
         <section class="builder-basics" aria-labelledby="builder-basics-heading">
           <h2 id="builder-basics-heading">Template</h2>
           <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
@@ -1095,8 +1102,9 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           }).join('') : ''}
         </details>
         <button class="button-link button-link-primary form-primary-action" type="submit" name="_action" value="save">Save draft</button>
+        ${options.viewingVersion ? '</fieldset>' : ''}
       </form>
-      <section class="builder-publish" aria-labelledby="builder-publish-heading">
+      ${options.viewingVersion ? '' : `<section class="builder-publish" aria-labelledby="builder-publish-heading">
         <h2 id="builder-publish-heading">Publish</h2>
         <p>Publishing creates a new immutable version from the saved draft. Past published versions and submissions remain unchanged.</p>
         <form method="post" action="${configureHref}/publish">
@@ -1105,10 +1113,16 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           <button class="button-link builder-publish-action" type="submit">Publish saved draft</button>
         </form>
         ${configureLifecycle(template, csrfToken)}
-      </section>
+      </section>`}
     </section>
   </main>
   ${themeScript(options.cspNonce, options.effectiveTheme || themeDefaults(template))}
+  <script${options.cspNonce ? ` nonce="${escapeHtml(options.cspNonce)}"` : ''}>
+  document.addEventListener('change', function (event) {
+    var select = event.target.closest('.version-select-form select');
+    if (select) select.form.submit();
+  });
+  </script>
   ${options.fieldsTable ? `<script${options.cspNonce ? ` nonce="${escapeHtml(options.cspNonce)}"` : ''}>
   (function () {
     // #327: drag to reorder — writes the built order to a hidden input; the
@@ -1524,6 +1538,13 @@ function postedFields(current, body) {
 }
 
 function applyBuilderAction(fields, action) {
+  const deleteMatch = /^field-delete:(\d+)$/.exec(action);
+  if (deleteMatch) {
+    // #337: permanent delete — only offered on already-destroyed rows; the
+    // registry refuses removal of live fields regardless.
+    fields.splice(Number(deleteMatch[1]), 1);
+    return;
+  }
   if (action === 'field-add') {
     let id;
     do id = generatedDefinitionId('field');
@@ -2541,6 +2562,7 @@ function createFormsRouter(options) {
       .map((candidate) => ({templateId: candidate.draft.templateId, title: candidate.draft.title}))
       .sort((left, right) => String(left.title).localeCompare(String(right.title)));
     // #307/#324: a child's Configure gets the unified fields table
+    const viewingVersion = Boolean(responseOptions && responseOptions.viewingVersion);
     let inherited = null;
     let fieldsTable = null;
     let themeSource = '';
@@ -2548,7 +2570,7 @@ function createFormsRouter(options) {
     let themeRow = {local: false, effective: ''};
     let modeRow = {local: false, effective: ''};
     let effectiveTheme = null;
-    if (record.draft.parentId) {
+    if (record.draft.parentId && !viewingVersion) {
       const parent = await registry.getTemplate(record.draft.parentId);
       if (parent) {
         const ownIds = new Set((record.draft.fields || []).map((field) => field.id));
@@ -2869,6 +2891,27 @@ function createFormsRouter(options) {
       if (!record) return formNotFound(req, res, type);
       if (!await allowed(req, 'forms.manage', record.draft)) return formNotFound(req, res, type);
       emitAudit(req, type, 'accepted', record.draft);
+      // #337: ?version=N renders that published version, read-only.
+      const versionNumber = Number(req.query.version);
+      if (Number.isSafeInteger(versionNumber) && versionNumber >= 1) {
+        const version = await registry.getTemplateVersion(req.params.templateId, versionNumber);
+        if (version) {
+          const displayRecord = {
+            ...record,
+            draft: {
+              ...structuredClone(version),
+              templateId: record.draft.templateId,
+              revision: record.draft.revision,
+              ...(record.draft.destinationId === undefined ? {} : {destinationId: record.draft.destinationId}),
+            },
+          };
+          await sendConfigure(res, displayRecord, issueContext(req, res), {
+            viewingVersion: versionNumber,
+            realRevision: record.draft.revision,
+          });
+          return;
+        }
+      }
       await sendConfigure(res, record, issueContext(req, res));
     } catch (error) {
       next(error);

--- a/lib/forms/template-registry.js
+++ b/lib/forms/template-registry.js
@@ -547,7 +547,10 @@ class TemplateRegistry {
           const parent = await this.entryFor(revised.parentId);
           if (parent) inherited = new Set(parent.template.fields.map((field) => field.id));
         }
-        const removed = (entry.template.fields || []).filter((field) => !revisedIds.has(field.id) && !inherited.has(field.id));
+        // #337: a field archived first (isDestroyed in the CURRENT draft) may be
+        // deleted for good — the two-step mirror of tracker delete. Receipts
+        // stay safe via capture-time snapshots.
+        const removed = (entry.template.fields || []).filter((field) => !revisedIds.has(field.id) && !inherited.has(field.id) && field.isDestroyed !== true);
         if (removed.length) {
           throw validationError(removed.map((field) => ({
             path: 'fields',

--- a/public/style.css
+++ b/public/style.css
@@ -2908,6 +2908,12 @@ tbody tr:last-child td {
 .form-layout .parent-tracker-row .nested-children { padding: 0.5rem 0 0.6rem 1.1rem; display: grid; gap: 0.5rem; }
 .form-layout .forms-index-container .container-members { display: grid; gap: 0.55rem; }
 
+/* #337: version viewer + select-in-dd. */
+.form-layout .version-select-form { display: inline-flex; gap: 0.4rem; align-items: center; }
+.form-layout .version-banner { display: grid; gap: 0.5rem; }
+.form-layout .version-banner-actions { display: flex; gap: 0.9rem; align-items: center; }
+.form-layout fieldset.version-view { border: 0; margin: 0; padding: 0; opacity: 0.75; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -311,10 +311,13 @@ test('collapsed field rows reorder with CAS and soft-delete identities can only 
     latest = await browserPage(response);
     assert.equal(latest.document.querySelectorAll('.builder-field-removed').length, 1);
     assert.match(latest.document.querySelector('.builder-field-removed').textContent, /Restore field/);
+    // #337: removing a LIVE field still rejects; an already-destroyed field
+    // may be deleted for good (two-step, mirrored on trackers) — tested below.
     await assert.rejects(
-      server.registry.reviseDraft('training-log', draft.revision, {fields: draft.fields.filter((field) => field.id !== 'lift')}),
+      server.registry.reviseDraft('training-log', draft.revision, {fields: draft.fields.filter((field) => field.id !== 'notes')}),
       (error) => error && error.code === 'EVALIDATION',
     );
+
 
     response = await browserPost(
       server,
@@ -350,6 +353,16 @@ test('collapsed field rows reorder with CAS and soft-delete identities can only 
     assert.equal(draft.fields[1].id, 'lift');
     assert.equal(draft.fields[1].isDestroyed, undefined);
     assert.ok((await browserPage(await server.request('/forms/training-log'))).document.querySelector('[name="lift"]'));
+
+    // #337: two-step field delete at the end of the flow — destroy, then remove
+    const endState = await server.registry.getManagementTemplate('training-log');
+    const marked = await server.registry.reviseDraft('training-log', endState.draft.revision, {
+      fields: endState.draft.fields.map((field) => field.id === 'lift' ? {...field, isDestroyed: true} : field),
+    });
+    const deleted = await server.registry.reviseDraft('training-log', marked.draft.revision, {
+      fields: marked.draft.fields.filter((field) => field.id !== 'lift'),
+    });
+    assert.ok(!deleted.draft.fields.some((field) => field.id === 'lift'), 'destroyed field must delete for good');
   } finally {
     await server.close();
   }

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2289,6 +2289,14 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     assert.deepEqual(dndOrdered.template.inherit.order.slice(0, 3), ['warmup-done', 'spotter', 'lift']);
     assert.ok((dndOrdered.template.inherit.exclude || []).includes('notes'), 'drag order must preserve exclusions');
 
+    // #337: the version viewer — Published is a dropdown; ?version renders read-only
+    const viewer = await (await server.request('/forms/bench-day/configure?version=1', {headers: {Cookie: context.cookie}})).text();
+    assert.match(viewer, /version-select-form/);
+    assert.match(viewer, /Viewing published v1 — read-only/);
+    assert.match(viewer, /fieldset disabled class="version-view"/);
+    assert.match(viewer, /Restore this version to draft/);
+    assert.doesNotMatch(viewer, /builder-publish-action/);
+
     // detach materializes the resolved fields onto the child
     const childRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;
     const detached = await patch('/api/forms/templates/bench-day', {revision: childRev, parentId: null});


### PR DESCRIPTION
Closes #337. Published IS the dropdown (change = refresh into that version, read-only, restore/back actions; View button = no-JS path; #336 restore form retires — narrated on #334). Fields: archive (isDestroyed) then Delete field — registry allows removing only already-destroyed fields. Group bars gain New tracker/New group buttons matching the root. Suite 203/0.🤖 Generated with [Claude Code](https://claude.com/claude-code)