### PR TITLE
fix(forms): one bar for the root family, and settle what the root is called

### DIFF
--- a/docs/TRACKERS.md
+++ b/docs/TRACKERS.md
@@ -180,12 +180,18 @@ group provides one (see fallback above).
 
 One rule: **every bar starts with its parent.**
 
-- The root (`/forms`) is the groups page: a Groups | Trackers view switcher
-  (Trackers lists every tracker under its group heading), quiet
-  "+ New tracker · + New group" links beneath, and archived *groups* collapsed
-  at the bottom.
-- A group's bar: `Groups | Trackers | History | Configure`.
-- A tracker's bar: `← <Group> | Log an entry | History | Configure`.
+- The root (`/forms`) **is called Trackers** — it renders the whole hierarchy,
+  every tracker nested under its group, with archived *groups* collapsed at the
+  bottom. Everything that links back to it says `Trackers`; nothing says
+  "Groups".
+- The root family — the root, its history, and the unscoped create pages —
+  all carry one bar: `Trackers | History | New tracker | New group`, with the
+  current page lit and the two create links present only for a viewer who can
+  create. Being at the root, it has no up-link.
+- A group's bar: `← Trackers | Trackers | History | Configure | New tracker | New group`.
+- A tracker's bar: `← Trackers | Log an entry | History | Configure`.
+- A create page scoped to a group (`/forms/new?group=<id>`) carries that
+  group's bar instead, so the way you arrived stays on screen.
 - A receipt carries its tracker's bar, with nothing marked current — a receipt
   is none of the four views the bar lists. Without it, submitting an entry
   dead-ends: the in-card actions all lead back into the same tracker.

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -149,7 +149,7 @@ function containerHubNav(templateId, active, canManage) {
   // the action sits next to what it acts on, admin stays last.
   // #295 (final): the bar carries views; creation is a quiet link line under it.
   const links = [
-    ['groups', '/forms', '← Groups'],
+    ['groups', '/forms', '← Trackers'],
     ['view', href, 'Trackers'],
     ['history', `${href}/entries`, 'History'],
     ...(canManage ? [
@@ -160,6 +160,25 @@ function containerHubNav(templateId, active, canManage) {
   ];
   return `<nav class="form-hub-nav" aria-label="Group views">${links.map(([key, linkHref, label]) =>
     `<a class="${key}-link" href="${linkHref}"${key === active ? ' aria-current="page"' : ''}>${label}</a>`
+  ).join('')}</nav>`;
+}
+
+function rootHubNav(active, canCreate) {
+  // #365: the root family (root, its history, the unscoped create page) built
+  // this bar three separate times and drifted — history lost the create links
+  // and the create page lit New group while you were making a tracker. Same
+  // shape as formHubNav/containerHubNav: one helper, an active key.
+  // #364: the root calls itself Trackers, so every bar that points here says so.
+  const links = [
+    ['view', '/forms', 'Trackers'],
+    ['entries', '/forms/entries', 'History'],
+    ...(canCreate ? [
+      ['new', '/forms/new', 'New tracker'],
+      ['newgroup', '/forms/new?kind=container', 'New group'],
+    ] : []),
+  ];
+  return `<nav class="form-hub-nav" aria-label="Root views">${links.map(([key, href, label]) =>
+    `<a class="${key === 'entries' ? 'entries-link' : `${key}-link`}" href="${href}"${key === active ? ' aria-current="page"' : ''}>${label}</a>`
   ).join('')}</nav>`;
 }
 
@@ -1446,7 +1465,7 @@ function renderRootHistoryPage(tagged, csrfToken, options = {}) {
     <header class="topbar forms-index-header">
       <div><h1>History</h1><p class="subtitle">Every tracker, newest first.</p></div>
     </header>
-    <nav class="form-hub-nav" aria-label="Root views"><a class="view-link" href="/forms">Trackers</a><a class="entries-link" href="/forms/entries" aria-current="page">History</a></nav>
+    ${rootHubNav('entries', options.canCreate)}
     <section class="content form-card entries-card">${sections || '<div class="entries-empty"><h2>Nothing logged yet.</h2></div>'}</section>
   </main>
   ${themeScript(options.cspNonce)}`;
@@ -1483,7 +1502,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
     <header class="topbar forms-index-header">
       <div><h1>Groups</h1><p class="subtitle">${managed ? 'Everything, nested — tap a group heading for its page, a name to log, a chevron to peek.' : 'Choose a tracker to log an entry.'}</p></div>
     </header>
-    <nav class="form-hub-nav" aria-label="Root views"><a class="view-link" href="/forms" aria-current="page">Trackers</a><a class="entries-link" href="/forms/entries">History</a>${canCreate ? '<a class="new-link" href="/forms/new">New tracker</a><a class="newgroup-link" href="/forms/new?kind=container">New group</a>' : ''}</nav>
+    ${rootHubNav('view', canCreate)}
     <section class="content form-card container-card">
       ${sections || emptyState}
     </section>
@@ -1491,7 +1510,7 @@ function renderFormsIndexPage(templates, canCreate, csrfToken, options = {}) {
   </main>
   ${themeScript(options.cspNonce)}`;
   return baseHtml({
-    title: 'Groups',
+    title: 'Trackers',
     body,
     customThemeCss: options.customThemeCss,
     cspNonce: options.cspNonce,
@@ -1506,7 +1525,7 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
   const lead = options.group ? 'New tracker' : (options.kind === 'container' ? 'New group' : 'New template');
   const escapeNav = options.group
     ? containerHubNav(options.group.templateId, 'new', true)
-    : `<nav class="form-hub-nav" aria-label="Tracker views"><a class="groups-link" href="/forms">← Groups</a><a class="configure-link" href="/forms/new?kind=container" aria-current="page">New group</a></nav>`;
+    : rootHubNav(options.kind === 'container' ? 'newgroup' : 'new', true);
   const body = `${toolbarHtml()}
   <main class="layout form-layout builder-layout">
     <header class="topbar">${formBreadcrumbs(null, {leadLabel: lead})}</header>
@@ -3278,6 +3297,7 @@ function createFormsRouter(options) {
       emitAudit(req, type, 'accepted');
       res.status(200).type('html').send(renderRootHistoryPage(tagged, issueContext(req, res), {
         customThemeCss, cspNonce, timezone: serverTimezone,
+        canCreate: await canCreateTemplate(req),
       }));
     } catch (error) {
       next(error);
@@ -3808,4 +3828,5 @@ module.exports = {
   renderFormPage,
   renderFormsIndexPage,
   renderReceiptPage,
+  renderRootHistoryPage,
 };

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -13,7 +13,7 @@ const { JSDOM } = require('jsdom');
 const { chromium } = require('playwright');
 
 const { createApp } = require('../server');
-const { renderReceiptPage } = require('../lib/forms/routes');
+const { renderReceiptPage, renderFormsIndexPage, renderRootHistoryPage } = require('../lib/forms/routes');
 const { TemplateRegistry } = require('../lib/forms/template-registry');
 const { SubmissionStore } = require('../lib/forms/submission-store');
 
@@ -2121,7 +2121,7 @@ test('container forms: lifecycle, page, membership nav, root grouping, guards (#
     assert.match(containerPage, /<a class="container-member-title" href="\/forms\/gym-session-entry"/);
     assert.match(containerPage, /container-member-configure/);
     // #285: hierarchy lives in the bars — a group's bar leads with Groups; no dropdown
-    assert.match(containerPage, /groups-link" href="\/forms">← Groups</);
+    assert.match(containerPage, /groups-link" href="\/forms">← Trackers</);
     assert.doesNotMatch(containerPage, /data-group-menu/);
     assert.match(containerPage, /toolbar-properties/);
     assert.match(containerPage, /<dt>Group<\/dt>|Group<\/dt>/);
@@ -2447,7 +2447,7 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
     assert.match(createPage, /Gym &amp; Fitness!/);
     assert.match(createPage, /href="\/forms\/gym-fitness\/entries"/);
     assert.match(createPage, /Joining group/);
-    assert.match(createPage, /groups-link" href="\/forms">← Groups</);
+    assert.match(createPage, /groups-link" href="\/forms">← Trackers</);
     // #293: archive a group member — it lists on the GROUP page, not the root
     const rowing2 = JSON.parse(await (await server.request('/api/forms/templates/rowing-2')).text()).template;
     const archivedResp = await server.request('/api/forms/templates/rowing-2/archive', {
@@ -2465,8 +2465,9 @@ test('creation follows containment: slug-derived IDs and group-joined trackers (
 
     // the root create page carries the Browse escape
     const rootCreate = await (await server.request('/forms/new?kind=container', {headers: {Cookie: context.cookie}})).text();
-    assert.match(rootCreate, /groups-link" href="\/forms">← Groups</);
-    assert.match(rootCreate, /New group/);
+    // #365: the unscoped create page carries the ROOT bar, with New group lit.
+    assert.match(rootCreate, /view-link" href="\/forms">Trackers</);
+    assert.match(rootCreate, /newgroup-link" href="\/forms\/new\?kind=container" aria-current="page">New group</);
   } finally {
     await cleanup(fixture, server);
   }
@@ -2606,5 +2607,77 @@ test('tracker listings that are indexes sort by title (#357, #358)', async () =>
     assert.ok(withInclude.includes('Beta Solo'));
   } finally {
     await cleanup(fixture, server);
+  }
+});
+
+test('the root family shares one bar, with the right item lit (#364, #365)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture, {formsTimezone: 'America/New_York'});
+  try {
+    const context = await getBrowserContext(server);
+    const barOf = (html) => {
+      const nav = new JSDOM(html).window.document.querySelector('.form-hub-nav');
+      return {
+        links: [...nav.querySelectorAll('a')].map((a) => a.textContent),
+        current: nav.querySelector('[aria-current="page"]')?.textContent ?? null,
+      };
+    };
+    const get = async (route) => barOf(await (await server.request(route, {headers: {Cookie: context.cookie}})).text());
+
+    const expected = ['Trackers', 'History', 'New tracker', 'New group'];
+    const root = await get('/forms');
+    const history = await get('/forms/entries');
+    const newTracker = await get('/forms/new');
+    const newGroup = await get('/forms/new?kind=container');
+
+    // #365: one link set across the whole root family — no page quietly drops items.
+    for (const [name, bar] of [['root', root], ['history', history], ['new tracker', newTracker], ['new group', newGroup]]) {
+      assert.deepEqual(bar.links, expected, `${name} bar`);
+    }
+    // ...and each lights its own page. The create pages used to both light New group.
+    assert.equal(root.current, 'Trackers');
+    assert.equal(history.current, 'History');
+    assert.equal(newTracker.current, 'New tracker');
+    assert.equal(newGroup.current, 'New group');
+
+    // #364: nothing calls the root "Groups" any more.
+    for (const route of ['/forms', '/forms/entries', '/forms/new', '/forms/new?kind=container', '/forms/gym-session-entry']) {
+      const html = await (await server.request(route, {headers: {Cookie: context.cookie}})).text();
+      assert.doesNotMatch(html, /← Groups/, `${route} must not call the root Groups`);
+    }
+
+    // A group's bar leads with the root under its settled name.
+    const created = await server.request('/api/forms/templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token },
+      body: JSON.stringify({templateId: 'gym', title: 'Gym', kind: 'container', grammarVersion: 1}),
+    });
+    assert.equal(created.status, 201, await created.text());
+    const groupBar = await get('/forms/gym');
+    assert.equal(groupBar.links[0], '← Trackers');
+    // /forms/new?group=<id> still inherits the GROUP's bar, not the root's.
+    const scopedCreate = await get('/forms/new?group=gym');
+    assert.equal(scopedCreate.links[0], '← Trackers');
+    assert.equal(scopedCreate.current, 'New tracker');
+    assert.ok(scopedCreate.links.includes('Configure'), 'scoped create keeps the group bar');
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('canCreate gates the create links on root and history together (#365)', () => {
+  // The access model makes a browser principal that can read but not manage
+  // awkward to stand up here, so drive the gate directly — it is the same flag
+  // on both pages now, which is the property that stops them drifting apart.
+  const barLinks = (html) => [...new JSDOM(html).window.document
+    .querySelector('.form-hub-nav').querySelectorAll('a')].map((a) => a.textContent);
+
+  for (const canCreate of [true, false]) {
+    const root = barLinks(renderFormsIndexPage([], canCreate, '', {}));
+    const history = barLinks(renderRootHistoryPage([], '', {canCreate}));
+    assert.deepEqual(root, history, `root and history must agree when canCreate=${canCreate}`);
+    assert.deepEqual(root, canCreate
+      ? ['Trackers', 'History', 'New tracker', 'New group']
+      : ['Trackers', 'History'], `canCreate=${canCreate}`);
   }
 });


### PR DESCRIPTION
Closes #364
Closes #365

Both reported from use: the new-template page "says groups instead of Trackers at the top", and the History bar should look like it does everywhere else.

### The root family shared nothing (#365)

Three pages sit at the root and each hand-rolled its own bar:

| Page | Before | After |
|---|---|---|
| `/forms` | `Trackers* · History · New tracker · New group` | unchanged |
| `/forms/entries` | `Trackers · History*` | gains the create links |
| `/forms/new` | `← Groups · New group*` | `Trackers · History · New tracker* · New group` |
| `/forms/new?kind=container` | `← Groups · New group*` | same bar, `New group` lit |

Note the third row: `/forms/new` and `/forms/new?kind=container` rendered **byte-identical** bars, so the New tracker page was lighting *New group* as the current page. Adds `rootHubNav(active, canCreate)` — the shape `formHubNav` and `containerHubNav` already have — and routes all three through it. A create page scoped to a group still inherits that group's bar.

### Two names for one place (#364)

The root called itself `Trackers` while a group's bar and the create page called it `Groups`, left over from the `Groups|Trackers` switcher #335 retired. Every bar pointing at `/forms` now says `Trackers`; the page title follows.

## Test gate
One test asserts all four root-family pages render the same link set and each lights its own item, and that no page renders `← Groups`; it also pins that `/forms/new?group=<id>` still carries the group bar. A second drives the `canCreate` gate directly against both renderers — a browser principal that reads but cannot manage is awkward to stand up through the access config, and the property worth pinning is that both pages read the same flag. `renderRootHistoryPage` is exported for that.

Three existing assertions on the old `← Groups` wording updated. Full suite green (223 pass, 0 fail); both validators exit 0. `docs/TRACKERS.md` navigation model updated to match.