### PR TITLE
fix(embed): stop leaking unprefixed CSS variables into authored documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — Embed namespace isolation (#354)
+
+- **Regression fix for #352.** Making the embed scheme-aware injected the viewer's scheme blocks verbatim, and those blocks declare *unprefixed* custom properties (`--bg`, `--text`, `--accent`, `--link`, `--border`, …) on `:root` of the authored document. A scheme selector like `:root[data-color-scheme="solarized"][data-theme="light"]` has specificity (0,3,0) and beats a page setting its own tokens on `[data-lookie-follow-theme]` (0,1,0) — so authored variables were silently overridden. Observed on a kit-styled document: the page asked for `--accent: var(--lookie-link)` (`#268bd2`) and resolved to the scheme's `--accent` (`#2aa198`). The Ops HTML Kit uses `--accent` throughout, so every kit-styled document was affected.
+- `customThemeCss` had the same shape and was already being injected, but harmlessly — the embed root did not set `data-color-scheme` / `data-theme`, so it never matched. #352 set those attributes, activating a latent leak as well as adding a new one.
+- Scheme blocks are now **rewritten rather than passed through**: only the eight properties that map to bridge tokens survive, renamed to their `--lookie-*` equivalents; everything else (`--page-bg`, `--toolbar-*`, `--heading-font`, `color-scheme`) is dropped. Both built-in and custom themes go through the same rewrite, so nothing but `--lookie-*` can enter an authored document. `color-scheme` is emitted from the known mode instead of inherited from whichever block happens to match.
+- The `var(--bg, …)` alias layer from #352 is retired — scheme blocks now set the prefixed tokens directly, with the constant palettes kept as base fallbacks.
+- This also makes true a claim that was inaccurate in the #352 commit message and changelog: the injected CSS now really does declare custom properties only.
+- Tests: a leak test asserting no unprefixed declaration reaches the authored document, plus a negative canary — passing the blocks through verbatim fails the suite.
+
 ## Unreleased — Embed follows the active color scheme (#352)
 
 - Embedded documents that opt into `data-lookie-follow-theme` now use the colors of the **selected scheme** (Slate, Teal, Nord, El Charro, …), not a fixed light/dark pair. `themeScheme` was already accepted and written to the root, but nothing consumed it — the tokens were constants.

--- a/lib/embed-html.js
+++ b/lib/embed-html.js
@@ -279,19 +279,32 @@ const LOOKIE_TOKEN_ALIASES = [
   ['--lookie-link', '--link'],
 ];
 
-function tokenAliasBlock(fallbackTokens) {
-  const fallbacks = new Map(
-    fallbackTokens.split(';')
-      .map((pair) => pair.trim())
-      .filter(Boolean)
-      .map((pair) => {
-        const at = pair.indexOf(':');
-        return [pair.slice(0, at).trim(), pair.slice(at + 1).trim()];
-      }),
-  );
-  return LOOKIE_TOKEN_ALIASES
-    .map(([token, source]) => `${token}: var(${source}, ${fallbacks.get(token)});`)
-    .join(' ');
+// Only --lookie-* names may enter an authored document. A scheme block declares
+// unprefixed names (--bg, --text, --accent, ...) at a selector specific enough to
+// beat a page's own tokens, so the blocks are REWRITTEN rather than passed through:
+// mapped properties are renamed, everything else (--page-bg, --toolbar-*,
+// --heading-font, color-scheme) is dropped.
+const SCHEME_TOKEN_RENAMES = new Map(LOOKIE_TOKEN_ALIASES.map(([token, source]) => [source, token]));
+const SCHEME_BLOCK_PATTERN = /:root\[data-color-scheme="[a-z0-9-]+"\](?:\[data-theme="light"\])?\s*\{[^}]*\}/g;
+
+function rewriteSchemeBlocks(cssText) {
+  if (!cssText) return '';
+  const blocks = [];
+  for (const block of String(cssText).match(SCHEME_BLOCK_PATTERN) || []) {
+    const open = block.indexOf('{');
+    const selector = block.slice(0, open).trim();
+    const declarations = [];
+    for (const declaration of block.slice(open + 1, -1).split(';')) {
+      const at = declaration.indexOf(':');
+      if (at === -1) continue;
+      const name = declaration.slice(0, at).trim();
+      const value = declaration.slice(at + 1).trim();
+      const renamed = SCHEME_TOKEN_RENAMES.get(name);
+      if (renamed && value) declarations.push(`${renamed}: ${value};`);
+    }
+    if (declarations.length) blocks.push(`${selector} { ${declarations.join(' ')} }`);
+  }
+  return blocks.join('\n');
 }
 
 // Built-in scheme palettes live only as CSS in public/style.css, which the embedded
@@ -303,11 +316,7 @@ function builtInSchemeCss() {
   if (builtInSchemeCssCache !== null) return builtInSchemeCssCache;
   try {
     const source = fs.readFileSync(path.join(__dirname, '..', 'public', 'style.css'), 'utf8');
-    const blocks = [];
-    const selector = /:root\[data-color-scheme="[a-z0-9-]+"\](?:\[data-theme="light"\])?\s*\{[^}]*\}/g;
-    let match;
-    while ((match = selector.exec(source)) !== null) blocks.push(match[0]);
-    builtInSchemeCssCache = blocks.join('\n');
+    builtInSchemeCssCache = rewriteSchemeBlocks(source);
   } catch (_error) {
     // A missing or unreadable stylesheet must not break rendering — the embed
     // falls back to the constant palettes below.
@@ -351,12 +360,14 @@ function addThemeInjection(document, options) {
     // Scheme palettes first, so the aliases below have --bg/--text/... to resolve
     // against. Built-in blocks are lifted from the viewer stylesheet; custom
     // themes arrive already keyed on the same attributes.
+    // Constant fallbacks first: they keep a document readable when no scheme block
+    // matches, and stay mode-correct via the attribute key.
+    `:root, :root[data-lookie-link-theme="dark"] { ${DARK_THEME_TOKENS} }`,
+    `:root[data-lookie-link-theme="light"] { color-scheme: light; ${LIGHT_THEME_TOKENS} }`,
+    // Scheme tokens last and more specific, so the active scheme wins. Both
+    // built-in and custom themes go through the same rename.
     builtInSchemeCss(),
-    options.customThemeCss || '',
-    // Aliases last. Fallbacks keep a document readable if a scheme block is
-    // missing entirely, and stay mode-correct via the attribute key.
-    `:root, :root[data-lookie-link-theme="dark"] { ${tokenAliasBlock(DARK_THEME_TOKENS)} }`,
-    `:root[data-lookie-link-theme="light"] { color-scheme: light; ${tokenAliasBlock(LIGHT_THEME_TOKENS)} }`,
+    rewriteSchemeBlocks(options.customThemeCss || ''),
   ].join('\n');
   document.head.appendChild(style);
 

--- a/test/embed-html.test.js
+++ b/test/embed-html.test.js
@@ -337,15 +337,15 @@ test('embed theme tokens track the mode, not just color-scheme', async () => {
     // Both palettes ship in either render so the runtime set-theme message can
     // re-theme without a reload; they are keyed on the attribute.
     for (const html of [light, dark]) {
-      assert.match(html, /:root\[data-lookie-link-theme="light"\][^}]*--lookie-bg:\s*var\(--bg,\s*#f4f6f8\)/,
+      assert.match(html, /:root\[data-lookie-link-theme="light"\][^}]*--lookie-bg:\s*#f4f6f8/,
         'light fallback must be emitted and keyed on the theme attribute');
-      assert.match(html, /:root,\s*:root\[data-lookie-link-theme="dark"\][^}]*--lookie-bg:\s*var\(--bg,\s*#111827\)/,
+      assert.match(html, /:root,\s*:root\[data-lookie-link-theme="dark"\][^}]*--lookie-bg:\s*#111827/,
         'dark fallback must be emitted and keyed on the theme attribute');
     }
 
     // Negative canary: the pre-fix bug was a single hardcoded dark palette, so a
     // light render must NOT resolve --lookie-text to the dark value on bare :root.
-    assert.doesNotMatch(light, /:root\[data-lookie-link-theme="light"\][^}]*--lookie-text:\s*var\(--text,\s*#e5e7eb\)/,
+    assert.doesNotMatch(light, /:root\[data-lookie-link-theme="light"\][^}]*--lookie-text:\s*#e5e7eb/,
       'light render must not fall back to dark text');
     assert.match(light, /data-lookie-link-theme="light"/);
     assert.match(light, /:root \{ color-scheme: light; \}/);
@@ -399,8 +399,8 @@ test('embed tokens resolve from the active color scheme, not a constant palette'
       assert.match(html, /:root\[data-color-scheme="teal"\]/, 'built-in scheme palettes must ship with the embed');
       assert.match(html, /:root\[data-color-scheme="nord"\]/);
       // Tokens alias the scheme variables rather than restating fixed hexes.
-      assert.match(html, /--lookie-bg:\s*var\(--bg,/, 'tokens must alias the scheme variable');
-      assert.match(html, /--lookie-text:\s*var\(--text,/);
+      assert.match(html, /:root\[data-color-scheme="teal"\][^}]*--lookie-bg:/,
+        'scheme blocks must set the prefixed token directly');
     }
 
     // Light mode must reach the scheme's light block, not just flip a keyword.
@@ -415,8 +415,8 @@ test('embed tokens resolve from the active color scheme, not a constant palette'
 
     // Negative canary: the pre-fix bug restated fixed hex values on the alias
     // block. If tokens stop aliasing, this fails.
-    assert.doesNotMatch(teal, /--lookie-bg:\s*#111827;/,
-      'tokens must not be pinned to a constant palette outside the fallback slot');
+    assert.match(teal, /:root, :root\[data-lookie-link-theme="dark"\] \{[^}]*--lookie-bg: #111827;/,
+      'constant palette remains as the base fallback');
 
     // A custom theme resolves through the same path as a built-in.
     const custom = transformEmbedHtml(source, options(fixture, {
@@ -425,11 +425,43 @@ test('embed tokens resolve from the active color scheme, not a constant palette'
       customThemeCss: ':root[data-color-scheme="el-charro"] { --bg: #0d1a1b; --text: #eaf3f1; }',
     }));
     assert.match(custom, /data-color-scheme="el-charro"/);
-    assert.match(custom, /--bg: #0d1a1b/, 'custom theme CSS must still ship');
-    assert.ok(
-      custom.indexOf('--bg: #0d1a1b') < custom.indexOf('--lookie-bg: var(--bg,'),
-      'scheme palettes must precede the alias block so the aliases can resolve',
-    );
+    assert.match(custom, /:root\[data-color-scheme="el-charro"\][^}]*--lookie-bg: #0d1a1b/,
+      'custom theme values must survive the rename');
+  } finally {
+    await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('embed never leaks unprefixed CSS variables into the authored document', async () => {
+  const fixture = await makeFixture();
+  try {
+    const source = '<!doctype html><html data-lookie-follow-theme><head><title>T</title></head><body><h1>Hi</h1></body></html>';
+    const html = transformEmbedHtml(source, options(fixture, {
+      themeMode: 'light',
+      themeScheme: 'solarized',
+      customThemeCss: ':root[data-color-scheme="el-charro"] { --bg: #0d1a1b; --text: #eaf3f1; --accent: #ff8a6b; --heading-font: serif; }',
+    }));
+
+    // Only the injected theme style is ours to police; the authored document's
+    // own CSS is untouched by definition.
+    const injected = html.slice(html.indexOf('id="lookie-link-embed-theme"'));
+    const themeBlock = injected.slice(0, injected.indexOf('</style>'));
+
+    // A scheme selector is specific enough to beat a page's own tokens, so an
+    // unprefixed declaration here silently overrides authored variables.
+    for (const leaked of ['--bg:', '--text:', '--accent:', '--link:', '--border:', '--bg-elev:', '--bg-code:', '--text-soft:', '--heading-font:', '--page-bg:']) {
+      assert.ok(
+        !new RegExp(`(?<!-)(?<!lookie)${leaked.replace(/[-]/g, '\\-')}`).test(themeBlock.replace(/--lookie-[a-z-]+:/g, '')),
+        `unprefixed ${leaked} must not be injected into an authored document`,
+      );
+    }
+
+    // Values still arrive — renamed, not dropped.
+    assert.match(themeBlock, /:root\[data-color-scheme="solarized"\][^}]*--lookie-bg:/);
+    assert.match(themeBlock, /:root\[data-color-scheme="el-charro"\][^}]*--lookie-bg: #0d1a1b/);
+
+    // color-scheme is emitted from the known mode, never inherited from a block.
+    assert.match(themeBlock, /:root \{ color-scheme: light; \}/);
   } finally {
     await fsPromises.rm(fixture.fixtureRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #354. Regression from #352, found by rendering a kit-styled document and reading its computed styles rather than trusting the tests.

## What broke

#352 made the embed scheme-aware by injecting the viewer's scheme blocks verbatim. Those blocks declare **unprefixed** custom properties on `:root` of the authored document:

```css
:root[data-color-scheme="solarized"][data-theme="light"] {
  --bg: #fdf6e3; --text: #657b83; --accent: #2aa198; --link: #268bd2; ...
}
```

That selector is specificity (0,3,0). A page setting its own tokens on `[data-lookie-follow-theme]` is (0,1,0), so the page loses. Observed live:

| Property | Page asked for | Actually resolved |
|---|---|---|
| `--accent` | `var(--lookie-link)` → `#268bd2` | `#2aa198` (scheme's `--accent`) |

The Ops HTML Kit uses `--accent` throughout, so every kit-styled document was silently re-coloured. The `--lookie-*` prefix exists precisely to prevent this, and #352 defeated it.

`customThemeCss` had the same shape and was already shipping — harmlessly, because the embed root did not set `data-color-scheme` / `data-theme` so it never matched. #352 set those attributes, which **activated a latent leak** in addition to introducing a new one.

## The fix

Scheme blocks are rewritten instead of passed through. Only the eight properties that map to bridge tokens survive, renamed to their `--lookie-*` equivalents; `--page-bg`, `--toolbar-*`, `--heading-font`, and `color-scheme` are dropped. Built-in and custom themes share one rewrite path, so nothing but `--lookie-*` can enter an authored document. `color-scheme` is emitted from the known mode rather than inherited from whichever block happens to match.

The `var(--bg, …)` alias layer from #352 is retired — scheme blocks now set the prefixed tokens directly, with the constant palettes kept as base fallbacks for when no scheme matches.

## Also corrects the record

#352's commit message and changelog claimed the lifted blocks "declare custom properties and style no elements." That was inaccurate — they also set `color-scheme`. After this change the claim is true.

## Tests

A leak test asserts no unprefixed `--bg` / `--text` / `--accent` / `--link` / `--border` / `--heading-font` / `--page-bg` declaration reaches the authored document, while confirming the values still arrive renamed. Negative canary: passing the blocks through verbatim fails the suite.

Full suite: 207 + 12 passing, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
