### PR TITLE
feat(forms): Path in Properties; one-step Publish; one Showing control

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -428,7 +428,7 @@ function renderContainerPage(template, members, options = {}) {
   const cards = members.length
     ? renderNestedMembers(members, options)
     : '<p class="container-empty">No trackers in this group yet. Add some from its Configure page.</p>';
-  const body = `${toolbarHtml(formProperties(template, {memberCount: members.length}))}
+  const body = `${toolbarHtml(formProperties(template, {memberCount: members.length, path: `Groups > ${template.title}`}))}
   <main class="layout form-layout container-layout">
     <header class="topbar">
       <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}</div>
@@ -534,7 +534,11 @@ function renderFormPage(template, csrfToken, values = {}, errors = [], options =
   const submitLabel = editing
     ? 'Save correction'
     : configuredSubmitLabel || 'Submit';
-  const body = `${toolbarHtml(formProperties(template))}
+  const propertiesExtras = {
+    path: ['Groups', options.relatedForms && options.relatedForms.container && options.relatedForms.container.title, template && template.title].filter(Boolean).join(' > '),
+    parentTitle: options.parentTitle || null,
+  };
+  const body = `${toolbarHtml(formProperties(template, propertiesExtras))}
   <main class="layout form-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
@@ -583,12 +587,14 @@ function formProperties(record, extras = {}) {
   const isGroup = template.kind === 'container';
   const rows = [
     [isGroup ? 'Group' : 'Form', escapeHtml(template.templateId)],
+    ...(extras.path ? [['Path', escapeHtml(extras.path)]] : []),
+    ...(extras.parentTitle ? [['Parent', escapeHtml(extras.parentTitle)]] : []),
     ['Revision', escapeHtml(String(template.revision))],
     ['Published', published
       ? escapeHtml(`v${published.templateVersion} from revision ${published.sourceRevision}`)
       : 'not published'],
     // #271: a group has no destination or fields of its own — report members.
-    ...(isGroup ? [] : [['Destination', escapeHtml(template.destinationId || 'default')]]),
+    ...(isGroup ? [] : [['Entry storage', escapeHtml(template.destinationId || 'default')]]),
     ['Owner', escapeHtml(template.ownerId)],
     isGroup
       ? ['Trackers', escapeHtml(String(extras.memberCount ?? 0))]
@@ -671,7 +677,11 @@ function renderReceiptPage(template, record, options = {}) {
   const editHref = `${formHref}/receipts/${encodeURIComponent(record.submissionId)}/edit`;
   const canEdit = options.canEdit !== false;
   const received = formatRecordTime(record, options.timezone).dateTimeLabel;
-  const body = `${toolbarHtml(formProperties(template))}
+  const propertiesExtras = {
+    path: ['Groups', options.relatedForms && options.relatedForms.container && options.relatedForms.container.title, template && template.title].filter(Boolean).join(' > '),
+    parentTitle: options.parentTitle || null,
+  };
+  const body = `${toolbarHtml(formProperties(template, propertiesExtras))}
   <main class="layout form-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {leadLabel: template ? undefined : 'Form receipt', container: options.relatedForms && options.relatedForms.container})}
@@ -839,7 +849,11 @@ function renderEntriesPage(template, records, options = {}) {
   const content = records.length > 0
     ? entries
     : `<div class="entries-empty"><h2>Ready for your first entry?</h2><p>Log it now and it will show up here.</p><a class="button-link button-link-primary form-primary-action" href="${formHref}">${template.kind === 'container' ? 'Open the trackers' : 'Log an entry'}</a></div>`;
-  const body = `${toolbarHtml(formProperties(template))}
+  const propertiesExtras = {
+    path: ['Groups', options.relatedForms && options.relatedForms.container && options.relatedForms.container.title, template && template.title].filter(Boolean).join(' > '),
+    parentTitle: options.parentTitle || null,
+  };
+  const body = `${toolbarHtml(formProperties(template, propertiesExtras))}
   <main class="layout form-layout entries-layout">
     <header class="topbar">
       ${formBreadcrumbs(template, {container: options.relatedForms && options.relatedForms.container})}
@@ -1025,18 +1039,24 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
     </header>
     ${formHubNav(template.templateId, 'configure', true, options.relatedForms && options.relatedForms.container)}
     <section class="content form-card builder-card">
-      <dl class="builder-revisions">
-        <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
-        <div><dt>Published</dt><dd>${Array.isArray(record.publishedVersions) && record.publishedVersions.length ? `<form method="get" action="${configureHref}" class="version-select-form"><select name="version">${[...record.publishedVersions].reverse().map((version, index) => `<option value="${escapeHtml(version.templateVersion)}"${options.viewingVersion === version.templateVersion || (!options.viewingVersion && index === 0) ? ' selected' : ''}>v${escapeHtml(version.templateVersion)} — from r${escapeHtml(version.sourceRevision)}</option>`).join('')}</select><button type="submit">View</button></form>` : escapeHtml(publishedText)}</dd></div>
-      </dl>
-      ${options.viewingVersion ? `<div class="builder-warning version-banner"><strong>Viewing published v${escapeHtml(options.viewingVersion)} — read-only.</strong> The working draft is r${escapeHtml(options.realRevision)}.
+      <div class="builder-revisions version-showing">
+        <span>Showing</span>
+        <form method="get" action="${configureHref}" class="version-select-form">
+          <select name="version">
+            <option value=""${options.viewingVersion ? '' : ' selected'}>Current draft</option>
+            ${Array.isArray(record.publishedVersions) ? [...record.publishedVersions].reverse().map((version) => `<option value="${escapeHtml(version.templateVersion)}"${options.viewingVersion === version.templateVersion ? ' selected' : ''}>Version ${escapeHtml(version.templateVersion)}${version.publishedAt ? ` · ${escapeHtml(String(version.publishedAt).slice(0, 10))}` : ''}</option>`).join('') : ''}
+          </select>
+          <button type="submit" class="version-go">Go</button>
+        </form>
+      </div>
+      ${options.viewingVersion ? `<div class="builder-warning version-banner"><strong>Viewing Version ${escapeHtml(options.viewingVersion)} — read-only.</strong>
         <span class="version-banner-actions"><form method="post" action="${configureHref}/restore-version">
           <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
           <input type="hidden" name="revision" value="${escapeHtml(options.realRevision)}">
           <input type="hidden" name="templateVersion" value="${escapeHtml(options.viewingVersion)}">
-          <button type="submit">Restore this version to draft</button>
+          <button type="submit">Restore to draft</button>
         </form>
-        <a href="${configureHref}">Back to draft</a></span></div>` : ''}
+        <a href="${configureHref}">Back to current draft</a></span></div>` : ''}
       ${status}${conflict}${builderErrors(options.errors)}
       <p class="builder-warning"><strong>Past entries stay intact.</strong> Removed fields are retained as restorable schema identities and hidden from new entries; earlier receipts keep their captured values and labels.</p>
       <form method="post" action="${configureHref}" class="builder-form">
@@ -1101,19 +1121,14 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
             ).join('')}</details>`;
           }).join('') : ''}
         </details>
-        <button class="button-link button-link-primary form-primary-action" type="submit" name="_action" value="save">Save draft</button>
+        <div class="builder-save-actions">
+          <button class="button-link button-link-primary form-primary-action" type="submit" name="_action" value="save">Save draft</button>
+          <button class="button-link builder-publish-action" type="submit" name="_action" value="publish">Publish</button>
+        </div>
+        <p class="builder-help">Publish saves this page and makes it live, one step. Past versions and submissions never change.</p>
         ${options.viewingVersion ? '</fieldset>' : ''}
       </form>
-      ${options.viewingVersion ? '' : `<section class="builder-publish" aria-labelledby="builder-publish-heading">
-        <h2 id="builder-publish-heading">Publish</h2>
-        <p>Publishes the last SAVED draft (revision above) as a new immutable version — if you changed anything on this page, Save draft first. Past versions and submissions never change.</p>
-        <form method="post" action="${configureHref}/publish">
-          <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-          <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
-          <button class="button-link builder-publish-action" type="submit">Publish</button>
-        </form>
-        ${configureLifecycle(template, csrfToken)}
-      </section>`}
+      ${options.viewingVersion ? '' : configureLifecycle(template, csrfToken)}
     </section>
   </main>
   ${themeScript(options.cspNonce, options.effectiveTheme || themeDefaults(template))}
@@ -1322,18 +1337,13 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
           <p class="builder-help">Checked trackers join this group; unchecking releases them. Members gain back-and-sibling navigation automatically.</p>
           <div class="container-member-choices">${membersHtml}</div>
         </section>
-        <button class="button-link button-link-primary" type="submit">Save draft</button>
+        <div class="builder-save-actions">
+          <button class="button-link button-link-primary" type="submit" name="_action" value="save">Save draft</button>
+          <button class="button-link builder-publish-action" type="submit" name="_action" value="publish">Publish</button>
+        </div>
+        <p class="builder-help">Publish saves this page and makes it live, one step.</p>
       </form>
-      <section class="builder-publish" aria-labelledby="group-publish-heading">
-        <h2 id="group-publish-heading">Publish</h2>
-        <p>Publishes the last SAVED draft (revision above) as a new immutable version — if you changed anything on this page, Save draft first. Past versions and submissions never change.</p>
-        <form method="post" action="${configureHref}/publish">
-          <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-          <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
-          <button class="button-link builder-publish-action" type="submit">Publish</button>
-        </form>
-        ${configureLifecycle(template, csrfToken)}
-      </section>
+      ${configureLifecycle(template, csrfToken)}
     </section>
   </main>
   ${themeScript(options.cspNonce, themeDefaults(template))}`;
@@ -1434,7 +1444,11 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
 }
 
 function renderArchivedFormPage(template, options = {}) {
-  const body = `${toolbarHtml(formProperties(template))}
+  const propertiesExtras = {
+    path: ['Groups', options.relatedForms && options.relatedForms.container && options.relatedForms.container.title, template && template.title].filter(Boolean).join(' > '),
+    parentTitle: options.parentTitle || null,
+  };
+  const body = `${toolbarHtml(formProperties(template, propertiesExtras))}
   <main class="layout form-layout">
     <header class="topbar">${formBreadcrumbs(template)}</header>
     ${formHubNav(template.templateId, 'log', options.canManage)}
@@ -2962,6 +2976,11 @@ function createFormsRouter(options) {
         }
         const fresh = await registry.getManagementTemplate(containerId);
         emitAudit(req, type, 'accepted', revisedContainer.draft);
+        if (postedString(req.body, '_action') === 'publish') {
+          await publishTemplateThroughApi(req, containerId, {revision: fresh.draft.revision});
+          await sendConfigure(res, await registry.getManagementTemplate(containerId), issueContext(req, res), {status: 'Saved and published.'});
+          return;
+        }
         if (postedString(req.body, '_action') === 'basics') {
           // #257: root quick-configure — one tap makes the change live.
           await publishTemplateThroughApi(req, containerId, {revision: fresh.draft.revision});
@@ -3076,6 +3095,13 @@ function createFormsRouter(options) {
         }
       }
       const revised = await reviseTemplateThroughApi(req.params.templateId, patch);
+      if (postedString(req.body, '_action') === 'publish') {
+        // #341: Publish = save this page as a draft revision, then publish it.
+        await publishTemplateThroughApi(req, req.params.templateId, {revision: revised.draft.revision});
+        emitAudit(req, type, 'accepted', revised.draft);
+        await sendConfigure(res, await registry.getManagementTemplate(req.params.templateId), issueContext(req, res), {status: 'Saved and published.'});
+        return;
+      }
       emitAudit(req, type, 'accepted', revised.draft);
       await sendConfigure(res, revised, issueContext(req, res), {status: 'Draft saved.'});
     } catch (error) {
@@ -3163,7 +3189,9 @@ function createFormsRouter(options) {
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.render', 'accepted', template);
       const relatedForms = await relatedFormsFor(req, template);
-      res.status(200).type('html').send(renderFormPage(withGroupTheme(template, relatedForms.container, await parentThemeSourceFor(registry, template)), csrfToken, {}, [], {
+      const parentTemplate = await parentThemeSourceFor(registry, template);
+      res.status(200).type('html').send(renderFormPage(withGroupTheme(template, relatedForms.container, parentTemplate), csrfToken, {}, [], {
+        parentTitle: parentTemplate ? parentTemplate.title : null,
         customThemeCss,
         cspNonce,
         recentRecords,
@@ -3205,7 +3233,9 @@ function createFormsRouter(options) {
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.submissions.list', 'accepted', template);
       const relatedForms = {container: await containerCrumbFor(template), related: []};
-      res.status(200).type('html').send(renderEntriesPage(withGroupTheme(template, relatedForms.container, await parentThemeSourceFor(registry, template)), submissions, {
+      const parentTemplate2 = await parentThemeSourceFor(registry, template);
+      res.status(200).type('html').send(renderEntriesPage(withGroupTheme(template, relatedForms.container, parentTemplate2), submissions, {
+        parentTitle: parentTemplate2 ? parentTemplate2.title : null,
         customThemeCss,
         cspNonce,
         timezone: serverTimezone,
@@ -3583,7 +3613,9 @@ function createFormsRouter(options) {
       formHeaders(res, cspNonce);
       emitAudit(req, 'form.receipt.read', 'accepted', record);
       const receiptRelated = await relatedFormsFor(req, template);
-      res.status(200).type('html').send(renderReceiptPage(withGroupTheme(template, receiptRelated.container, await parentThemeSourceFor(registry, template)), record, {
+      const receiptParent = await parentThemeSourceFor(registry, template);
+      res.status(200).type('html').send(renderReceiptPage(withGroupTheme(template, receiptRelated.container, receiptParent), record, {
+        parentTitle: receiptParent ? receiptParent.title : null,
         customThemeCss,
         cspNonce,
         canEdit,

--- a/public/style.css
+++ b/public/style.css
@@ -2914,6 +2914,12 @@ tbody tr:last-child td {
 .form-layout .version-banner-actions { display: flex; gap: 0.9rem; align-items: center; }
 .form-layout fieldset.version-view { border: 0; margin: 0; padding: 0; opacity: 0.75; }
 
+/* #341: Showing select, save/publish pair, path row. */
+.form-layout .version-showing { display: flex; align-items: center; gap: 0.6rem; font-size: 0.9rem; color: var(--text-soft); margin-bottom: 0.7rem; }
+.form-layout .version-showing select { font-size: 0.9rem; padding: 0.3rem 0.5rem; }
+.form-layout .version-go { font-size: 0.8rem; padding: 0.25rem 0.6rem; }
+.form-layout .builder-save-actions { display: flex; gap: 0.8rem; align-items: center; }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -209,8 +209,13 @@ test('hub navigation and builder lifecycle preserve snapshots, option IDs, CAS, 
     assert.match(receipt.document.body.textContent, /Squat <heavy>/);
     assert.doesNotMatch(receipt.document.body.textContent, /Back squat/);
 
-    const publishForm = configure.document.querySelector('.builder-publish form');
-    response = await browserPost(server, '/forms/training-log/configure/publish', formValues(publishForm), cookie);
+    // #341: the page's Publish is one-step (save+publish); the standalone
+    // /configure/publish route remains and is exercised here directly.
+    const publishValues = new URLSearchParams({
+      _csrf: formValues(configure.document.querySelector('.builder-form')).get('_csrf'),
+      revision: String((await server.registry.getManagementTemplate('training-log')).draft.revision),
+    });
+    response = await browserPost(server, '/forms/training-log/configure/publish', publishValues, cookie);
     assert.equal(response.status, 200);
     const published = await server.registry.getManagementTemplate('training-log');
     assert.equal(published.publishedVersion.templateVersion, 1);
@@ -590,7 +595,7 @@ test('a form carries its own Properties, reporting facts rather than claims', as
     assert.equal(rows.get('Form'), 'training-log');
     assert.equal(rows.get('Revision'), '1');
     assert.equal(rows.get('Published'), 'not published', 'reports reality, not intent');
-    assert.equal(rows.get('Destination'), 'gym-log');
+    assert.equal(rows.get('Entry storage'), 'gym-log');
     assert.equal(rows.get('Fields'), '2');
     assert.equal(rows.has('Theme'), false, 'no theme set, so no theme row');
   } finally {

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2292,10 +2292,13 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     // #337: the version viewer — Published is a dropdown; ?version renders read-only
     const viewer = await (await server.request('/forms/bench-day/configure?version=1', {headers: {Cookie: context.cookie}})).text();
     assert.match(viewer, /version-select-form/);
-    assert.match(viewer, /Viewing published v1 — read-only/);
+    assert.match(viewer, /Viewing Version 1 — read-only/);
+    assert.match(viewer, /Current draft/);
+    assert.doesNotMatch(viewer, /from r[0-9]/);
     assert.match(viewer, /fieldset disabled class="version-view"/);
-    assert.match(viewer, /Restore this version to draft/);
-    assert.doesNotMatch(viewer, /builder-publish-action/);
+    assert.match(viewer, /Restore to draft/);
+    // publish/save sit inside the disabled fieldset while viewing; lifecycle hides
+    assert.doesNotMatch(viewer, /configure-lifecycle/);
 
     // detach materializes the resolved fields onto the child
     const childRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;


### PR DESCRIPTION
Three operator asks (2026-07-31 evening), one pass:

1. "properties on a form should show its full path" — Properties gains a **Path** row (`Groups > Gym > Lat Pulldown`) and a **Parent** row when inheriting; the stale "Destination" row label becomes Entry storage.
2. "shouldn't publish also save the new draft?" — **Yes, now it does**: Publish joins Save draft inside the editor form as a one-step action (saves this page as a new revision, publishes it). The standalone /configure/publish route survives for API/scripts.
3. "the draft and publish buttons look weird, i mean the dropdowns, and the view button... versions and revisions why??? confusing" — **one numbering, one control**: the Draft/Published lines collapse into a single **Showing** select — "Current draft" or "Version N · date" — auto-refreshing (small Go for no-JS). Draft r-numbers vanish from every user surface (CAS keeps them in hidden inputs); the version banner reads "Viewing Version N — read-only" with Restore to draft / Back to current draft.
