### PR TITLE
fix(forms): entries route order; group pages leave the nav; no nest arrows

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -469,9 +469,9 @@ function renderRelatedFormsNav(nav) {
   const related = nav && nav.related ? nav.related : [];
   const container = nav && nav.container ? nav.container : null;
   if (!related.length && !container) return '';
-  const back = container
-    ? `<a class="related-container-link" href="/forms/${encodeURIComponent(container.templateId)}">← ${escapeHtml(container.title)}</a>`
-    : '';
+  // #345: the group back-link retired with group-page navigation — the bar's
+  // ← Trackers goes home; the strip is purely lateral now.
+  const back = '';
   const pills = related.map((template) => (
     `<a class="related-form-link" href="/forms/${encodeURIComponent(template.templateId)}">${escapeHtml(template.title)}</a>`
   )).join('');
@@ -1410,7 +1410,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     ...containers.map((container) => {
       const members = active.filter((template) => template.containerId === container.templateId);
       return `<section class="forms-index-container" aria-label="${escapeHtml(container.title)}">
-        <div class="forms-index-container-head"><a href="/forms/${encodeURIComponent(container.templateId)}"><h2>${escapeHtml(container.title)}</h2></a><span class="forms-index-container-count">${members.length} tracker${members.length === 1 ? '' : 's'}</span></div>
+        <div class="forms-index-container-head"><h2>${escapeHtml(container.title)}</h2><span class="forms-index-container-count">${members.length} tracker${members.length === 1 ? '' : 's'}</span>${container.management ? `<a class="forms-index-container-configure" href="/forms/${encodeURIComponent(container.templateId)}/configure">Configure</a>` : ''}</div>
         <div class="container-members">${renderNestedMembers(members, rowOptions)}</div>
       </section>`;
     }),
@@ -3194,6 +3194,31 @@ function createFormsRouter(options) {
     }
   });
 
