### PR TITLE
feat(annotations): capture mode for rapid live-note taking (#371, #372, #373)

### DIFF
--- a/lib/annotations.js
+++ b/lib/annotations.js
@@ -131,7 +131,7 @@ function nextAnnotationId(annotations, isoTimestamp) {
       continue;
     }
 
-    const match = annotation.id.match(new RegExp(`^${prefix}-(\\d{3})$`));
+    const match = annotation.id.match(new RegExp(`^${prefix}-(\\d+)$`));
     if (!match) {
       continue;
     }
@@ -322,50 +322,76 @@ async function writeAnnotationDocument(sidecarPath, document, expectedMtimeMs) {
   };
 }
 
-async function createAnnotation(rootPath, repo, relativePath, input) {
-  const existing = await readAnnotationDocument(rootPath, repo, relativePath);
-  const annotation = buildAnnotation(input, existing.document.annotations);
-  const nextDocument = {
-    ...existing.document,
-    annotations: [...existing.document.annotations, annotation],
-  };
+// Mutations are read-modify-write over the whole sidecar, and creates carry no
+// expectedMtimeMs (an appending client cannot know the current mtime), so
+// overlapping mutations in this process must be serialized per sidecar file.
+const mutationQueues = new Map();
 
-  const saved = await writeAnnotationDocument(existing.sidecarPath, nextDocument);
-  return {
-    annotation,
-    mtimeMs: saved.mtimeMs,
-    document: saved.document,
-  };
+function mutationQueueKey(rootPath, repo, relativePath) {
+  return `${path.resolve(rootPath)}|${repo}|${toPosixPath(relativePath)}`;
 }
 
-async function updateAnnotation(rootPath, repo, relativePath, input) {
+function withMutationQueue(key, task) {
+  const previous = mutationQueues.get(key) || Promise.resolve();
+  const result = previous.then(() => task());
+  const settled = result.catch(() => {}).finally(() => {
+    if (mutationQueues.get(key) === settled) {
+      mutationQueues.delete(key);
+    }
+  });
+  mutationQueues.set(key, settled);
+  return result;
+}
+
+function createAnnotation(rootPath, repo, relativePath, input) {
+  return withMutationQueue(mutationQueueKey(rootPath, repo, relativePath), async () => {
+    const existing = await readAnnotationDocument(rootPath, repo, relativePath);
+    const annotation = buildAnnotation(input, existing.document.annotations);
+    const nextDocument = {
+      ...existing.document,
+      annotations: [...existing.document.annotations, annotation],
+    };
+
+    const saved = await writeAnnotationDocument(existing.sidecarPath, nextDocument);
+    return {
+      annotation,
+      mtimeMs: saved.mtimeMs,
+      document: saved.document,
+    };
+  });
+}
+
+function updateAnnotation(rootPath, repo, relativePath, input) {
   const id = requireNonEmptyString(input && input.id, 'id');
   const op = requireNonEmptyString(input && input.op, 'op');
-  const existing = await readAnnotationDocument(rootPath, repo, relativePath);
-  const index = existing.document.annotations.findIndex((annotation) => annotation && annotation.id === id);
 
-  if (index === -1) {
-    throw new Error('Annotation not found.');
-  }
+  return withMutationQueue(mutationQueueKey(rootPath, repo, relativePath), async () => {
+    const existing = await readAnnotationDocument(rootPath, repo, relativePath);
+    const index = existing.document.annotations.findIndex((annotation) => annotation && annotation.id === id);
 
-  const updatedAnnotation = applyAnnotationOperation(existing.document.annotations[index], op, input.payload || {});
-  const annotations = existing.document.annotations.slice();
-  annotations[index] = updatedAnnotation;
+    if (index === -1) {
+      throw new Error('Annotation not found.');
+    }
 
-  const saved = await writeAnnotationDocument(
-    existing.sidecarPath,
-    {
-      ...existing.document,
-      annotations,
-    },
-    input.expectedMtimeMs
-  );
+    const updatedAnnotation = applyAnnotationOperation(existing.document.annotations[index], op, input.payload || {});
+    const annotations = existing.document.annotations.slice();
+    annotations[index] = updatedAnnotation;
 
-  return {
-    annotation: updatedAnnotation,
-    mtimeMs: saved.mtimeMs,
-    document: saved.document,
-  };
+    const saved = await writeAnnotationDocument(
+      existing.sidecarPath,
+      {
+        ...existing.document,
+        annotations,
+      },
+      input.expectedMtimeMs
+    );
+
+    return {
+      annotation: updatedAnnotation,
+      mtimeMs: saved.mtimeMs,
+      document: saved.document,
+    };
+  });
 }
 
 module.exports = {

--- a/public/annotations.js
+++ b/public/annotations.js
@@ -299,9 +299,10 @@
   }
 
   function clearAnchorMounts() {
+    // Re-renders must not destroy an open compose form (or a draft in it).
     document.querySelectorAll(mountSelector).forEach((mount) => {
-      mount.innerHTML = '';
-      mount.hidden = true;
+      mount.querySelectorAll('.lookie-annotation-card').forEach((card) => card.remove());
+      mount.hidden = !mount.querySelector('.lookie-annotate-form');
     });
   }
 
@@ -385,6 +386,7 @@
     form.appendChild(el('div', { class: 'lookie-line-range-row' }, startInput, endInput, authorInput));
     form.appendChild(bodyInput);
     form.appendChild(el('div', { class: 'lookie-annotate-form-actions' }, submit));
+    bindQuickSubmit(form, bodyInput, submit);
 
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
@@ -466,6 +468,19 @@
     }
   }
 
