### PR TITLE
fix(forms): the builder says tracker, and stops leaking issue numbers

### DIFF
--- a/docs/TRACKERS.md
+++ b/docs/TRACKERS.md
@@ -28,12 +28,19 @@ for builders and this doc, not end-user marketing:
 
 ## Two-plane language
 
-End-user surfaces say **tracker** and **group**. The builder, the API, and the
-storage say **form template**, **kind: 'container'**, and keep every URL under
-`/forms/…`. This split is deliberate: creators get honest system words,
-civilians get words that need no explanation, and the plumbing never churns
-when the language does. This document uses each plane's words in its own
-sections.
+End-user surfaces say **tracker** and **group**. The API and the storage say
+**form template**, **kind: 'container'**, and keep every URL under `/forms/…`.
+This split is deliberate: the plumbing never churns when the language does.
+
+**The visible builder is an end-user surface.** Its chrome — headings, buttons,
+select options, help text — says *tracker*, because what you are creating is a
+tracker. The system words stay in the API, the stored documents and this
+document. A page that shows a person the word *template* is leaking its
+plumbing.
+
+Help text is also written for the person reading it, never for a reviewer:
+no internal issue numbers in visible copy. If provenance is worth keeping, it
+belongs in a code comment beside the string.
 
 ## Core guarantees
 

--- a/lib/forms/routes.js
+++ b/lib/forms/routes.js
@@ -1142,7 +1142,7 @@ function renderConfigurePage(record, csrfToken, destinationIds, options = {}) {
           </details>
           ${options.fieldsTable ? '' : `<label><span>Theme</span><select name="theme">${themeOptions}</select></label>
           <label><span>Theme mode</span><select name="themeMode">${themeModeOptions}</select></label>`}
-          ${Array.isArray(options.parents) && options.parents.length ? `<label><span>Parent form</span><select name="parent"><option value=""${!template.parentId ? ' selected' : ''}>None</option>${options.parents.map((parent) => `<option value="${escapeHtml(parent.templateId)}"${template.parentId === parent.templateId ? ' selected' : ''}>${escapeHtml(parent.title)}</option>`).join('')}</select></label><p class="builder-help">A child form inherits every parent field live. Fields below override a parent field with the same id or extend the form; detaching copies the resolved fields back onto this form (#245).</p>` : ''}
+          ${Array.isArray(options.parents) && options.parents.length ? `<label><span>Parent form</span><select name="parent"><option value=""${!template.parentId ? ' selected' : ''}>None</option>${options.parents.map((parent) => `<option value="${escapeHtml(parent.templateId)}"${template.parentId === parent.templateId ? ' selected' : ''}>${escapeHtml(parent.title)}</option>`).join('')}</select></label><p class="builder-help">A child form inherits every parent field live. Fields below override a parent field with the same id or extend the form; detaching copies the resolved fields back onto this tracker.</p>` : ''}
           ${Array.isArray(options.children) && options.children.length ? `<p class="builder-help builder-parent-note">Parent of ${options.children.length} form${options.children.length === 1 ? '' : 's'}: ${options.children.map((child) => escapeHtml(child.title)).join(', ')}. Edits here flow to them live.</p>` : ''}
           ${Array.isArray(options.containers) && options.containers.length ? `<label><span>Group</span><select name="container"><option value=""${!template.containerId ? ' selected' : ''}>None</option>${options.containers.map((container) => `<option value="${escapeHtml(container.templateId)}"${template.containerId === container.templateId ? ' selected' : ''}>${escapeHtml(container.title)}</option>`).join('')}</select></label><p class="builder-help">Groups hold related trackers and give each member back-and-sibling navigation.</p>` : ''}
           <p class="builder-help">Themes are installed by the deployment and read from the server. Leave both alone and this form follows whatever theme the viewer has chosen.</p>
@@ -1522,7 +1522,13 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
     `<option value="${escapeHtml(destinationId)}"${options.destinationId === destinationId ? ' selected' : ''}>${escapeHtml(destinationId)}</option>`
   ).join('');
   // #281: no dead ends — the bar you arrived from persists, current tab lit.
