### PR TITLE
feat(annotations): formatting toolbar on the compose box (#377)

### DIFF
--- a/public/annotations.js
+++ b/public/annotations.js
@@ -397,6 +397,7 @@
     const submit = el('button', { type: 'submit', class: 'lookie-annotation-submit' }, 'Annotate lines');
 
     form.appendChild(el('div', { class: 'lookie-line-range-row' }, startInput, endInput, authorInput));
+    form.appendChild(buildComposeToolbar(bodyInput));
     form.appendChild(bodyInput);
     form.appendChild(el('div', { class: 'lookie-annotate-form-actions' }, submit));
     bindQuickSubmit(form, bodyInput, submit);
@@ -481,6 +482,73 @@
     }
   }
 
+  function applyInlineMarkdown(bodyInput, prefix, suffix, placeholder) {
+    const start = bodyInput.selectionStart || 0;
+    const end = bodyInput.selectionEnd || 0;
+    const value = bodyInput.value;
+    const selected = value.slice(start, end) || placeholder;
+    bodyInput.value = `${value.slice(0, start)}${prefix}${selected}${suffix}${value.slice(end)}`;
+    const selectFrom = start + prefix.length;
+    bodyInput.setSelectionRange(selectFrom, selectFrom + selected.length);
+    bodyInput.focus();
+  }
+
+  function applyListMarkdown(bodyInput) {
+    const value = bodyInput.value;
+    const start = bodyInput.selectionStart || 0;
+    const end = bodyInput.selectionEnd || 0;
+    const blockStart = value.lastIndexOf('\n', start - 1) + 1;
+    let blockEnd = value.indexOf('\n', end);
+    if (blockEnd === -1) {
+      blockEnd = value.length;
+    }
+    const block = value.slice(blockStart, blockEnd) || 'item';
+    const listed = block
+      .split('\n')
+      .map((line) => (line.startsWith('- ') ? line : `- ${line}`))
+      .join('\n');
+    bodyInput.value = `${value.slice(0, blockStart)}${listed}${value.slice(blockEnd)}`;
+    const caret = blockStart + listed.length;
+    bodyInput.setSelectionRange(caret, caret);
+    bodyInput.focus();
+  }
+
+  function applyLinkMarkdown(bodyInput) {
+    const start = bodyInput.selectionStart || 0;
+    const end = bodyInput.selectionEnd || 0;
+    const value = bodyInput.value;
+    const label = value.slice(start, end) || 'link text';
+    const inserted = `[${label}](url)`;
+    bodyInput.value = `${value.slice(0, start)}${inserted}${value.slice(end)}`;
+    const urlStart = start + label.length + 3;
+    bodyInput.setSelectionRange(urlStart, urlStart + 3);
+    bodyInput.focus();
+  }
+
+  function buildComposeToolbar(bodyInput) {
+    const tools = [
+      { label: 'B', title: 'Bold', run: () => applyInlineMarkdown(bodyInput, '**', '**', 'bold') },
+      { label: 'I', title: 'Italic', run: () => applyInlineMarkdown(bodyInput, '*', '*', 'italic') },
+      { label: '<>', title: 'Code', run: () => applyInlineMarkdown(bodyInput, '`', '`', 'code') },
+      { label: '• List', title: 'List', run: () => applyListMarkdown(bodyInput) },
+      { label: 'Link', title: 'Link', run: () => applyLinkMarkdown(bodyInput) },
+    ];
+
+    const bar = el('div', { class: 'lookie-compose-toolbar', role: 'toolbar', 'aria-label': 'Formatting' });
+    for (const tool of tools) {
+      bar.appendChild(el('button', {
+        type: 'button',
+        class: 'lookie-compose-tool',
+        title: tool.title,
+        'aria-label': tool.title,
+        // Keep the textarea's focus and selection through the click.
+        onmousedown: (event) => event.preventDefault(),
+        onclick: tool.run,
+      }, tool.label));
+    }
+    return bar;
+  }
+
   function bindQuickSubmit(form, bodyInput, submit) {
     bodyInput.addEventListener('keydown', (event) => {
       if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
@@ -537,6 +605,7 @@
     }, 'Cancel');
 
     form.appendChild(authorInput);
+    form.appendChild(buildComposeToolbar(bodyInput));
     form.appendChild(bodyInput);
     form.appendChild(el('div', { class: 'lookie-annotate-form-actions' }, submit, cancel));
     bindQuickSubmit(form, bodyInput, submit);

--- a/public/style.css
+++ b/public/style.css
@@ -2408,6 +2408,14 @@ tbody tr:last-child td {
 }
 .lookie-annotate-form textarea { resize: vertical; min-height: 9rem; }
 .lookie-annotate-form-actions { display: flex; gap: 0.4rem; }
+.lookie-compose-toolbar { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.lookie-compose-tool {
+  min-width: 2.4rem; min-height: 2rem; padding: 0.25rem 0.6rem;
+  font: inherit; font-size: 0.85em; font-weight: 600;
+  background: var(--bg-code); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px; cursor: pointer;
+}
+.lookie-compose-tool:hover { border-color: var(--accent); color: var(--accent); }
 .lookie-annotation-submit, .lookie-annotation-cancel {
   padding: 0.3rem 0.75rem; font: inherit; border-radius: 4px; cursor: pointer;
   border: 1px solid var(--border);

--- a/test/annotations-client.test.js
+++ b/test/annotations-client.test.js
@@ -486,3 +486,75 @@ test('annotation bodies render server-provided markdown html and fall back to pl
 
   dom.window.close();
 });
+
+test('compose toolbar applies markdown to the body without submitting the form', async () => {
+  const requests = [];
+  const dom = await bootDom({
+    body: `
+      <button type="button" data-annotations-toggle hidden></button>
+      <main>
+        <article class="content markdown" data-rendered-view>
+          <h1 id="board">
+            Board
+            <button type="button" data-annotate-trigger data-anchor-id="board" data-anchor-kind="heading">💬 Annotate</button>
+          </h1>
+          <section data-annotations-mount data-anchor-id="board" data-anchor-kind="heading"></section>
+        </article>
+        <aside data-annotations-stale hidden></aside>
+      </main>
+    `,
+    bootstrap: {
+      repo: 'docs',
+      relativePath: 'doc.md',
+      queryToken: null,
+      supportsLineRangeAnnotations: false,
+      sourceLineCount: 3,
+    },
+    fetchImpl: async (url, init = {}) => {
+      requests.push({ method: init.method || 'GET' });
+      return {
+        ok: true,
+        async json() {
+          return { schema: 1, file: 'docs/doc.md', mtimeMs: null, annotations: [] };
+        },
+      };
+    },
+  });
+
+  const { document } = dom.window;
+  document.querySelector('[data-annotate-trigger]').click();
+  const form = document.querySelector('.lookie-annotate-form');
+  const bodyInput = form.querySelector('textarea[name="body"]');
+  const tools = Object.fromEntries(
+    Array.from(form.querySelectorAll('.lookie-compose-tool')).map((button) => [button.title, button])
+  );
+  assert.deepEqual(Object.keys(tools).sort(), ['Bold', 'Code', 'Italic', 'Link', 'List']);
+
+  bodyInput.value = 'pick me';
+  bodyInput.setSelectionRange(0, 4);
+  tools.Bold.click();
+  assert.equal(bodyInput.value, '**pick** me');
+  assert.equal(bodyInput.value.slice(bodyInput.selectionStart, bodyInput.selectionEnd), 'pick');
+
+  bodyInput.value = '';
+  bodyInput.setSelectionRange(0, 0);
+  tools.Italic.click();
+  assert.equal(bodyInput.value, '*italic*');
+  assert.equal(bodyInput.value.slice(bodyInput.selectionStart, bodyInput.selectionEnd), 'italic');
+
+  bodyInput.value = 'one\ntwo';
+  bodyInput.setSelectionRange(0, bodyInput.value.length);
+  tools.List.click();
+  assert.equal(bodyInput.value, '- one\n- two');
+
+  bodyInput.value = 'Fast Track';
+  bodyInput.setSelectionRange(0, 10);
+  tools.Link.click();
+  assert.equal(bodyInput.value, '[Fast Track](url)');
+  assert.equal(bodyInput.value.slice(bodyInput.selectionStart, bodyInput.selectionEnd), 'url');
+
+  assert.equal(requests.filter((request) => request.method === 'POST').length, 0, 'toolbar clicks never submit');
+  assert.ok(document.body.contains(form));
+
+  dom.window.close();
+});


### PR DESCRIPTION
Closes #377. Follow-on to #376: formatting buttons for the compose box.

Bold / Italic / Code / List / Link above the body textarea in both compose forms. Each applies markdown to the current selection or inserts a selected placeholder at the caret, and keeps focus in the textarea (mousedown prevented so the selection survives the click). `type="button"` throughout — the toolbar can never submit the form.

Deliberately **not** WYSIWYG: no contenteditable, no rich-text dependency, no HTML↔markdown round-tripping — syntax insertion only, with the rendered annotation card as the preview. Client-only change: deploys on pull, no service restart.

Test gates (fail against the previous client): selection wrapping, caret placeholder insertion, line prefixing for lists, link URL pre-selection, and a no-POST canary for toolbar clicks. Full suite: 220/220 unit + 12/12 browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
