### PR TITLE
feat(forms): root is home — button bar, root History, REAL quick entry

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -167,9 +167,8 @@ function formHubNav(templateId, active, canManage, group) {
   const formHref = `/forms/${encodeURIComponent(templateId)}`;
   // #284: the way UP rides the sticky bar — the tracker's group, or the root
   // for ungrouped trackers. Always on screen; no dead ends inside a tracker.
-  const up = group
-    ? ['up', `/forms/${encodeURIComponent(group.templateId)}`, `← ${escapeHtml(group.title)}`]
-    : ['up', '/forms', '← Trackers'];
+  // #343: up goes HOME — the root; the bottom strip keeps ← <group>.
+  const up = ['up', '/forms', '← Trackers'];
   const links = [
     up,
     ['log', formHref, 'Log an entry'],
@@ -395,12 +394,28 @@ function renderArchivedMembers(archived, csrfToken) {
 }
 
 function renderLeafRow(member, options = {}) {
+  // #343: the expanded row IS the entry form — live fields, auto-stamped
+  // datetimes, pinned stamps, Submit straight to the receipt.
+  const fields = (member.fields || []).filter((field) => field.isDestroyed !== true);
+  const datetimeSeed = localDatetimeInZone(options.now instanceof Date ? options.now : new Date(), options.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone);
+  const controls = fields.map((field) => {
+    const controlId = `quick-${member.templateId}-${field.id}`;
+    const autoStamp = field.type === 'datetime' && (field.default === undefined || field.default === '');
+    return `<div class="field field-${escapeHtml(field.type)}">
+      <label for="${escapeHtml(controlId)}">${escapeHtml(field.label)}${field.required ? ' <span aria-label="required">*</span>' : ''}</label>
+      ${renderControl(field, {}, [], false, {controlId, autoStamp, datetimeSeed})}
+    </div>`;
+  }).join('');
   return `<details class="container-member-row">
         <summary class="container-member"><a class="container-member-title" href="/forms/${encodeURIComponent(member.templateId)}">${escapeHtml(member.title)}</a><span aria-hidden="true">›</span></summary>
         <div class="container-member-preview">
-          ${renderFormPreview(member)}
+          ${options.csrfToken ? `<form method="post" action="/forms/${encodeURIComponent(member.templateId)}" class="container-member-quick">
+            <input type="hidden" name="_csrf" value="${escapeHtml(options.csrfToken)}">
+            ${controls}
+            <button class="button-link button-link-primary" type="submit">Log entry</button>
+          </form>` : renderFormPreview(member)}
           <div class="container-member-actions">
-            <a class="button-link button-link-primary container-member-open" href="/forms/${encodeURIComponent(member.templateId)}">Open ${escapeHtml(member.title)}</a>
+            <a class="container-member-open" href="/forms/${encodeURIComponent(member.templateId)}">Open ${escapeHtml(member.title)}</a>
             ${options.canManage ? `<a class="container-member-configure" href="/forms/${encodeURIComponent(member.templateId)}/configure">Configure</a>` : ''}
           </div>
         </div>
@@ -1355,6 +1370,31 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
   });
 }
 
+function renderRootHistoryPage(tagged, csrfToken, options = {}) {
+  // #343: everything's history, day-grouped, chipped "Group · Tracker".
+  const groups = new Map();
+  for (const item of tagged) {
+    const stamp = formatRecordTime(item.record, options.timezone);
+    if (!groups.has(stamp.dateKey)) groups.set(stamp.dateKey, {stamp, items: []});
+    groups.get(stamp.dateKey).items.push(item);
+  }
+  const sections = [...groups.values()].map(({stamp, items}) => `
+      <section class="entries-day" aria-labelledby="entries-${escapeHtml(stamp.dateKey)}">
+        <h2 id="entries-${escapeHtml(stamp.dateKey)}"><time datetime="${escapeHtml(stamp.dateKey)}">${escapeHtml(stamp.dayLabel)}</time></h2>
+        <div class="entry-list">${items.map(({member, record, groupTitle}) => renderEntryRow(member, record, options.timezone, csrfToken, {memberTitle: `${groupTitle ? `${groupTitle} · ` : ''}${member.title}`})).join('')}</div>
+      </section>`).join('');
+  const body = `${toolbarHtml()}
+  <main class="layout form-layout entries-layout">
+    <header class="topbar forms-index-header">
+      <div><h1>History</h1><p class="subtitle">Every tracker, newest first.</p></div>
+    </header>
+    <nav class="form-hub-nav" aria-label="Root views"><a class="view-link" href="/forms">Trackers</a><a class="entries-link" href="/forms/entries" aria-current="page">History</a></nav>
+    <section class="content form-card entries-card">${sections || '<div class="entries-empty"><h2>Nothing logged yet.</h2></div>'}</section>
+  </main>
+  ${themeScript(options.cspNonce)}`;
+  return baseHtml({title: 'History', body, customThemeCss: options.customThemeCss, cspNonce: options.cspNonce});
+}
+
 function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   // #335: the root IS the hierarchy — group sections rendering the SAME nested
   // listing the group pages use. The Groups|Trackers switcher retired with it;
@@ -1365,12 +1405,12 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   const containers = active.filter((template) => template.kind === 'container');
   const containerIds = new Set(containers.map((template) => template.templateId));
   const ungrouped = active.filter((template) => template.kind !== 'container' && !(template.containerId && containerIds.has(template.containerId)));
-  const rowOptions = {canManage: managed};
+  const rowOptions = {canManage: managed, csrfToken, timezone: options.timezone, now: options.now};
   const sections = [
     ...containers.map((container) => {
       const members = active.filter((template) => template.containerId === container.templateId);
       return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
-        <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} tracker${members.length === 1 ? '' : 's'}</span>${container.management ? `<a class="forms-index-container-configure" href="/forms/${encodeURIComponent(container.templateId)}/configure">Configure</a>` : ''}</div>
+        <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} tracker${members.length === 1 ? '' : 's'}</span></div>
         <div class="container-members">${renderNestedMembers(members, rowOptions)}</div>
       </section>`;
     }),
@@ -1385,7 +1425,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     <header class="topbar forms-index-header">
       <div><h1>Groups</h1><p class="subtitle">${managed ? 'Everything, nested — tap a group heading for its page, a name to log, a chevron to peek.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
-    ${canCreate ? '<nav class="form-hub-nav" aria-label="Create"><a class="new-link" href="/forms/new">New tracker</a><a class="newgroup-link" href="/forms/new?kind=container">New group</a></nav>' : ''}
+    <nav class="form-hub-nav" aria-label="Root views"><a class="view-link" href="/forms" aria-current="page">Trackers</a><a class="entries-link" href="/forms/entries">History</a>${canCreate ? '<a class="new-link" href="/forms/new">New tracker</a><a class="newgroup-link" href="/forms/new?kind=container">New group</a>' : ''}</nav>
     <section class="content form-card container-card">
       ${sections || emptyState}
     </section>
@@ -2681,7 +2721,7 @@ function createFormsRouter(options) {
         enriched,
         canCreate,
         issueContext(req, res),
-        {customThemeCss, cspNonce},
+        {customThemeCss, cspNonce, timezone: serverTimezone, now: currentDate()},
       ));
     } catch (error) {
       next(error);
@@ -3199,6 +3239,31 @@ function createFormsRouter(options) {
         canManage,
         relatedForms,
         now: currentDate(),
+      }));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/forms/entries', async (req, res, next) => {
+    const type = 'form.submissions.list';
+    try {
+      if (!browserAuthenticated(req, res, type)) return;
+      // #343: root History — every visible tracker's entries, merged.
+      const visible = await listTemplatesThroughApi(req);
+      const fullById = new Map((await registry.listTemplates()).map((template) => [template.templateId, template]));
+      const groupTitles = new Map(visible.filter((t) => t.kind === 'container').map((t) => [t.templateId, t.title]));
+      const members = visible.filter((t) => t.kind !== 'container' && t.state !== 'archived')
+        .map((t) => fullById.get(t.templateId)).filter(Boolean);
+      const tagged = (await containerTaggedEntries(req, members, 200)).map((item) => ({
+        ...item,
+        groupTitle: item.member.containerId ? groupTitles.get(item.member.containerId) || null : null,
+      }));
+      const cspNonce = crypto.randomBytes(18).toString('base64url');
+      formHeaders(res, cspNonce);
+      emitAudit(req, type, 'accepted');
+      res.status(200).type('html').send(renderRootHistoryPage(tagged, issueContext(req, res), {
+        customThemeCss, cspNonce, timezone: serverTimezone,
       }));
     } catch (error) {
       next(error);

--- a/public/style.css
+++ b/public/style.css
@@ -2920,6 +2920,10 @@ tbody tr:last-child td {
 .form-layout .version-go { font-size: 0.8rem; padding: 0.25rem 0.6rem; }
 .form-layout .builder-save-actions { display: flex; gap: 0.8rem; align-items: center; }
 
+/* #343: quick entry inside rows; root history. */
+.form-layout .container-member-quick { display: grid; gap: 0.7rem; margin-bottom: 0.7rem; }
+.form-layout .container-member-quick .field label { display: block; margin-bottom: 0.25rem; font-size: 0.85rem; color: var(--text-soft); }
+
 /* ============================================================================
    Document components
    ----------------------------------------------------------------------------

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2012,9 +2012,10 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     const page = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     assert.match(page, /container-member-title/);
     assert.match(page, /gym-session-entry/);
-    // member rows expand to a disabled live preview of the form's fields
-    assert.match(page, /<fieldset disabled class="container-form-preview"/);
-    assert.match(page, /preview-gym-session-entry-lift/);
+    // #343: member rows expand to a REAL entry form — live fields, csrf, submit
+    assert.match(page, /container-member-quick/);
+    assert.match(page, /quick-gym-session-entry-lift/);
+    assert.doesNotMatch(page, /fieldset disabled class="container-form-preview"/);
     assert.match(page, /container-member-open/);
     const submit = await server.request('/forms/gym', {
       method: 'POST',
@@ -2022,6 +2023,30 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
       body: nativeBody(context.token),
     });
     assert.equal(submit.status, 404);
+
+    // #343: quick entry from the listing actually WORKS — scrape the row form, submit
+    const listing = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
+    const {JSDOM: QuickDOM} = require('jsdom');
+    const quickDom = new QuickDOM(listing);
+    const quickForm = quickDom.window.document.querySelector('.container-member-quick');
+    const quickValues = new URLSearchParams();
+    for (const control of quickForm.querySelectorAll('input, select, textarea')) {
+      if (!control.name || (control.type === 'checkbox' && !control.checked)) continue;
+      quickValues.append(control.name, control.value);
+    }
+    quickValues.set('lift', 'bench');
+    quickValues.set('top-weight', '135');
+    quickValues.set('top-reps', '8');
+    quickValues.set('rpe', '7');
+    quickValues.set('notes', 'Quick entry from the listing');
+    if (!quickValues.get('session-date')) quickValues.set('session-date', '2026-07-21T10:00');
+    const quickSubmit = await server.request(quickForm.getAttribute('action'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: quickValues.toString(),
+    });
+    assert.equal(quickSubmit.status, 303, 'quick entry must submit to a receipt');
+    assert.match(quickSubmit.headers.get('location'), /receipts/);
 
     // #248: the container dashboard — a member entry surfaces on the container
     // page's recent list (chipped by form) and on the aggregated history page.
@@ -2063,7 +2088,7 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     assert.ok(exclusives >= 3, `expected >=3 exclusive toolbar disclosures, got ${exclusives}`);
     // #284/#285: a tracker's bar leads with the way up to its group
     const memberToolbar = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
-    assert.match(memberToolbar, /up-link" href="\/forms\/gym">← Gym</);
+    assert.match(memberToolbar, /up-link" href="\/forms">← Trackers</);
     // #273: the ancestor path is gone — the heading is title-only; the toolbar navigates
     assert.match(containerPage, /<nav class="breadcrumbs"><h1 class="crumb-title">/);
     assert.doesNotMatch(containerPage, /breadcrumbs"><a href="\/forms">Trackers/);


### PR DESCRIPTION
Closes #343. Root bar (Trackers | History | New tracker | New group); /forms/entries = day-grouped everything-history chipped Group · Tracker; section Configure links retire; tracker up-button = ← Trackers → /forms; expanded rows become WORKING entry forms (live fields, auto-stamp, submit → receipt) — round-trip tested from a scraped row. Suite 203/0.🤖 Generated with [Claude Code](https://claude.com/claude-code)