### PR TITLE
feat(annotations): markdown-formatted bodies, rendered at read time (#375)

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -41,6 +41,19 @@ const markdown = new MarkdownIt({
   },
 });
 
+// Annotation bodies are user-authored API input, not trusted repo documents:
+// html stays off so authored markup arrives escaped, never parsed.
+const annotationMarkdown = new MarkdownIt({
+  html: false,
+  linkify: true,
+  typographer: true,
+  breaks: true,
+});
+
+function renderAnnotationMarkdown(body) {
+  return annotationMarkdown.render(String(body || ''));
+}
+
 const domPurifyWindow = new JSDOM('').window;
 const DOMPurify = createDOMPurify(domPurifyWindow);
 const YOUTUBE_EMBED_SRC_RE = /^https:\/\/(?:www\.)?youtube\.com\/embed\/[A-Za-z0-9_-]+(?:\?[^"\s]*)?$/i;
@@ -2709,6 +2722,7 @@ module.exports = {
   parseCsv,
   renderEditPage,
   renderPreviewHtml,
+  renderAnnotationMarkdown,
   setThemeList,
   setNavLinks,
   getNavLinks,

--- a/public/annotations.js
+++ b/public/annotations.js
@@ -180,6 +180,19 @@
     return `${text.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
   }
 
+  function annotationBodyNode(entry) {
+    const node = el('div', { class: 'lookie-annotation-body' });
+    // bodyHtml is rendered server-side with raw HTML escaped; absence means an
+    // older server or a degraded path, so fall back to the plain body.
+    if (typeof entry.bodyHtml === 'string') {
+      node.classList.add('lookie-annotation-body-rich');
+      node.innerHTML = entry.bodyHtml;
+    } else {
+      node.textContent = entry.body;
+    }
+    return node;
+  }
+
   function renderAnnotationItem(annotation) {
     const replyCount = Array.isArray(annotation.replies) ? annotation.replies.length : 0;
     const item = el('details', {
@@ -203,7 +216,7 @@
     ));
 
     const detail = el('div', { class: 'lookie-annotation-detail' });
-    detail.appendChild(el('p', { class: 'lookie-annotation-body' }, annotation.body));
+    detail.appendChild(annotationBodyNode(annotation));
 
     if (Array.isArray(annotation.replies) && annotation.replies.length > 0) {
       const replies = el('ul', { class: 'lookie-annotation-replies' });
@@ -213,7 +226,7 @@
           { class: 'lookie-annotation-reply' },
           el('span', { class: 'lookie-annotation-author' }, reply.author || 'anonymous'),
           el('time', { datetime: reply.createdAt }, formatTimestamp(reply.createdAt)),
-          el('p', { class: 'lookie-annotation-body' }, reply.body)
+          annotationBodyNode(reply)
         ));
       }
       detail.appendChild(replies);

--- a/public/style.css
+++ b/public/style.css
@@ -2372,6 +2372,15 @@ tbody tr:last-child td {
   white-space: nowrap;
 }
 .lookie-annotation-body { white-space: pre-wrap; margin: 0.15rem 0 0.45rem; color: var(--text); }
+/* Rendered-markdown bodies: block elements own their spacing, so pre-wrap would double it. */
+.lookie-annotation-body-rich { white-space: normal; }
+.lookie-annotation-body-rich > :first-child { margin-top: 0; }
+.lookie-annotation-body-rich > :last-child { margin-bottom: 0; }
+.lookie-annotation-body-rich p { margin: 0 0 0.4rem; }
+.lookie-annotation-body-rich ul, .lookie-annotation-body-rich ol { margin: 0 0 0.4rem; padding-left: 1.25rem; }
+.lookie-annotation-body-rich code { background: var(--bg-code); padding: 0 0.25rem; border-radius: 3px; }
+.lookie-annotation-body-rich pre { background: var(--bg-code); padding: 0.45rem 0.55rem; border-radius: 4px; overflow-x: auto; }
+.lookie-annotation-body-rich blockquote { margin: 0 0 0.4rem; padding-left: 0.6rem; border-left: 2px solid var(--border); color: var(--text-soft); }
 .lookie-annotation-replies {
   margin: 0.3rem 0 0.4rem 0.4rem; padding-left: 0.6rem;
   list-style: none; border-left: 2px solid var(--border);

--- a/server.js
+++ b/server.js
@@ -65,6 +65,7 @@ const {
   renderJsonPage,
   renderEditPage,
   renderPreviewHtml,
+  renderAnnotationMarkdown,
   setThemeList,
   setNavLinks,
 } = require('./lib/renderer');
@@ -2209,8 +2210,19 @@ function createApp(options = {}) {
           ? [req.query.state]
           : [];
       const filtered = filterAnnotationsByState(result.document, states);
+      // bodyHtml is a response-only projection; the stored sidecar stays plain text.
       res.status(200).json({
         ...filtered,
+        annotations: filtered.annotations.map((annotation) => ({
+          ...annotation,
+          bodyHtml: renderAnnotationMarkdown(annotation.body),
+          replies: Array.isArray(annotation.replies)
+            ? annotation.replies.map((reply) => ({
+                ...reply,
+                bodyHtml: renderAnnotationMarkdown(reply.body),
+              }))
+            : annotation.replies,
+        })),
         mtimeMs: result.mtimeMs,
       });
     } catch (error) {

--- a/test/annotations-client.test.js
+++ b/test/annotations-client.test.js
@@ -408,3 +408,81 @@ test('annotation form inputs hold the 16px mobile font floor', () => {
   assert.match(annotateBlock[0], /font-size:\s*16px/, 'annotate inputs declare the 16px floor (font: inherit alone re-zooms iOS)');
   assert.match(lineRangeBlock[0], /font-size:\s*16px/, 'line-range inputs declare the 16px floor');
 });
+
+test('annotation bodies render server-provided markdown html and fall back to plain text', async () => {
+  const dom = await bootDom({
+    body: `
+      <button type="button" data-annotations-toggle hidden></button>
+      <main>
+        <article class="content markdown" data-rendered-view>
+          <h1 id="board">Board</h1>
+          <section data-annotations-mount data-anchor-id="board" data-anchor-kind="heading"></section>
+        </article>
+        <aside data-annotations-stale hidden></aside>
+      </main>
+    `,
+    bootstrap: {
+      repo: 'docs',
+      relativePath: 'doc.md',
+      queryToken: null,
+      supportsLineRangeAnnotations: false,
+      sourceLineCount: 3,
+    },
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return {
+          schema: 1,
+          file: 'docs/doc.md',
+          mtimeMs: 7,
+          annotations: [
+            {
+              id: '2026-08-05-001',
+              anchor: '#board',
+              anchorKind: 'heading',
+              body: '**bold note**',
+              bodyHtml: '<p><strong>bold note</strong></p>\n',
+              author: 'capturer',
+              createdAt: '2026-08-05T13:00:00.000Z',
+              state: 'open',
+              claimedBy: null,
+              claimedAt: null,
+              resolvedAt: null,
+              replies: [],
+            },
+            {
+              id: '2026-08-05-002',
+              anchor: '#board',
+              anchorKind: 'heading',
+              body: 'plain fallback **not rendered**',
+              author: 'capturer',
+              createdAt: '2026-08-05T13:01:00.000Z',
+              state: 'open',
+              claimedBy: null,
+              claimedAt: null,
+              resolvedAt: null,
+              replies: [],
+            },
+          ],
+        };
+      },
+    }),
+  });
+
+  const { document } = dom.window;
+  const mount = document.querySelector('[data-annotations-mount][data-anchor-id="board"]');
+  const bodies = mount.querySelectorAll('.lookie-annotation-detail .lookie-annotation-body');
+  assert.equal(bodies.length, 2);
+
+  const rich = bodies[0];
+  assert.ok(rich.classList.contains('lookie-annotation-body-rich'));
+  assert.ok(rich.querySelector('strong'));
+  assert.equal(rich.querySelector('strong').textContent, 'bold note');
+
+  const plain = bodies[1];
+  assert.ok(!plain.classList.contains('lookie-annotation-body-rich'));
+  assert.equal(plain.querySelector('strong'), null, 'no bodyHtml means no markup interpretation');
+  assert.ok(plain.textContent.includes('plain fallback **not rendered**'));
+
+  dom.window.close();
+});

--- a/test/annotations-server.test.js
+++ b/test/annotations-server.test.js
@@ -294,3 +294,55 @@ test('annotation ids stay unique past 999 same-day annotations on one file', asy
     await fs.rm(root, { recursive: true, force: true });
   }
 });
+
+test('annotation GET responses render markdown bodies without letting authored HTML through', async () => {
+  const root = await makeFixture();
+
+  try {
+    const created = await createAnnotation(root, 'docs', 'guide.md', {
+      anchor: '#guide',
+      anchorKind: 'heading',
+      author: 'capturer',
+      body: '**bold claim** with <script>alert(1)</script>\n- point one',
+    });
+    await updateAnnotation(root, 'docs', 'guide.md', {
+      id: created.annotation.id,
+      op: 'reply',
+      payload: { author: 'reviewer', body: 'reply with `code`' },
+      expectedMtimeMs: created.mtimeMs,
+    });
+
+    const app = createApp({
+      mappings: { docs: root },
+      annotationsEnabled: true,
+      accessConfig: {
+        humanDefault: 'restricted',
+        tokens: {
+          writer: {
+            secret: 'writer-token',
+            repos: { docs: { paths: ['*'] } },
+            permissions: { view: true, write: true },
+          },
+        },
+      },
+    });
+    const get = getRouteHandler(app, 'get');
+    const res = createMockRes();
+    await get(requestWithToken('writer-token', undefined), res);
+
+    assert.equal(res.statusCode, 200);
+    const [annotation] = res.body.annotations;
+    assert.match(annotation.bodyHtml, /<strong>bold claim<\/strong>/);
+    assert.match(annotation.bodyHtml, /<li>point one<\/li>/);
+    assert.doesNotMatch(annotation.bodyHtml, /<script>/, 'authored HTML must arrive escaped, not parsed');
+    assert.match(annotation.bodyHtml, /&lt;script&gt;/);
+    assert.match(annotation.replies[0].bodyHtml, /<code>code<\/code>/);
+    assert.equal(annotation.body, '**bold claim** with <script>alert(1)</script>\n- point one', 'plain body stays verbatim');
+
+    const sidecarPath = (await readAnnotationDocument(root, 'docs', 'guide.md')).sidecarPath;
+    const storedRaw = await fs.readFile(sidecarPath, 'utf8');
+    assert.doesNotMatch(storedRaw, /bodyHtml/, 'rendered HTML is a response projection, never stored');
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #375. Follow-on to #374 — the first deliberately-deferred item from #370, pulled forward by owner call after the first live capture session.

## What changed

- `lib/renderer.js`: a second, restricted markdown instance for annotation bodies — `html: false` (bodies are user-authored API input; the document renderer's `html: true` instance is for trusted repo files and is not reused), `linkify: true`, `breaks: true` so quick-note line breaks survive.
- `server.js`: the annotations GET response adds `bodyHtml` per annotation and per reply as a response-only projection. The stored sidecar stays verbatim plain text.
- `public/annotations.js`: bodies render `bodyHtml` when present (`.lookie-annotation-body-rich`), fall back to plain `textContent` when absent — older servers and the PATCH-409 recovery path degrade gracefully.
- `public/style.css`: markdown-body styles (tight block margins, code/pre/blockquote/list treatment); `white-space: normal` on rich bodies since block elements own their spacing.

## Test gates (both fail against the previous implementation)

- Server: GET renders `**bold**` → `<strong>`, lists → `<li>`, and an authored `<script>` arrives escaped, never parsed; the sidecar on disk contains no `bodyHtml`; the plain `body` stays verbatim.
- Client: `bodyHtml` renders formatting; an annotation without `bodyHtml` renders plain text with no markup interpretation.

Full suite: 219/219 unit + 12/12 browser green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
