### PR TITLE
feat(forms): three kinds — parents define, groups get the version paradigm

### DIFF
--- a/docs/TRACKERS.md
+++ b/docs/TRACKERS.md
@@ -10,6 +10,22 @@ Enable it with the `forms:` block in the config (see
 [CONFIGURATION.md](CONFIGURATION.md) and the annotated
 `lookie-link.yaml.example`). Everything below assumes it is enabled.
 
+## Three kinds (internal taxonomy)
+
+Internally the platform has three kinds of template — the labels below are
+for builders and this doc, not end-user marketing:
+
+- **TRACKER** (`kind: 'form'`) — logs. Entry form, history, receipts.
+- **PARENT** (`kind: 'parent'`, or any form something inherits from) —
+  defines. Its fields serve on its children live; it never accepts new
+  entries itself (a born parent refuses everything and carries no entry
+  storage; an emergent parent — a form that gained children — keeps its
+  legacy history readable and correctable but takes no new entries). Its
+  page lists its children.
+- **GROUP** (`kind: 'container'`) — holds. Navigation, membership, theme
+  defaults, aggregated history. Same lifecycle and versioning as everything
+  else.
+
 ## Two-plane language
 
 End-user surfaces say **tracker** and **group**. The builder, the API, and the

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -430,12 +430,40 @@ function renderNestedMembers(members, options = {}) {
   const tops = members.filter((member) => !(member.parentId && ids.has(member.parentId)));
   return tops.map((top) => {
     const children = childrenOf(top.templateId);
-    if (!children.length) return renderLeafRow(top, options);
+    if (!children.length) {
+      // #347: a born-parent with nothing inheriting yet still never logs.
+      if (top.kind === 'parent') return `<a class="container-member forms-root-row" href="/forms/${encodeURIComponent(top.templateId)}"><span class="container-member-title">${escapeHtml(top.title)}</span><span class="forms-root-count">defines</span><span aria-hidden="true">›</span></a>`;
+      return renderLeafRow(top, options);
+    }
     return `<details class="container-member-row parent-tracker-row">
         <summary class="container-member"><a class="container-member-title" href="/forms/${encodeURIComponent(top.templateId)}">${escapeHtml(top.title)}</a><span class="forms-root-count">${children.length} tracker${children.length === 1 ? '' : 's'}</span><span aria-hidden="true">›</span></summary>
         <div class="nested-children">${children.map((child) => `<div class="tracker-nested">${renderLeafRow(child, options)}</div>`).join('')}</div>
       </details>`;
   }).join('');
+}
+
+function renderParentPage(template, children, options = {}) {
+  // #347: a PARENT with children is a definition, not a logging surface — its
+  // page is its children (quick entry included) plus its own history.
+  const body = `${toolbarHtml(formProperties(template, {path: ['Groups', options.relatedForms && options.relatedForms.container && options.relatedForms.container.title, template.title].filter(Boolean).join(' > ')}))}
+  <main class="layout form-layout container-layout">
+    <header class="topbar">
+      <div>${formBreadcrumbs(template)}${template.description ? `<p class="subtitle">${escapeHtml(template.description)}</p>` : ''}<p class="subtitle">Defines ${children.length} tracker${children.length === 1 ? '' : 's'} — log on one of them below.</p></div>
+    </header>
+    <nav class="form-hub-nav" aria-label="Parent views"><a class="up-link" href="/forms">← Trackers</a><a class="view-link" href="/forms/${encodeURIComponent(template.templateId)}" aria-current="page">Trackers</a><a class="entries-link" href="/forms/${encodeURIComponent(template.templateId)}/entries">History</a>${options.canManage ? `<a class="configure-link" href="/forms/${encodeURIComponent(template.templateId)}/configure">Configure</a>` : ''}</nav>
+    <section class="content form-card container-card">
+      <div class="container-members">${renderNestedMembers(children, options)}</div>
+    </section>
+  </main>
+  ${themeScript(options.cspNonce, themeDefaults(template))}`;
+  return baseHtml({
+    title: template.title,
+    body,
+    customThemeCss: options.customThemeCss,
+    cspNonce: options.cspNonce,
+    defaultScheme: themeDefaults(template).scheme || null,
+    defaultMode: themeDefaults(template).mode || null,
+  });
 }
 
 function renderContainerPage(template, members, options = {}) {
@@ -1332,14 +1360,29 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
     </header>
     ${containerHubNav(template.templateId, 'configure', true)}
     <section class="content form-card builder-card container-configure-card">
-      <dl class="builder-revisions">
-        <div><dt>Draft</dt><dd>Revision ${escapeHtml(template.revision)}</dd></div>
-        <div><dt>Published</dt><dd>${escapeHtml(publishedText)}</dd></div>
-      </dl>
+      <div class="builder-revisions version-showing">
+        <span>Showing</span>
+        <form method="get" action="${configureHref}" class="version-select-form">
+          <select name="version">
+            <option value=""${options.viewingVersion ? '' : ' selected'}>Current draft</option>
+            ${Array.isArray(record.publishedVersions) ? [...record.publishedVersions].reverse().map((version) => `<option value="${escapeHtml(version.templateVersion)}"${options.viewingVersion === version.templateVersion ? ' selected' : ''}>Version ${escapeHtml(version.templateVersion)}${version.publishedAt ? ` · ${escapeHtml(String(version.publishedAt).slice(0, 10))}` : ''}</option>`).join('') : ''}
+          </select>
+          <button type="submit" class="version-go">Go</button>
+        </form>
+      </div>
+      ${options.viewingVersion ? `<div class="builder-warning version-banner"><strong>Viewing Version ${escapeHtml(options.viewingVersion)} — read-only.</strong>
+        <span class="version-banner-actions"><form method="post" action="${configureHref}/restore-version">
+          <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
+          <input type="hidden" name="revision" value="${escapeHtml(options.realRevision)}">
+          <input type="hidden" name="templateVersion" value="${escapeHtml(options.viewingVersion)}">
+          <button type="submit">Restore to draft</button>
+        </form>
+        <a href="${configureHref}">Back to current draft</a></span></div>` : ''}
       ${status}${conflict}${builderErrors(options.errors)}
       <form method="post" action="${configureHref}" class="builder-form">
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
         <input type="hidden" name="revision" value="${escapeHtml(template.revision)}">
+        ${options.viewingVersion ? '<fieldset disabled class="version-view">' : ''}
         <section class="builder-basics" aria-labelledby="container-basics-heading">
           <h2 id="container-basics-heading">Group</h2>
           <label><span>Title</span><input name="title" value="${escapeHtml(template.title)}" maxlength="200" required></label>
@@ -1357,11 +1400,18 @@ function renderContainerConfigurePage(record, csrfToken, options = {}) {
           <button class="button-link builder-publish-action" type="submit" name="_action" value="publish">Publish</button>
         </div>
         <p class="builder-help">Publish saves this page and makes it live, one step.</p>
+        ${options.viewingVersion ? '</fieldset>' : ''}
       </form>
-      ${configureLifecycle(template, csrfToken)}
+      ${options.viewingVersion ? '' : configureLifecycle(template, csrfToken)}
     </section>
   </main>
-  ${themeScript(options.cspNonce, themeDefaults(template))}`;
+  ${themeScript(options.cspNonce, themeDefaults(template))}
+  <script${options.cspNonce ? ` nonce="${escapeHtml(options.cspNonce)}"` : ''}>
+  document.addEventListener('change', function (event) {
+    var select = event.target.closest('.version-select-form select');
+    if (select) select.form.submit();
+  });
+  </script>`;
   return baseHtml({
     title: `Configure — ${template.title}`,
     body,
@@ -1461,7 +1511,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
         <label><span>Name</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required autofocus></label>
         <label><span>ID (optional)</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*"></label>
         <p class="builder-help">Leave the ID blank and it derives from the name (#279).</p>
-        ${options.group ? `<input type="hidden" name="group" value="${escapeHtml(options.group.templateId)}"><p class="builder-help">Joining group: <strong>${escapeHtml(options.group.title || options.group.templateId)}</strong></p>` : `<label><span>Kind</span><select name="kind"><option value="">Form</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>`}
+        ${options.group ? `<input type="hidden" name="group" value="${escapeHtml(options.group.templateId)}"><p class="builder-help">Joining group: <strong>${escapeHtml(options.group.title || options.group.templateId)}</strong></p>` : `<label><span>Kind</span><select name="kind"><option value="">Form</option><option value="parent"${options.kind === 'parent' ? ' selected' : ''}>Parent (defines trackers — does not log itself)</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>`}
         <details class="builder-advanced"><summary>Advanced</summary>
         <label><span>Entry storage</span><select name="destinationId">${destinationOptions}</select></label>
         <p class="builder-help">Where entries are saved — a storage area named by the server operator; ${options.group ? 'preset to what this group already uses' : "'default' is fine"}. Applies to trackers only (groups hold trackers, not entries).</p>
@@ -2251,7 +2301,7 @@ function createFormsRouter(options) {
           destinationId: record.draft.destinationId || 'default',
           state: record.state,
           entryCount,
-          kind: record.draft.kind === 'container' ? 'container' : 'form',
+          kind: record.draft.kind === 'container' || record.draft.kind === 'parent' ? record.draft.kind : 'form',
           containerId: record.draft.containerId || null,
           parentId: record.draft.parentId || null,
           theme: (record.draft.presentation && record.draft.presentation.theme) || '',
@@ -2261,7 +2311,7 @@ function createFormsRouter(options) {
         templates.push({
           templateId: record.draft.templateId,
           title: record.draft.title,
-          kind: record.draft.kind === 'container' ? 'container' : 'form',
+          kind: record.draft.kind === 'container' || record.draft.kind === 'parent' ? record.draft.kind : 'form',
           containerId: record.draft.containerId || null,
           parentId: record.draft.parentId || null,
         });
@@ -2793,6 +2843,10 @@ function createFormsRouter(options) {
       // no destination; the Configure page then manages members.
       const body = kind === 'container'
         ? {templateId, grammarVersion: 1, title, kind: 'container'}
+        : kind === 'parent'
+        ? {templateId, grammarVersion: 1, title, kind: 'parent',
+          fields: [{id: 'entry', type: 'short-text', label: 'Entry', required: true}],
+          ...(postedString(req.body, 'group') ? {containerId: postedString(req.body, 'group')} : {})}
         : {
           templateId,
           grammarVersion: 1,
@@ -3248,6 +3302,27 @@ function createFormsRouter(options) {
         }));
         return;
       }
+      // #347: parents define — born (kind) or emergent (something inherits).
+      const activeChildIds = registry.childrenOf(template.templateId);
+      if (template.kind === 'parent' || activeChildIds.length) {
+        const fullById = new Map((await registry.listTemplates()).map((entry) => [entry.templateId, entry]));
+        const children = [];
+        for (const childId of activeChildIds) {
+          const child = fullById.get(childId);
+          if (!child) continue;
+          if (await allowed(req, 'forms.submit', child) || await allowed(req, 'forms.view', child)) children.push(child);
+        }
+        const relatedForms = await relatedFormsFor(req, template);
+        const csrfToken = issueContext(req, res);
+        const cspNonce = crypto.randomBytes(18).toString('base64url');
+        formHeaders(res, cspNonce);
+        emitAudit(req, 'form.render', 'accepted', template);
+        res.status(200).type('html').send(renderParentPage(template, children, {
+          customThemeCss, cspNonce, canManage, csrfToken, relatedForms,
+          timezone: serverTimezone, now: currentDate(),
+        }));
+        return;
+      }
       const recentRecords = await listVisibleSubmissions(req, template, RECENT_ENTRY_LIMIT) || [];
       const csrfToken = issueContext(req, res);
       const cspNonce = crypto.randomBytes(18).toString('base64url');
@@ -3386,6 +3461,13 @@ function createFormsRouter(options) {
       const template = await registry.getTemplate(req.params.templateId);
       if (!template || !await allowed(req, 'forms.submit', template)) return formNotFound(req, res, 'form.submit');
       if (template.kind === 'container') return formNotFound(req, res, 'form.submit');
+      // #347: parents define, they do not log. Born parents refuse everything;
+      // emergent parents (something inherits) still allow CORRECTIONS to their
+      // legacy entries but no new ones.
+      if (template.kind === 'parent') return formNotFound(req, res, 'form.submit');
+      if (registry.childrenOf(template.templateId).length && !(req.body && req.body._supersedes)) {
+        return formNotFound(req, res, 'form.submit');
+      }
       const destinationStore = storeForTemplate(store, template);
       const actor = principalFor(req);
       if (!actor) return formNotFound(req, res, 'form.submit');
@@ -3508,6 +3590,10 @@ function createFormsRouter(options) {
       const template = await registry.getTemplate(req.params.templateId);
       if (!template || !await allowed(req, 'forms.submit', template)) return apiNotFound(req, res);
       if (template.kind === 'container') return apiNotFound(req, res);
+      if (template.kind === 'parent') return apiNotFound(req, res);
+      if (registry.childrenOf(template.templateId).length && !(req.body && req.body.supersedesRecord)) {
+        return apiNotFound(req, res);
+      }
       const destinationStore = storeForTemplate(store, template);
       const actor = principalFor(req);
       if (!actor) return apiNotFound(req, res);

--- a/lib/forms/schema.js
+++ b/lib/forms/schema.js
@@ -418,8 +418,13 @@ function validateTemplate(doc) {
   for (const key of required) if (!own(doc, key)) addError(errors, key, 'is required');
   // #234: containers are templates of kind 'container' — same lifecycle, no fields,
   // no destination, no nesting. Their page renders member navigation instead.
-  if (own(doc, 'kind') && doc.kind !== 'form' && doc.kind !== 'container') {
-    addError(errors, 'kind', "must be 'form' or 'container'");
+  // #347: three kinds — form (logs), container (holds), parent (defines).
+  if (own(doc, 'kind') && doc.kind !== 'form' && doc.kind !== 'container' && doc.kind !== 'parent') {
+    addError(errors, 'kind', "must be 'form', 'parent', or 'container'");
+  }
+  if (doc.kind === 'parent') {
+    if (own(doc, 'destinationId')) addError(errors, 'destinationId', 'must be absent for a parent — parents define, they do not log');
+    if (own(doc, 'parentId')) addError(errors, 'parentId', 'a parent cannot itself inherit (single level)');
   }
   if (isContainer) {
     if (own(doc, 'fields') && (!Array.isArray(doc.fields) || doc.fields.length > 0)) {

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2329,6 +2329,38 @@ test('parent/sub-form inheritance: resolution, overrides, live edits, detach, gu
     // publish/save sit inside the disabled fieldset while viewing; lifecycle hides
     assert.doesNotMatch(viewer, /configure-lifecycle/);
 
+    // #347: three kinds — the emergent parent's page is its children, not a form
+    const parentPage = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    assert.match(parentPage, /Defines 2 trackers/);
+    assert.match(parentPage, /container-member-title" href="\/forms\/bench-day"/);
+    assert.doesNotMatch(parentPage, /name="_supersedes"|form-primary-action" type="submit">Submit/);
+    // new entries into an emergent parent are refused; corrections still land
+    const refuse = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: nativeBody(context.token),
+    });
+    assert.equal(refuse.status, 404, 'parent with children must refuse new entries');
+    // born parent: kind parent from creation — never logs, no destination
+    const born = await post('/api/forms/templates', {templateId: 'measurements', title: 'Measurements', grammarVersion: 1, kind: 'parent',
+      fields: [{id: 'value', type: 'number', label: 'Value', required: true}]});
+    assert.equal(born.status, 201);
+    const bornBad = await post('/api/forms/templates', {templateId: 'bad-parent', title: 'Bad', grammarVersion: 1, kind: 'parent', destinationId: 'default',
+      fields: [{id: 'value', type: 'number', label: 'Value', required: true}]});
+    assert.equal(bornBad.status, 422, 'parents must not carry entry storage');
+    const bornPage = await (await server.request('/forms/measurements', {headers: {Cookie: context.cookie}})).text();
+    assert.match(bornPage, /Defines 0 trackers/);
+    // #347: groups get the version paradigm — Showing select + read-only viewer
+    assert.equal((await post('/api/forms/templates/vgroup', {})).status >= 400, true);
+    await post('/api/forms/templates', {templateId: 'vgroup', title: 'VGroup', grammarVersion: 1, kind: 'container'});
+    await post('/api/forms/templates/vgroup/publish', {revision: 1});
+    const groupConfigure = await (await server.request('/forms/vgroup/configure', {headers: {Cookie: context.cookie}})).text();
+    assert.match(groupConfigure, /version-showing/);
+    assert.match(groupConfigure, /Current draft/);
+    const groupViewer = await (await server.request('/forms/vgroup/configure?version=1', {headers: {Cookie: context.cookie}})).text();
+    assert.match(groupViewer, /Viewing Version 1 — read-only/);
+    assert.match(groupViewer, /fieldset disabled class="version-view"/);
+
     // detach materializes the resolved fields onto the child
     const childRev = JSON.parse(await (await server.request('/api/forms/templates/bench-day')).text()).template.revision;
     const detached = await patch('/api/forms/templates/bench-day', {revision: childRev, parentId: null});


### PR DESCRIPTION
Closes #347. TRACKER logs / PARENT defines / GROUP holds. kind:parent creatable from birth (no entry storage, refuses submissions, page = children); emergent parents refuse NEW entries, corrections to legacy history still land; groups gain the full Showing/version-viewer/restore paradigm. TRACKERS.md records the taxonomy. Suite 203/0.🤖 Generated with [Claude Code](https://claude.com/claude-code)