+  router.get('/forms/entries', async (req, res, next) => {
+    const type = 'form.submissions.list';
+    try {
+      if (!browserAuthenticated(req, res, type)) return;
+      // #343: root History — every visible tracker's entries, merged.
+      const visible = await listTemplatesThroughApi(req);
+      const fullById = new Map((await registry.listTemplates()).map((template) => [template.templateId, template]));
+      const groupTitles = new Map(visible.filter((t) => t.kind === 'container').map((t) => [t.templateId, t.title]));
+      const members = visible.filter((t) => t.kind !== 'container' && t.state !== 'archived')
+        .map((t) => fullById.get(t.templateId)).filter(Boolean);
+      const tagged = (await containerTaggedEntries(req, members, 100)).map((item) => ({
+        ...item,
+        groupTitle: item.member.containerId ? groupTitles.get(item.member.containerId) || null : null,
+      }));
+      const cspNonce = crypto.randomBytes(18).toString('base64url');
+      formHeaders(res, cspNonce);
+      emitAudit(req, type, 'accepted');
+      res.status(200).type('html').send(renderRootHistoryPage(tagged, issueContext(req, res), {
+        customThemeCss, cspNonce, timezone: serverTimezone,
+      }));
+    } catch (error) {
+      next(error);
+    }
+  });
+
   router.get('/forms/:templateId', async (req, res, next) => {
     try {
       if (!browserAuthenticated(req, res, 'form.render')) return;
@@ -3239,31 +3264,6 @@ function createFormsRouter(options) {
         canManage,
         relatedForms,
         now: currentDate(),
-      }));
-    } catch (error) {
-      next(error);
-    }
-  });
-
-  router.get('/forms/entries', async (req, res, next) => {
-    const type = 'form.submissions.list';
-    try {
-      if (!browserAuthenticated(req, res, type)) return;
-      // #343: root History — every visible tracker's entries, merged.
-      const visible = await listTemplatesThroughApi(req);
-      const fullById = new Map((await registry.listTemplates()).map((template) => [template.templateId, template]));
-      const groupTitles = new Map(visible.filter((t) => t.kind === 'container').map((t) => [t.templateId, t.title]));
-      const members = visible.filter((t) => t.kind !== 'container' && t.state !== 'archived')
-        .map((t) => fullById.get(t.templateId)).filter(Boolean);
-      const tagged = (await containerTaggedEntries(req, members, 200)).map((item) => ({
-        ...item,
-        groupTitle: item.member.containerId ? groupTitles.get(item.member.containerId) || null : null,
-      }));
-      const cspNonce = crypto.randomBytes(18).toString('base64url');
-      formHeaders(res, cspNonce);
-      emitAudit(req, type, 'accepted');
-      res.status(200).type('html').send(renderRootHistoryPage(tagged, issueContext(req, res), {
-        customThemeCss, cspNonce, timezone: serverTimezone,
       }));
     } catch (error) {
       next(error);

--- a/public/style.css
+++ b/public/style.css
@@ -2896,8 +2896,7 @@ tbody tr:last-child td {
 .form-layout .drag-handle { cursor: grab; touch-action: none; color: var(--text-soft); padding: 0.1rem 0.35rem; user-select: none; letter-spacing: -0.12em; }
 .form-layout .dragging { opacity: 0.55; }
 .form-layout .fields-table-local { display: contents; }
-.form-layout .tracker-nested { margin-left: 1.4rem; position: relative; }
-.form-layout .tracker-nested::before { content: '↳'; position: absolute; left: -1.1rem; top: 50%; transform: translateY(-50%); color: var(--text-soft); }
+.form-layout .tracker-nested { margin-left: 1.4rem; }
 
 /* #333/#334: delete affordance + version restore. */
 .form-layout .delete-button { color: #ff6b6b; border-color: color-mix(in srgb, #ff6b6b 45%, transparent); }

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2024,6 +2024,10 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     });
     assert.equal(submit.status, 404);
 
+    // #345: /forms/entries resolves as root history, not a template lookup
+    const rootHistory = await server.request('/forms/entries', {headers: {Cookie: context.cookie}});
+    assert.equal(rootHistory.status, 200, 'root history must not be eaten by :templateId');
+
     // #343: quick entry from the listing actually WORKS — scrape the row form, submit
     const listing = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
     const {JSDOM: QuickDOM} = require('jsdom');
@@ -2067,8 +2071,8 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
 
     // member form carries the back-to-container button
     const member = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
-    assert.match(member, /related-container-link/);
-    assert.match(member, /← Gym/);
+    // #345: the strip is purely lateral — no group back-link (the bar goes home)
+    assert.doesNotMatch(member, /related-container-link/);
 
     // #335: the root renders group sections through the shared nested listing
     const root = await (await server.request('/forms', {headers: {Cookie: context.cookie}})).text();
@@ -2438,7 +2442,7 @@ test('related-strip config: all-in-group default, cross-group picks, API roundtr
     page = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
     assert.doesNotMatch(page, /related-form-link" href="\/forms\/cardio"/);
     assert.match(page, /related-form-link" href="\/forms\/weight"/);
-    assert.match(page, /related-container-link/);
+    assert.doesNotMatch(page, /related-container-link/);
 
     // configure carries the compact disclosure; bad include ids are refused
     const configure = await (await server.request('/forms/gym-session-entry/configure', {headers: {Cookie: context.cookie}})).text();


### PR DESCRIPTION
Operator (2026-07-31 night): "/forms/entries not found... /forms/gym ...I don't think we even need that type of page anymore, configure can just be next to the group like it was before. the little down and right arrows next to the nested trackers... not needed."

- **/forms/entries 404**: registered after `/forms/:templateId` — 'entries' was eaten as a template id; also the merged-history limit exceeded the store cap (100) once routed. Both fixed; regression-guarded in the suite.
- **Group pages leave the nav**: root section heads regain Configure (heading unlinked); the strip's group back-link retires (bar's ← Trackers is the way up; strip = lateral only). The /forms/:groupId routes stay alive for URLs, just unadvertised.
- **Nest arrows removed** — indent suffices.