-  const lead = options.group ? 'New tracker' : (options.kind === 'container' ? 'New group' : 'New template');
+  // #367: this surface says TRACKER. The two-plane rule lets the builder say
+  // "form template", but not here: the bar above already says New tracker, and
+  // on /forms/new the kind is undecided, so it presents as the common case and
+  // the Kind select changes what you get.
+  const makingGroup = !options.group && options.kind === 'container';
+  const lead = makingGroup ? 'New group' : 'New tracker';
+  const createLabel = makingGroup ? 'Create group' : 'Create tracker';
   const escapeNav = options.group
     ? containerHubNav(options.group.templateId, 'new', true)
     : rootHubNav(options.kind === 'container' ? 'newgroup' : 'new', true);
@@ -1537,14 +1543,14 @@ function renderCreateTemplatePage(csrfToken, destinationIds, options = {}) {
         <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
         <label><span>Name</span><input name="title" value="${escapeHtml(options.title || '')}" maxlength="200" required autofocus></label>
         <label><span>ID (optional)</span><input name="templateId" value="${escapeHtml(options.templateId || '')}" maxlength="64" pattern="[a-z][a-z0-9]*(?:-[a-z0-9]+)*"></label>
-        <p class="builder-help">Leave the ID blank and it derives from the name (#279).</p>
-        ${options.group ? `<input type="hidden" name="group" value="${escapeHtml(options.group.templateId)}"><p class="builder-help">Joining group: <strong>${escapeHtml(options.group.title || options.group.templateId)}</strong></p>` : `<label><span>Kind</span><select name="kind"><option value="">Form</option><option value="parent"${options.kind === 'parent' ? ' selected' : ''}>Parent (defines trackers — does not log itself)</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>`}
+        <p class="builder-help">Leave the ID blank and it derives from the name.</p>
+        ${options.group ? `<input type="hidden" name="group" value="${escapeHtml(options.group.templateId)}"><p class="builder-help">Joining group: <strong>${escapeHtml(options.group.title || options.group.templateId)}</strong></p>` : `<label><span>Kind</span><select name="kind"><option value="">Tracker (logs entries)</option><option value="parent"${options.kind === 'parent' ? ' selected' : ''}>Parent (defines trackers — does not log itself)</option><option value="container"${options.kind === 'container' ? ' selected' : ''}>Group (holds related trackers)</option></select></label>`}
         <details class="builder-advanced"><summary>Advanced</summary>
         <label><span>Entry storage</span><select name="destinationId">${destinationOptions}</select></label>
         <p class="builder-help">Where entries are saved — a storage area named by the server operator; ${options.group ? 'preset to what this group already uses' : "'default' is fine"}. Applies to trackers only (groups hold trackers, not entries).</p>
         </details>
         <p class="builder-help">Only deployment-approved destination aliases are available; a filesystem path is never accepted.</p>
-        <button class="button-link button-link-primary form-primary-action" type="submit">Create template</button>
+        <button class="button-link button-link-primary form-primary-action" type="submit">${escapeHtml(createLabel)}</button>
       </form>
     </section>
   </main>

--- a/test/forms-hub-builder.test.js
+++ b/test/forms-hub-builder.test.js
@@ -385,7 +385,7 @@ test('forms index offers its single API-backed creation path only to managers an
     assert.ok(emptyIndex.document.querySelector('a[href="/forms/new?kind=container"]'));
     let firstRun = await browserPage(await server.request('/forms/new'));
     const cookie = firstRun.cookie;
-    assert.match(firstRun.document.querySelector('h1').textContent, /New template/);
+    assert.match(firstRun.document.querySelector('h1').textContent, /New tracker/);
     assert.deepEqual(
       [...firstRun.document.querySelector('select[name="destinationId"]').options].map((option) => option.value),
       ['default', 'gym-log'],

--- a/test/forms-runner.test.js
+++ b/test/forms-runner.test.js
@@ -2681,3 +2681,62 @@ test('canCreate gates the create links on root and history together (#365)', () 
       : ['Trackers', 'History'], `canCreate=${canCreate}`);
   }
 });
+
+test('the create surface says tracker, never template or form (#367)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture);
+  try {
+    const context = await getBrowserContext(server);
+    assert.equal((await server.request('/api/forms/templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: context.cookie, Origin: PUBLIC_ORIGIN, 'x-csrf-token': context.token },
+      body: JSON.stringify({templateId: 'gym', title: 'Gym', kind: 'container', grammarVersion: 1}),
+    })).status, 201);
+
+    const visible = (html) => {
+      const main = new JSDOM(html).window.document.querySelector('main');
+      return main.textContent.replace(/\s+/g, ' ');
+    };
+    const page = async (route) => visible(await (await server.request(route, {headers: {Cookie: context.cookie}})).text());
+
+    const plain = await page('/forms/new');
+    assert.match(plain, /New tracker/);
+    assert.match(plain, /Create tracker/);
+    assert.match(plain, /Tracker \(logs entries\)/);
+
+    const group = await page('/forms/new?kind=container');
+    assert.match(group, /New group/);
+    assert.match(group, /Create group/);
+
+    const scoped = await page('/forms/new?group=gym');
+    assert.match(scoped, /New tracker/);
+    assert.match(scoped, /Create tracker/);
+
+    // The internal words must not reach the surface a person reads.
+    for (const [route, text] of [['/forms/new', plain], ['/forms/new?kind=container', group], ['/forms/new?group=gym', scoped]]) {
+      assert.doesNotMatch(text, /\btemplate\b/i, `${route} must not say template`);
+    }
+  } finally {
+    await cleanup(fixture, server);
+  }
+});
+
+test('no user-facing copy carries an internal issue number (#368)', async () => {
+  const fixture = await makeFixture();
+  const server = await startServer(fixture);
+  try {
+    const context = await getBrowserContext(server);
+    // Asserted over the rendered text, not the two known strings, so a third
+    // provenance note cannot be added quietly.
+    for (const route of ['/forms', '/forms/entries', '/forms/new', '/forms/new?kind=container',
+      '/forms/gym-session-entry', '/forms/gym-session-entry/configure', '/forms/gym-session-entry/entries']) {
+      const html = await (await server.request(route, {headers: {Cookie: context.cookie}})).text();
+      const main = new JSDOM(html).window.document.querySelector('main');
+      assert.ok(main, `${route} rendered a main`);
+      const leaked = main.textContent.match(/\(#\d+\)/g);
+      assert.equal(leaked, null, `${route} leaks ${leaked && leaked.join(', ')}`);
+    }
+  } finally {
+    await cleanup(fixture, server);
+  }
+});


### PR DESCRIPTION
Closes #367
Closes #368

Reported from use, flatly: it should be tracker, not template.

### The create page contradicted itself (#367)

Under a bar that reads **New tracker**, the page said:

| | Before | After |
|---|---|---|
| Heading + tab title | New template | New tracker (New group for `?kind=container`) |
| Kind select, first option | Form | Tracker (logs entries) |
| Submit button | Create template | Create tracker / Create group |

The other two Kind options already used the end-user words — "Parent (defines trackers…)", "Group (holds related trackers)" — so "Form" was the odd one out.

On `/forms/new` the kind really is undecided until you touch the select, which is why the heading was generic. Resolved in favour of the common case: the page presents as a tracker and the select changes what you get. **Known nit:** switching the select to Group without reloading leaves the heading and button saying tracker until submit. The heading already behaved that way; the button now agrees with it rather than with neither.

### Issue numbers in user-facing copy (#368)

"Leave the ID blank and it derives from the name **(#279)**." and "…back onto this form **(#245)**." — provenance notes for reviewers that shipped to readers, who have no idea what those are. Dropped.

### Doctrine

`docs/TRACKERS.md` said the builder may use system words, which made the old wording defensible by the letter. That rule now stops at the API and the storage: the visible builder is an end-user surface, and a page that shows a person the word *template* is leaking its plumbing.

## Test gate
One test pins the wording across all three create-page variants and asserts none of them renders the word *template*. A second asserts no rendered page carries an `(#nnn)` reference in its visible text — written against the rendered text of seven routes rather than the two known strings, so a third provenance note cannot be added quietly. One stale assertion on the old heading updated.

Full suite green (225 pass, 0 fail); both validators exit 0.