### PR TITLE
fix(forms): sort tracker listings that are indexes by title

### DIFF
--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -180,6 +180,13 @@ function formHubNav(templateId, active, canManage, group) {
   ).join('')}</nav>`;
 }
 
+// #357/#358: every tracker listing that is an index rather than a curated
+// sequence sorts by title. Titles, not ids — an id is plumbing and the two
+// diverge. Returns a new array; callers keep their own ordering decisions.
+function byTitle(templates) {
+  return [...templates].sort((left, right) => String(left.title).localeCompare(String(right.title)));
+}
+
 function errorMap(errors) {
   const mapped = new Map();
   for (const error of errors || []) {
@@ -2161,7 +2168,10 @@ function createFormsRouter(options) {
         related.push(candidate);
       }
     }
-    if (container || related.length || cfg) return {container, related};
+    // #357: the strip is an index, not a sequence — one alphabetical run, so the
+    // eye can start from the letter. The group's memberOrder still curates its
+    // own hub page, where the order IS the sequence to work through.
+    if (container || related.length || cfg) return {container, related: byTitle(related)};
     const tags = Array.isArray(template.tags) ? template.tags : [];
     if (!tags.length) return {container: null, related: []};
     for (const candidate of await registry.listTemplates()) {
@@ -2173,7 +2183,7 @@ function createFormsRouter(options) {
         related.push(candidate);
       }
     }
-    return {container: null, related: related.sort((left, right) => String(left.title).localeCompare(String(right.title)))};
+    return {container: null, related: byTitle(related)};
   }
 
   function managementEnvelope(req, res, mutation, type) {
@@ -3318,7 +3328,10 @@ function createFormsRouter(options) {
         const cspNonce = crypto.randomBytes(18).toString('base64url');
         formHeaders(res, cspNonce);
         emitAudit(req, 'form.render', 'accepted', template);
-        res.status(200).type('html').send(renderParentPage(template, children, {
+        // #358: childrenOf returns registry Map order, which reads as almost-sorted
+        // and is worse than clearly unsorted — a reader trusts it and then cannot
+        // find the row. Match every other listing.
+        res.status(200).type('html').send(renderParentPage(template, byTitle(children), {
           customThemeCss, cspNonce, canManage, csrfToken, relatedForms,
           timezone: serverTimezone, now: currentDate(),
         }));

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2547,3 +2547,64 @@ test('related-strip config: all-in-group default, cross-group picks, API roundtr
     await cleanup(fixture, server);
   }
 });
+
+test('tracker listings that are indexes sort by title (#357, #358)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {formsTimezone: 'America/New_York'});
+  try {
+    const context = await getBrowserContext(server);
+    const jsonHeaders = { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token };
+    const post = (route, body) => server.request(route, {method: 'POST', headers: jsonHeaders, body: JSON.stringify(body)});
+    const patch = (route, body) => server.request(route, {method: 'PATCH', headers: jsonHeaders, body: JSON.stringify(body)});
+    const titles = (html, selector) => [...new JSDOM(html).window.document.querySelectorAll(selector)].map((node) => node.textContent);
+
+    assert.equal((await post('/api/forms/templates', {templateId: 'gym', title: 'Gym', kind: 'container', grammarVersion: 1})).status, 201);
+    // The parent, plus children registered deliberately out of alphabetical order.
+    assert.equal((await patch('/api/forms/templates/gym-session-entry', {revision: 1, containerId: 'gym'})).status, 200);
+    for (const [templateId, title] of [['zeta', 'Zeta Machine'], ['alpha', 'Alpha Machine'], ['mid', 'Mid Machine']]) {
+      assert.equal((await post('/api/forms/templates', {
+        templateId, title, grammarVersion: 1, destinationId: 'default', containerId: 'gym',
+        parentId: 'gym-session-entry', fields: [],
+      })).status, 201, `create ${templateId}`);
+    }
+    // A standalone member the group pins first — the curated order, last alphabetically.
+    const zuluCreate = await post('/api/forms/templates', {templateId: 'zulu', title: 'Zulu Standalone', grammarVersion: 1,
+      destinationId: 'default', containerId: 'gym', fields: [{id: 'n', type: 'number', label: 'N', required: false}]});
+    assert.equal(zuluCreate.status, 201, await zuluCreate.text());
+    const gymRev = JSON.parse(await (await server.request('/api/forms/templates/gym')).text()).template.revision;
+    assert.equal((await patch('/api/forms/templates/gym', {revision: gymRev, memberOrder: ['zulu']})).status, 200);
+
+    // #358: the parent's page lists its children alphabetically, not in registry order.
+    const parentPage = await (await server.request('/forms/gym-session-entry', {headers: {Cookie: context.cookie}})).text();
+    assert.deepEqual(
+      titles(parentPage, '.container-members .container-member-title'),
+      ['Alpha Machine', 'Mid Machine', 'Zeta Machine'],
+      'parent page children sort by title'
+    );
+
+    // #357: the strip is one alphabetical run — memberOrder does not pin it.
+    const childPage = await (await server.request('/forms/alpha', {headers: {Cookie: context.cookie}})).text();
+    const strip = titles(childPage, '.related-forms .related-form-link');
+    assert.deepEqual(strip, [...strip].sort((a, b) => a.localeCompare(b)), 'strip is alphabetical');
+    assert.equal(strip[strip.length - 1], 'Zulu Standalone',
+      'the memberOrder-pinned member sorts to its alphabetical place, not the front');
+
+    // The group hub keeps its curated memberOrder — there the order IS the sequence.
+    const groupPage = await (await server.request('/forms/gym', {headers: {Cookie: context.cookie}})).text();
+    assert.equal(titles(groupPage, '.container-members .container-member-title')[0], 'Zulu Standalone',
+      'group hub still leads with the pinned member');
+
+    // Cross-group includes join the same single alphabetical run.
+    assert.equal((await post('/api/forms/templates', {templateId: 'beta-solo', title: 'Beta Solo', grammarVersion: 1,
+      destinationId: 'default', fields: [{id: 'n', type: 'number', label: 'N', required: false}]})).status, 201);
+    const alphaRev = JSON.parse(await (await server.request('/api/forms/templates/alpha')).text()).template.revision;
+    assert.equal((await patch('/api/forms/templates/alpha', {revision: alphaRev, related: {group: true, include: ['beta-solo']}})).status, 200);
+    const withInclude = titles(await (await server.request('/forms/alpha', {headers: {Cookie: context.cookie}})).text(),
+      '.related-forms .related-form-link');
+    assert.deepEqual(withInclude, [...withInclude].sort((a, b) => a.localeCompare(b)),
+      'an included cross-group pick sorts in, not appended after the group');
+    assert.ok(withInclude.includes('Beta Solo'));
+  } finally {
+    await cleanup(fixture, server);
+  }
+});


### PR DESCRIPTION
Closes #357
Closes #358

Two listings read as *almost* sorted, which is worse than clearly unsorted: a reader trusts the order and then cannot find the row they want.

- **The related strip (#357)** put the group's `memberOrder`-pinned members first and only then sorted, so the run opened out of alphabet. The strip is an index, not a sequence. The group hub page keeps `memberOrder` untouched — there the order *is* the sequence to work through.
- **A parent's page (#358)** listed its children in registry Map order, never sorted at any step: `childrenOf` returns raw insertion order, while every other surface reaches its members through `orderMembers`.

Both now route through one `byTitle` helper. Titles, not ids — an id is plumbing and the two diverge.

Filed as two issues because the root causes are in different code paths; shipped as one PR because it is one behavior change with two test gates, and splitting it would mean two service restarts on a live instance for two sorts.

## Test gate
One new test covers all three claims: the parent page sorts its children by title; the strip is a single alphabetical run with the `memberOrder`-pinned member in its alphabetical place rather than the front; and the group hub still leads with that pinned member (no regression on the curated order). A cross-group `include` pick is asserted to sort *into* the run rather than being appended after the group.

Full suite green (221 pass, 0 fail); `validate:editable` and `validate:raw-html` both exit 0.