+  function bindQuickSubmit(form, bodyInput, submit) {
+    bodyInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        if (typeof form.requestSubmit === 'function') {
+          form.requestSubmit(submit);
+        } else {
+          submit.click();
+        }
+      }
+    });
+  }
+
   function openAnchorForm(anchorId, anchorKind) {
     const mount = getMount(anchorId);
     if (!mount) {
@@ -475,7 +490,11 @@
     mount.hidden = false;
     const prior = mount.querySelector('.lookie-annotate-form');
     if (prior) {
-      prior.remove();
+      const priorBody = prior.querySelector('textarea[name="body"]');
+      if (priorBody) {
+        priorBody.focus();
+      }
+      return;
     }
 
     const form = el('form', { class: 'lookie-annotate-form' });
@@ -488,7 +507,7 @@
     });
     const bodyInput = el('textarea', {
       name: 'body',
-      rows: '3',
+      rows: '6',
       placeholder: 'What needs attention?',
       required: 'required',
     });
@@ -507,7 +526,10 @@
     form.appendChild(authorInput);
     form.appendChild(bodyInput);
     form.appendChild(el('div', { class: 'lookie-annotate-form-actions' }, submit, cancel));
+    bindQuickSubmit(form, bodyInput, submit);
 
+    // The form persists after a save (body clears, focus returns) so a run of
+    // rapid notes on one anchor costs one open, not one per note.
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
       const author = authorInput.value.trim();
@@ -524,12 +546,14 @@
           author,
           body,
         });
+        bodyInput.value = '';
       } catch (error) {
         window.alert(`Save annotation failed: ${error.message}`);
-        submit.disabled = false;
         return;
+      } finally {
+        submit.disabled = false;
       }
-      form.remove();
+      bodyInput.focus();
     });
 
     mount.appendChild(form);
@@ -601,7 +625,7 @@
       const card = createCard(title, anchorId);
       renderGroup(card, annotations);
       mount.hidden = false;
