### PR TITLE
fix(embed): resolve theme tokens from the active color scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased — Embed follows the active color scheme (#352)
+
+- Embedded documents that opt into `data-lookie-follow-theme` now use the colors of the **selected scheme** (Slate, Teal, Nord, El Charro, …), not a fixed light/dark pair. `themeScheme` was already accepted and written to the root, but nothing consumed it — the tokens were constants.
+- Built-in scheme palettes live only as CSS in `public/style.css`, which the embedded document never loads, and `customThemeCss` was keyed on attributes the embed root did not set. The embed now ships the `:root[data-color-scheme="…"]` blocks lifted from the viewer stylesheet (custom-property declarations only — they style no elements, so they cannot leak into authored page CSS), sets `data-color-scheme` / `data-theme` on its root so both built-in and custom blocks match, and aliases `--lookie-bg: var(--bg, …)` and friends off the resolved scheme. `public/style.css` stays the single source of truth.
+- The runtime `lookie-link:set-theme` handler sets the scheme attributes too, so switching scheme or mode re-resolves in CSS with no reload.
+- Tests: two negative canaries — dropping the aliasing, or not shipping the built-in palettes, each fails the suite.
+
 ## Unreleased — Embed theme tokens and the annotation gate (#350, #351)
 
 - Fixed theme-follow, which never followed. The embed injected `color-scheme: <mode>` but pinned the `--lookie-*` token *values* to one hardcoded dark palette. Documents consume those as `var(--lookie-bg, <light-fallback>)`, and a CSS fallback only applies when the property is undefined — so an always-defined dark token made every authored light fallback unreachable, and every theme-following document rendered dark whatever the toggle said. Both palettes now ship, keyed on `data-lookie-link-theme`, so the runtime `lookie-link:set-theme` message re-themes without a reload. Dark values are byte-identical to before (no visual shift for the default); light mirrors the viewer's slate-light chrome so embedded content matches the frame around it.

--- a/lib/embed-html.js
+++ b/lib/embed-html.js
@@ -264,6 +264,58 @@ function markAnnotationTargets(document) {
 const DARK_THEME_TOKENS = '--lookie-bg: #111827; --lookie-bg-elev: #1f2937; --lookie-bg-code: #0f172a; --lookie-text: #e5e7eb; --lookie-text-soft: #9ca3af; --lookie-accent: #22c55e; --lookie-border: #374151; --lookie-link: #38bdf8;';
 const LIGHT_THEME_TOKENS = '--lookie-bg: #f4f6f8; --lookie-bg-elev: #ffffff; --lookie-bg-code: #edf1f5; --lookie-text: #1a2630; --lookie-text-soft: #5a6b78; --lookie-accent: #3a7a92; --lookie-border: #d0dae3; --lookie-link: #1f6d8a;';
 
+// The bridge tokens an authored page reads, mapped to the scheme variable each one
+// mirrors. Aliasing (rather than copying values server-side) keeps public/style.css
+// the single source of truth for built-in palettes and lets a runtime scheme change
+// re-resolve in CSS with no reload.
+const LOOKIE_TOKEN_ALIASES = [
+  ['--lookie-bg', '--bg'],
+  ['--lookie-bg-elev', '--bg-elev'],
+  ['--lookie-bg-code', '--bg-code'],
+  ['--lookie-text', '--text'],
+  ['--lookie-text-soft', '--text-soft'],
+  ['--lookie-accent', '--accent'],
+  ['--lookie-border', '--border'],
+  ['--lookie-link', '--link'],
+];
+
+function tokenAliasBlock(fallbackTokens) {
+  const fallbacks = new Map(
+    fallbackTokens.split(';')
+      .map((pair) => pair.trim())
+      .filter(Boolean)
+      .map((pair) => {
+        const at = pair.indexOf(':');
+        return [pair.slice(0, at).trim(), pair.slice(at + 1).trim()];
+      }),
+  );
+  return LOOKIE_TOKEN_ALIASES
+    .map(([token, source]) => `${token}: var(${source}, ${fallbacks.get(token)});`)
+    .join(' ');
+}
+
+// Built-in scheme palettes live only as CSS in public/style.css, which the embedded
+// document never loads. Lift out just the `:root[data-color-scheme=...]` blocks: they
+// declare custom properties and style no elements, so they cannot leak into an
+// authored page's own styling.
+let builtInSchemeCssCache = null;
+function builtInSchemeCss() {
+  if (builtInSchemeCssCache !== null) return builtInSchemeCssCache;
+  try {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'public', 'style.css'), 'utf8');
+    const blocks = [];
+    const selector = /:root\[data-color-scheme="[a-z0-9-]+"\](?:\[data-theme="light"\])?\s*\{[^}]*\}/g;
+    let match;
+    while ((match = selector.exec(source)) !== null) blocks.push(match[0]);
+    builtInSchemeCssCache = blocks.join('\n');
+  } catch (_error) {
+    // A missing or unreadable stylesheet must not break rendering — the embed
+    // falls back to the constant palettes below.
+    builtInSchemeCssCache = '';
+  }
+  return builtInSchemeCssCache;
+}
+
 // The embedded document does not load the viewer's public/style.css, so the gate
 // that hides annotate buttons until annotation mode is on never reached it and the
 // buttons rendered unconditionally. Mirror the two rules that matter here.
