### PR TITLE
fix(forms): the publish button says Publish

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -1106,11 +1106,11 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
       </form>
       ${options.viewingVersion ? '' : `<section class="builder-publish" aria-labelledby="builder-publish-heading">
         <h2 id="builder-publish-heading">Publish</h2>
-        <p>Publishing creates a new immutable version from the saved draft. Past published versions and submissions remain unchanged.</p>
+        <p>Publishes the last SAVED draft (revision above) as a new immutable version — if you changed anything on this page, Save draft first. Past versions and submissions never change.</p>
         <form method="post" action="${configureHref}/publish">
           <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
           <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
-          <button class="button-link builder-publish-action" type="submit">Publish saved draft</button>
+          <button class="button-link builder-publish-action" type="submit">Publish</button>
         </form>
         ${configureLifecycle(template, csrfToken)}
       </section>`}
@@ -1326,11 +1326,11 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
       </form>
       <section class="builder-publish" aria-labelledby="group-publish-heading">
         <h2 id="group-publish-heading">Publish</h2>
-        <p>Publishing creates a new immutable version from the saved draft. Past published versions and submissions remain unchanged.</p>
+        <p>Publishes the last SAVED draft (revision above) as a new immutable version — if you changed anything on this page, Save draft first. Past versions and submissions never change.</p>
         <form method="post" action="${configureHref}/publish">
           <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
           <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
-          <button class="button-link builder-publish-action" type="submit">Publish saved draft</button>
+          <button class="button-link builder-publish-action" type="submit">Publish</button>
         </form>
         ${configureLifecycle(template, csrfToken)}
       </section>


### PR DESCRIPTION
Operator: "Does publish saved draft really just mean publish the draft we're in? that's confusing." The label was a smuggled warning; the button now says Publish and the help states the save-first caveat in plain words. Both configure pages.🤖 Generated with [Claude Code](https://claude.com/claude-code)