-      mount.appendChild(card);
+      mount.insertBefore(card, mount.querySelector('.lookie-annotate-form'));
     }
 
     if (supportsLineRanges) {

--- a/public/style.css
+++ b/public/style.css
@@ -2392,11 +2392,12 @@ tbody tr:last-child td {
   background: var(--bg); border: 1px dashed var(--border); border-radius: 5px;
 }
 .lookie-annotate-form input, .lookie-annotate-form textarea {
-  font: inherit; padding: 0.35rem 0.5rem;
+  /* 16px floor: below it, iOS Safari zooms the page on focus (matches the forms platform). */
+  font: inherit; font-size: 16px; padding: 0.35rem 0.5rem;
   background: var(--bg-code); color: var(--text);
   border: 1px solid var(--border); border-radius: 4px;
 }
-.lookie-annotate-form textarea { resize: vertical; min-height: 4.5rem; }
+.lookie-annotate-form textarea { resize: vertical; min-height: 9rem; }
 .lookie-annotate-form-actions { display: flex; gap: 0.4rem; }
 .lookie-annotation-submit, .lookie-annotation-cancel {
   padding: 0.3rem 0.75rem; font: inherit; border-radius: 4px; cursor: pointer;
@@ -2426,6 +2427,7 @@ tbody tr:last-child td {
 .lookie-line-range-form input,
 .lookie-line-range-form textarea {
   font: inherit;
+  font-size: 16px;
   padding: 0.35rem 0.5rem;
   background: var(--bg-code);
   color: var(--text);

--- a/test/annotations-client.test.js
+++ b/test/annotations-client.test.js
@@ -289,3 +289,122 @@ delta</code></pre>
   assert.ok(lineRangeRoot.textContent.includes('Check these lines'));
   dom.window.close();
 });
+
+test('heading compose form persists across saves for rapid capture', async () => {
+  const requests = [];
+  const savedAnnotations = [];
+  const dom = await bootDom({
+    body: `
+      <button type="button" data-annotations-toggle hidden></button>
+      <main>
+        <article class="content markdown" data-rendered-view>
+          <h1 id="board">
+            Board
+            <button type="button" data-annotate-trigger data-anchor-id="board" data-anchor-kind="heading">💬 Annotate</button>
+          </h1>
+          <section data-annotations-mount data-anchor-id="board" data-anchor-kind="heading"></section>
+        </article>
+        <aside data-annotations-stale hidden></aside>
+      </main>
+    `,
+    bootstrap: {
+      repo: 'docs',
+      relativePath: 'doc.md',
+      queryToken: null,
+      supportsLineRangeAnnotations: false,
+      sourceLineCount: 3,
+    },
+    fetchImpl: async (url, init = {}) => {
+      const method = init.method || 'GET';
+      requests.push({ url, method, body: init.body ? JSON.parse(init.body) : null });
+      if (method === 'POST') {
+        const body = JSON.parse(init.body);
+        savedAnnotations.push({
+          id: `2026-08-05-${String(savedAnnotations.length + 1).padStart(3, '0')}`,
+          anchor: body.anchor,
+          anchorKind: body.anchorKind,
+          body: body.body,
+          author: body.author,
+          createdAt: '2026-08-05T13:00:00.000Z',
+          state: 'open',
+          claimedBy: null,
+          claimedAt: null,
+          resolvedAt: null,
+          replies: [],
+        });
+        return {
+          ok: true,
+          async json() {
+            return { ok: true, mtimeMs: savedAnnotations.length, annotation: savedAnnotations[savedAnnotations.length - 1] };
+          },
+        };
+      }
+      return {
+        ok: true,
+        async json() {
+          return {
+            schema: 1,
+            file: 'docs/doc.md',
+            mtimeMs: savedAnnotations.length,
+            annotations: [...savedAnnotations],
+          };
+        },
+      };
+    },
+  });
+
+  const { document } = dom.window;
+  const mount = document.querySelector('[data-annotations-mount][data-anchor-id="board"]');
+  document.querySelector('[data-annotate-trigger]').click();
+
+  const form = mount.querySelector('.lookie-annotate-form');
+  assert.ok(form);
+  const authorInput = form.querySelector('input[name="author"]');
+  const bodyInput = form.querySelector('textarea[name="body"]');
+
+  authorInput.value = 'capturer';
+  bodyInput.value = 'First rapid note';
+  form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+  await flush();
+  await flush();
+
+  assert.equal(requests.filter((request) => request.method === 'POST').length, 1);
+  assert.ok(mount.contains(form), 'compose form must survive the save');
+  assert.equal(bodyInput.value, '', 'body clears for the next note');
+  assert.equal(authorInput.value, 'capturer', 'author is retained');
+  assert.equal(mount.hidden, false);
+  assert.equal(document.activeElement, bodyInput, 'focus returns to the body for the next note');
+  assert.ok(mount.textContent.includes('First rapid note'), 'saved note renders without reopening the form');
+
+  bodyInput.value = 'Second rapid note';
+  bodyInput.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+    key: 'Enter',
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  }));
+  await flush();
+  await flush();
+
+  const posts = requests.filter((request) => request.method === 'POST');
+  assert.equal(posts.length, 2, 'Ctrl+Enter submits without touching the Save button');
+  assert.equal(posts[1].body.body, 'Second rapid note');
+  assert.equal(posts[1].body.anchor, '#board');
+  assert.ok(mount.contains(form));
+  assert.equal(bodyInput.value, '');
+
+  document.querySelector('[data-annotate-trigger]').click();
+  assert.equal(mount.querySelectorAll('.lookie-annotate-form').length, 1, 'reopening focuses the existing form instead of duplicating it');
+
+  dom.window.close();
+});
+
+test('annotation form inputs hold the 16px mobile font floor', () => {
+  const css = fs.readFileSync(path.join(__dirname, '..', 'public', 'style.css'), 'utf8');
+  const annotateBlock = css.match(/\.lookie-annotate-form input[^{]*\{[^}]*\}/);
+  const lineRangeBlock = css.match(/\.lookie-line-range-form input[^{]*\{[^}]*\}/);
+  assert.ok(annotateBlock, 'annotate form input rule exists');
+  assert.ok(lineRangeBlock, 'line-range form input rule exists');
+  assert.match(annotateBlock[0], /font-size:\s*16px/, 'annotate inputs declare the 16px floor (font: inherit alone re-zooms iOS)');
+  assert.match(lineRangeBlock[0], /font-size:\s*16px/, 'line-range inputs declare the 16px floor');
+});