@@ -274,6 +326,11 @@ function addThemeInjection(document, options) {
   const scheme = /^[a-z0-9-]+$/.test(options.themeScheme || '') ? options.themeScheme : 'slate';
   document.documentElement.setAttribute('data-lookie-link-theme', mode);
   document.documentElement.setAttribute('data-lookie-link-scheme', scheme);
+  // The scheme blocks (built-in and custom alike) key on the viewer's own
+  // attribute names, so the embed root has to carry them for any block to match.
+  document.documentElement.setAttribute('data-color-scheme', scheme);
+  if (mode === 'light') document.documentElement.setAttribute('data-theme', 'light');
+  else document.documentElement.removeAttribute('data-theme');
 
   const base = document.createElement('base');
   const currentDir = path.posix.dirname(options.relativePath);
@@ -291,9 +348,15 @@ function addThemeInjection(document, options) {
   // matches the frame it sits in.
   style.textContent = [
     `:root { color-scheme: ${mode}; }`,
-    `:root, :root[data-lookie-link-theme="dark"] { ${DARK_THEME_TOKENS} }`,
-    `:root[data-lookie-link-theme="light"] { color-scheme: light; ${LIGHT_THEME_TOKENS} }`,
+    // Scheme palettes first, so the aliases below have --bg/--text/... to resolve
+    // against. Built-in blocks are lifted from the viewer stylesheet; custom
+    // themes arrive already keyed on the same attributes.
+    builtInSchemeCss(),
     options.customThemeCss || '',
+    // Aliases last. Fallbacks keep a document readable if a scheme block is
+    // missing entirely, and stay mode-correct via the attribute key.
+    `:root, :root[data-lookie-link-theme="dark"] { ${tokenAliasBlock(DARK_THEME_TOKENS)} }`,
+    `:root[data-lookie-link-theme="light"] { color-scheme: light; ${tokenAliasBlock(LIGHT_THEME_TOKENS)} }`,
   ].join('\n');
   document.head.appendChild(style);
 
@@ -308,7 +371,7 @@ function addThemeInjection(document, options) {
   //   blocked), so the runtime reports its own scroll height. targetOrigin must
   //   be '*' because an opaque origin cannot name its parent; the payload is
   //   only a height number.
-  script.textContent = `(function () {\n  var framed = window.parent !== window;\n  // Styling hook: the frame is content-height, so position:fixed overlays cover the\n  // whole document instead of the visible viewport — CSS (e.g. the kit's\n  // photo-lightbox) switches to in-flow variants under this class.\n  if (framed) document.documentElement.classList.add('lookie-embedded');\n  window.addEventListener('message', function (event) {\n    if (event.source !== window.parent || !event.data) return;\n    if (event.data.type === 'lookie-link:set-theme') {\n      document.documentElement.setAttribute('data-lookie-link-theme', event.data.mode === 'light' ? 'light' : 'dark');\n      if (/^[a-z0-9-]+$/.test(event.data.scheme || '')) document.documentElement.setAttribute('data-lookie-link-scheme', event.data.scheme);\n    }\n    if (event.data.type === 'lookie-link:set-annotation-mode') {\n      document.documentElement.classList.toggle('lookie-annotations-active', Boolean(event.data.enabled));\n    }\n  });\n  var lastHeight = 0;\n  function reportHeight() {\n    if (!framed) return;\n    var height = Math.max(\n      document.documentElement ? document.documentElement.scrollHeight : 0,\n      document.body ? document.body.scrollHeight : 0\n    );\n    if (height > 0 && height !== lastHeight) {\n      lastHeight = height;\n      window.parent.postMessage({ type: 'lookie-link:content-height', height: height }, '*');\n    }\n  }\n  document.addEventListener('DOMContentLoaded', reportHeight);\n  window.addEventListener('load', reportHeight);\n  if (typeof ResizeObserver === 'function') {\n    new ResizeObserver(reportHeight).observe(document.documentElement);\n  }\n  window.setInterval(reportHeight, 1500);\n  // A content-height frame cannot scroll internally, so fragment targets would be\n  // dead: report the target's document offset and let the viewer scroll to it.\n  function reportAnchor() {\n    if (!framed || !location.hash) return;\n    var id;\n    try { id = decodeURIComponent(location.hash.slice(1)); } catch (_e) { id = location.hash.slice(1); }\n    var el = id && document.getElementById(id);\n    if (!el) return;\n    var y = el.getBoundingClientRect().top + (window.scrollY || 0);\n    window.parent.postMessage({ type: 'lookie-link:scroll-to', y: Math.max(0, y) }, '*');\n  }\n  window.addEventListener('load', reportAnchor);\n  window.addEventListener('hashchange', reportAnchor);\n  // Image zoom goes through the VIEWER's own lightbox overlay (the same one\n  // markdown files use) — an in-document overlay cannot center on the visible\n  // viewport from inside a content-height frame. Clicking a link that targets a\n  // .photo-lightbox stage is intercepted and forwarded as an open-image request.\n  document.addEventListener('click', function (event) {\n    if (!framed || event.defaultPrevented) return;\n    var anchor = event.target && event.target.closest ? event.target.closest('a') : null;\n    if (!anchor) return;\n    var href = anchor.getAttribute('href') || '';\n    var hashAt = href.indexOf('#');\n    if (hashAt < 0) return;\n    var id;\n    try { id = decodeURIComponent(href.slice(hashAt + 1)); } catch (_e) { id = href.slice(hashAt + 1); }\n    var stage = id && document.getElementById(id);\n    if (!stage || !stage.classList || !stage.classList.contains('photo-lightbox')) return;\n    var img = stage.querySelector('img');\n    var src = img && (img.currentSrc || img.src);\n    if (!src) return;\n    event.preventDefault();\n    window.parent.postMessage({\n      type: 'lookie-link:open-image',\n      src: src,\n      alt: (img.getAttribute('alt') || anchor.getAttribute('aria-label') || '')\n    }, '*');\n  }, true);\n  // Escape closes the viewer lightbox (focus usually lives inside this frame), and\n  // still releases any fragment-targeted overlay by navigating to its close link.\n  window.addEventListener('keydown', function (event) {\n    if (event.key !== 'Escape' || !framed) return;\n    window.parent.postMessage({ type: 'lookie-link:close-image' }, '*');\n    var target = null;\n    try { target = document.querySelector(':target'); } catch (_e) {}\n    if (!target || target.tagName !== 'A') return;\n    var href = target.getAttribute('href') || '';\n    var hash = href.indexOf('#') >= 0 ? href.slice(href.indexOf('#')) : '';\n    if (!/^#[A-Za-z0-9_-]*$/.test(hash)) return;\n    window.parent.postMessage({ type: 'lookie-link:set-hash', hash: hash }, '*');\n  });\n}());`;
+  script.textContent = `(function () {\n  var framed = window.parent !== window;\n  // Styling hook: the frame is content-height, so position:fixed overlays cover the\n  // whole document instead of the visible viewport — CSS (e.g. the kit's\n  // photo-lightbox) switches to in-flow variants under this class.\n  if (framed) document.documentElement.classList.add('lookie-embedded');\n  window.addEventListener('message', function (event) {\n    if (event.source !== window.parent || !event.data) return;\n    if (event.data.type === 'lookie-link:set-theme') {\n      var nextMode = event.data.mode === 'light' ? 'light' : 'dark';\n      document.documentElement.setAttribute('data-lookie-link-theme', nextMode);\n      if (nextMode === 'light') document.documentElement.setAttribute('data-theme', 'light');\n      else document.documentElement.removeAttribute('data-theme');\n      if (/^[a-z0-9-]+$/.test(event.data.scheme || '')) {\n        document.documentElement.setAttribute('data-lookie-link-scheme', event.data.scheme);\n        document.documentElement.setAttribute('data-color-scheme', event.data.scheme);\n      }\n    }\n    if (event.data.type === 'lookie-link:set-annotation-mode') {\n      document.documentElement.classList.toggle('lookie-annotations-active', Boolean(event.data.enabled));\n    }\n  });\n  var lastHeight = 0;\n  function reportHeight() {\n    if (!framed) return;\n    var height = Math.max(\n      document.documentElement ? document.documentElement.scrollHeight : 0,\n      document.body ? document.body.scrollHeight : 0\n    );\n    if (height > 0 && height !== lastHeight) {\n      lastHeight = height;\n      window.parent.postMessage({ type: 'lookie-link:content-height', height: height }, '*');\n    }\n  }\n  document.addEventListener('DOMContentLoaded', reportHeight);\n  window.addEventListener('load', reportHeight);\n  if (typeof ResizeObserver === 'function') {\n    new ResizeObserver(reportHeight).observe(document.documentElement);\n  }\n  window.setInterval(reportHeight, 1500);\n  // A content-height frame cannot scroll internally, so fragment targets would be\n  // dead: report the target's document offset and let the viewer scroll to it.\n  function reportAnchor() {\n    if (!framed || !location.hash) return;\n    var id;\n    try { id = decodeURIComponent(location.hash.slice(1)); } catch (_e) { id = location.hash.slice(1); }\n    var el = id && document.getElementById(id);\n    if (!el) return;\n    var y = el.getBoundingClientRect().top + (window.scrollY || 0);\n    window.parent.postMessage({ type: 'lookie-link:scroll-to', y: Math.max(0, y) }, '*');\n  }\n  window.addEventListener('load', reportAnchor);\n  window.addEventListener('hashchange', reportAnchor);\n  // Image zoom goes through the VIEWER's own lightbox overlay (the same one\n  // markdown files use) — an in-document overlay cannot center on the visible\n  // viewport from inside a content-height frame. Clicking a link that targets a\n  // .photo-lightbox stage is intercepted and forwarded as an open-image request.\n  document.addEventListener('click', function (event) {\n    if (!framed || event.defaultPrevented) return;\n    var anchor = event.target && event.target.closest ? event.target.closest('a') : null;\n    if (!anchor) return;\n    var href = anchor.getAttribute('href') || '';\n    var hashAt = href.indexOf('#');\n    if (hashAt < 0) return;\n    var id;\n    try { id = decodeURIComponent(href.slice(hashAt + 1)); } catch (_e) { id = href.slice(hashAt + 1); }\n    var stage = id && document.getElementById(id);\n    if (!stage || !stage.classList || !stage.classList.contains('photo-lightbox')) return;\n    var img = stage.querySelector('img');\n    var src = img && (img.currentSrc || img.src);\n    if (!src) return;\n    event.preventDefault();\n    window.parent.postMessage({\n      type: 'lookie-link:open-image',\n      src: src,\n      alt: (img.getAttribute('alt') || anchor.getAttribute('aria-label') || '')\n    }, '*');\n  }, true);\n  // Escape closes the viewer lightbox (focus usually lives inside this frame), and\n  // still releases any fragment-targeted overlay by navigating to its close link.\n  window.addEventListener('keydown', function (event) {\n    if (event.key !== 'Escape' || !framed) return;\n    window.parent.postMessage({ type: 'lookie-link:close-image' }, '*');\n    var target = null;\n    try { target = document.querySelector(':target'); } catch (_e) {}\n    if (!target || target.tagName !== 'A') return;\n    var href = target.getAttribute('href') || '';\n    var hash = href.indexOf('#') >= 0 ? href.slice(href.indexOf('#')) : '';\n    if (!/^#[A-Za-z0-9_-]*$/.test(hash)) return;\n    window.parent.postMessage({ type: 'lookie-link:set-hash', hash: hash }, '*');\n  });\n}());`;
   document.head.appendChild(script);
 }
 

--- a/test/embed-html.test.js
+++ b/test/embed-html.test.js
@@ -337,16 +337,16 @@ test('embed theme tokens track the mode, not just color-scheme', async () => {
     // Both palettes ship in either render so the runtime set-theme message can
     // re-theme without a reload; they are keyed on the attribute.
     for (const html of [light, dark]) {
-      assert.match(html, /:root\[data-lookie-link-theme="light"\][^}]*--lookie-bg:\s*#f4f6f8/,
-        'light palette must be emitted and keyed on the theme attribute');
-      assert.match(html, /:root\[data-lookie-link-theme="dark"\][^}]*--lookie-bg:\s*#111827/,
-        'dark palette must be emitted and keyed on the theme attribute');
+      assert.match(html, /:root\[data-lookie-link-theme="light"\][^}]*--lookie-bg:\s*var\(--bg,\s*#f4f6f8\)/,
+        'light fallback must be emitted and keyed on the theme attribute');
+      assert.match(html, /:root,\s*:root\[data-lookie-link-theme="dark"\][^}]*--lookie-bg:\s*var\(--bg,\s*#111827\)/,
+        'dark fallback must be emitted and keyed on the theme attribute');
     }
 
     // Negative canary: the pre-fix bug was a single hardcoded dark palette, so a
     // light render must NOT resolve --lookie-text to the dark value on bare :root.
-    assert.doesNotMatch(light, /:root\s*\{[^}]*--lookie-text:\s*#e5e7eb/,
-      'light render must not pin dark text tokens onto bare :root');
+    assert.doesNotMatch(light, /:root\[data-lookie-link-theme="light"\][^}]*--lookie-text:\s*var\(--text,\s*#e5e7eb\)/,
+      'light render must not fall back to dark text');
     assert.match(light, /data-lookie-link-theme="light"/);
     assert.match(light, /:root \{ color-scheme: light; \}/);
   } finally {
@@ -374,6 +374,62 @@ test('annotate buttons are hidden in the embed until annotation mode is on', asy
     // Negative canary: buttons are still injected, so a regression that drops the
     // gate would leave them visible rather than absent.
     assert.ok(/lookie-annotate-btn/.test(html), 'annotate buttons should still be injected');
+  } finally {
+    await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('embed tokens resolve from the active color scheme, not a constant palette', async () => {
+  const fixture = await makeFixture();
+  try {
+    const source = '<!doctype html><html data-lookie-follow-theme><head><title>T</title></head><body><h1>Hi</h1></body></html>';
+
+    const teal = transformEmbedHtml(source, options(fixture, { themeMode: 'dark', themeScheme: 'teal' }));
+    const nord = transformEmbedHtml(source, options(fixture, { themeMode: 'dark', themeScheme: 'nord' }));
+
+    // The scheme blocks key on the viewer's own attribute names, so the embed
+    // root must carry them or nothing matches.
+    assert.equal(new JSDOM(teal).window.document.documentElement.getAttribute('data-color-scheme'), 'teal',
+      'embed root must carry data-color-scheme');
+    assert.equal(new JSDOM(nord).window.document.documentElement.getAttribute('data-color-scheme'), 'nord');
+
+    // Built-in palettes are lifted out of the viewer stylesheet and shipped with
+    // the embed, so a scheme other than the default actually has values to bind.
+    for (const html of [teal, nord]) {
+      assert.match(html, /:root\[data-color-scheme="teal"\]/, 'built-in scheme palettes must ship with the embed');
+      assert.match(html, /:root\[data-color-scheme="nord"\]/);
+      // Tokens alias the scheme variables rather than restating fixed hexes.
+      assert.match(html, /--lookie-bg:\s*var\(--bg,/, 'tokens must alias the scheme variable');
+      assert.match(html, /--lookie-text:\s*var\(--text,/);
+    }
+
+    // Light mode must reach the scheme's light block, not just flip a keyword.
+    const tealLight = transformEmbedHtml(source, options(fixture, { themeMode: 'light', themeScheme: 'teal' }));
+    const lightRoot = new JSDOM(tealLight).window.document.documentElement;
+    const darkRoot = new JSDOM(teal).window.document.documentElement;
+    assert.equal(lightRoot.getAttribute('data-theme'), 'light',
+      'light mode must set data-theme on the root so light scheme blocks match');
+    assert.equal(darkRoot.getAttribute('data-theme'), null,
+      'dark mode must not carry the light attribute on the root');
+    assert.match(tealLight, /:root\[data-color-scheme="teal"\]\[data-theme="light"\]/);
+
+    // Negative canary: the pre-fix bug restated fixed hex values on the alias
+    // block. If tokens stop aliasing, this fails.
+    assert.doesNotMatch(teal, /--lookie-bg:\s*#111827;/,
+      'tokens must not be pinned to a constant palette outside the fallback slot');
+
+    // A custom theme resolves through the same path as a built-in.
+    const custom = transformEmbedHtml(source, options(fixture, {
+      themeMode: 'dark',
+      themeScheme: 'el-charro',
+      customThemeCss: ':root[data-color-scheme="el-charro"] { --bg: #0d1a1b; --text: #eaf3f1; }',
+    }));
+    assert.match(custom, /data-color-scheme="el-charro"/);
+    assert.match(custom, /--bg: #0d1a1b/, 'custom theme CSS must still ship');
+    assert.ok(
+      custom.indexOf('--bg: #0d1a1b') < custom.indexOf('--lookie-bg: var(--bg,'),
+      'scheme palettes must precede the alias block so the aliases can resolve',
+    );
   } finally {
     await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #352.

## What was broken

`themeScheme` was accepted and written to `data-lookie-link-scheme`, but nothing consumed it. The `--lookie-*` tokens were a constant light/dark pair, so an embedded document tracked *mode* (fixed in #350) while ignoring which *scheme* was selected. Switching Slate → Teal → El Charro re-themed the chrome and left the document unchanged.

The palettes existed but could not reach the embed:

- **Built-in schemes** are CSS-only in `public/style.css`. The embedded document is a separate document and never loads it.
- **`customThemeCss`** already shipped with the embed, but keyed on `[data-color-scheme]` / `[data-theme]` — attributes the embed root did not set.

So the embed carried custom-theme CSS it could not use, and lacked the built-in CSS entirely.

## The fix

1. Lift the `:root[data-color-scheme="…"]` blocks out of `public/style.css` and ship them with the embed. Those blocks declare custom properties and style no elements, so they cannot leak into authored page CSS. `public/style.css` stays the single source of truth for built-in palettes — no values are duplicated into JS.
2. Set `data-color-scheme` / `data-theme` on the embed root so built-in and custom blocks both match.
3. Alias the bridge tokens off the resolved scheme — `--lookie-bg: var(--bg, <previous constant>)` — demoting the old constants to fallbacks that still keep a document readable if a scheme block is missing.
4. Set the scheme attributes in the runtime `lookie-link:set-theme` handler too, so switching scheme or mode re-resolves in CSS with no reload.

Extraction is cached and fails soft: an unreadable stylesheet falls back to the constants rather than breaking rendering.

## Verification

All 10 built-in schemes × 2 modes = 20 blocks extracted, matching `BUILT_IN_THEMES`.

## Tests

Two negative canaries — dropping the aliasing, or not shipping the built-in palettes, each fails the suite. Assertions read the root element via JSDOM rather than string-matching the document, since the injected CSS legitimately contains `[data-theme="light"]` selectors.

Full suite: 206 + 12 passing, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
