### PR TITLE
fix(forms): give the receipt page the tracker bar

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -729,6 +729,7 @@ function renderReceiptPage(template, record, options = {}) {
     <header class="topbar">
       ${formBreadcrumbs(template, {leadLabel: template ? undefined : 'Form receipt', container: options.relatedForms && options.relatedForms.container})}
     </header>
+    ${template ? formHubNav(template.templateId, null, options.canManage, options.relatedForms && options.relatedForms.container) : ''}
 
     <section class="content form-card receipt-card">
       ${record.supersedesRecord ? '<p class="correction-note"><strong>Correction saved.</strong> This entry supersedes an earlier version, which remains preserved.</p>' : ''}
@@ -3770,6 +3771,7 @@ function createFormsRouter(options) {
         customThemeCss,
         cspNonce,
         canEdit,
+        canManage: await allowed(req, 'forms.manage', template),
         relatedForms: receiptRelated,
         timezone: serverTimezone,
       }));

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -684,6 +684,43 @@ test('form and receipt use the themed shell, preserve escaping, and offer Log an
   }
 });
 
+test('the receipt carries the tracker bar, so a logged entry is not a dead end (#356)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture);
+  try {
+    const context = await getBrowserContext(server);
+    const accepted = await server.request('/forms/gym-session-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Cookie: context.cookie, Origin: PUBLIC_ORIGIN },
+      body: nativeBody(context.token),
+    });
+    assert.equal(accepted.status, 303);
+    const receipt = await (await server.request(accepted.headers.get('location'), {
+      headers: { Cookie: context.cookie },
+    })).text();
+    const document = new JSDOM(receipt).window.document;
+
+    const bar = document.querySelector('.form-layout > .form-hub-nav');
+    assert.ok(bar, 'the receipt renders the tracker bar');
+    assert.deepEqual(
+      [...bar.querySelectorAll('a')].map((link) => [link.className, link.getAttribute('href'), link.textContent]),
+      [
+        ['up-link', '/forms', '← Trackers'],
+        ['log-link', '/forms/gym-session-entry', 'Log an entry'],
+        ['entries-link', '/forms/gym-session-entry/entries', 'History'],
+        ['configure-link', '/forms/gym-session-entry/configure', 'Configure'],
+      ]
+    );
+    // A receipt is none of the four views the bar lists, so nothing claims to be current.
+    assert.equal(bar.querySelector('[aria-current]'), null);
+    // The bar sits outside the topbar, as it does on every other surface.
+    assert.equal(document.querySelector('.topbar .form-hub-nav'), null);
+    assert.equal(document.querySelector('.topbar .breadcrumbs a[href="/forms"]'), null);
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
 test('native POST redirects with 303 and the receipt page renders submitted values', async () => {
   const fixture = await makeFixture();
   const server = await startServer(fixture);


### PR DESCRIPTION
Closes #356

Submitting an entry landed on a receipt with no way back to the trackers root. The receipt rendered breadcrumbs, the entry actions and the related strip, but not the sticky `form-hub-nav` that every other tracker surface carries — so the only way out was the strip at the very bottom of the page. Reported from real use on a phone.

Renders the standard bar between the topbar and the receipt card, exactly as the form page does. No item is marked `aria-current`: a receipt is none of the four views the bar lists.

## Test gate
New test in `test/forms-runner.test.js` asserts the receipt carries `.form-layout > .form-hub-nav` with the full link set (up-link, log, history, configure), that nothing claims `aria-current`, and that the bar sits outside the topbar as it does everywhere else.

Full suite green (220 pass, 0 fail); `validate:editable` and `validate:raw-html` both exit 0.