--- a/test/annotations-server.test.js
+++ b/test/annotations-server.test.js
@@ -219,3 +219,78 @@ test('document rendering exposes line ranges and deliberate authored-HTML annota
   assert.match(authoredHtml, /data-annotate-trigger(?:="")? data-anchor-id="review-target"/);
   assert.match(authoredHtml, /data-annotations-mount(?:="")? data-anchor-id="review-target"/);
 });
+
+test('overlapping annotation creates on one file all persist with distinct ids', async () => {
+  const root = await makeFixture();
+
+  try {
+    const created = await Promise.all(
+      Array.from({ length: 5 }, (_value, index) => createAnnotation(root, 'docs', 'guide.md', {
+        anchor: '#guide',
+        anchorKind: 'heading',
+        author: 'capturer',
+        body: `Concurrent note ${index}`,
+      }))
+    );
+
+    const stored = await readAnnotationDocument(root, 'docs', 'guide.md');
+    assert.equal(stored.document.annotations.length, 5);
+
+    const ids = stored.document.annotations.map((annotation) => annotation.id);
+    assert.equal(new Set(ids).size, 5);
+
+    const bodies = stored.document.annotations.map((annotation) => annotation.body).sort();
+    assert.deepEqual(bodies, created.map((_result, index) => `Concurrent note ${index}`).sort());
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('annotation ids stay unique past 999 same-day annotations on one file', async () => {
+  const root = await makeFixture();
+
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    const sidecarPath = path.join(root, '.lookie-link', 'annotations', 'docs', 'guide.md.json');
+    await fs.mkdir(path.dirname(sidecarPath), { recursive: true });
+    await fs.writeFile(sidecarPath, `${JSON.stringify({
+      schema: 1,
+      file: 'docs/guide.md',
+      annotations: [{
+        id: `${today}-999`,
+        anchor: '#guide',
+        anchorKind: 'heading',
+        body: 'Note 999',
+        author: 'capturer',
+        createdAt: new Date().toISOString(),
+        state: 'open',
+        claimedBy: null,
+        claimedAt: null,
+        resolvedAt: null,
+        replies: [],
+      }],
+    }, null, 2)}\n`, 'utf8');
+
+    const thousandth = await createAnnotation(root, 'docs', 'guide.md', {
+      anchor: '#guide',
+      anchorKind: 'heading',
+      author: 'capturer',
+      body: 'Note 1000',
+    });
+    const thousandFirst = await createAnnotation(root, 'docs', 'guide.md', {
+      anchor: '#guide',
+      anchorKind: 'heading',
+      author: 'capturer',
+      body: 'Note 1001',
+    });
+
+    assert.equal(thousandth.annotation.id, `${today}-1000`);
+    assert.equal(thousandFirst.annotation.id, `${today}-1001`);
+
+    const stored = await readAnnotationDocument(root, 'docs', 'guide.md');
+    const ids = stored.document.annotations.map((annotation) => annotation.id);
+    assert.equal(new Set(ids).size, ids.length);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Implements the capture-mode slice from #370.

## What changed

**Server (`lib/annotations.js`)** — closes #371, closes #372:
- Annotation mutations on one sidecar now run through a per-file in-process queue. Creates carry no `expectedMtimeMs` by design (an appending client can't know the current mtime), so overlapping creates were unguarded read-modify-write and could silently drop an append. PATCH ops share the queue.
- The id scan matched exactly three digits, so the 1000th same-day annotation on one file reset the counter and collided. It now matches any digit count, keeping 3-digit padding below 1000 — existing ids are untouched.

**Client (`public/annotations.js`, `public/style.css`)** — closes #373:
- Re-renders no longer wipe an open compose form (or a draft in it) — `clearAnchorMounts` removes annotation cards instead of `innerHTML = ''`.
- After a successful save the heading compose form stays mounted, clears its body, and refocuses — a run of rapid notes on one anchor costs one open, not one per note.
- Ctrl/Cmd+Enter submits from the body textarea (both heading and line-range forms).
- Reopening an anchor focuses the existing form instead of destroying a draft.
- Taller default compose box; annotation form inputs hold a 16px font floor so iOS Safari stops zooming on focus (same rationale as the forms platform).

## Test gates

All four new tests fail against the previous implementation (verified by stashing the fix and re-running):
- overlapping annotation creates on one file all persist with distinct ids
- annotation ids stay unique past 999 same-day annotations on one file
- heading compose form persists across saves for rapid capture (includes Ctrl+Enter submit, focus return, no-duplicate-form reopen)
- annotation form inputs hold the 16px mobile font floor

Full suite: 217/217 unit + 12/12 browser tests pass.

## Deliberate non-changes

No markdown rendering of bodies, no unanchored annotation kind, no body-edit op, no schema change — see #370 for why those are boundaries, not omissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
