### PR TITLE
fix(annotations): open cards stop repeating the note as a plain preview (#381)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2332,6 +2332,8 @@ tbody tr:last-child td {
 }
 .lookie-annotation-item[open] > .lookie-annotation-summary { margin-bottom: 0.3rem; }
 .lookie-annotation-item[open] > .lookie-annotation-summary::before { content: '▾'; }
+/* An open card already shows the rendered body — the plain preview line would repeat it. */
+.lookie-annotation-item[open] > .lookie-annotation-summary .lookie-annotation-preview { display: none; }
 .lookie-annotation-preview {
   min-width: 0;
   grid-column: 1 / -1;

--- a/test/annotations-client.test.js
+++ b/test/annotations-client.test.js
@@ -655,3 +655,13 @@ test('saved notes reveal rendered and previews strip markdown sigils', async () 
 
   dom.window.close();
 });
+
+test('open annotation cards hide the plain preview line', () => {
+  const css = fs.readFileSync(path.join(__dirname, '..', 'public', 'style.css'), 'utf8');
+  const rule = css.match(/\.lookie-annotation-item\[open\][^{]*\.lookie-annotation-preview[^{]*\{[^}]*\}/);
+  assert.ok(rule, 'open-card preview rule exists');
+  assert.match(rule[0], /display:\s*none/, 'preview hides while the rendered body is visible');
+  const collapsedRule = css.match(/^\.lookie-annotation-preview\s*\{[^}]*\}/m);
+  assert.ok(collapsedRule, 'base preview rule still present for collapsed cards');
+  assert.doesNotMatch(collapsedRule[0], /display:\s*none/, 'collapsed cards keep their one-line preview');
+});


### PR DESCRIPTION
Closes #381. Client-only CSS: the summary preview hides under `details[open]` so an expanded card reads rendered-body-first instead of plain-text-first; collapsed cards keep their one-line preview. Test gate fails against the previous stylesheet. 222/222 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)